### PR TITLE
Enabled PDB for Envoy deployments ADDENDUM

### DIFF
--- a/api/v1beta1/kafkacluster_types.go
+++ b/api/v1beta1/kafkacluster_types.go
@@ -115,7 +115,7 @@ type DisruptionBudget struct {
 // DisruptionBudgetWithStrategy defines the configuration for PodDisruptionBudget where the workload is managed by an external controller (eg. Deployments)
 type DisruptionBudgetWithStrategy struct {
 	// PodDisruptionBudget default settings
-	DisruptionBudget DisruptionBudget `json:",inline"`
+	DisruptionBudget `json:",inline"`
 	// The strategy to be used, either minAvailable or maxUnavailable
 	// +kubebuilder:validation:Enum=minAvailable;maxUnavailable
 	Stategy string `json:"strategy,omitempty"`


### PR DESCRIPTION
DisruptionBudget is declared as an inline field
so instead of composing the new struct, inherit it so it can be 
automatically read.

Currently you'd still need to declare:
```
podDisruptionBudget:
  PodDisruptionBudget:
    ...
  stragety:
```

for this to work while the CRD lists all the fields inlined
which is misleading for the user

| Q               | A      |
| --------------- | ------ |
| Bug fix?        | no/yes |
| New feature?    | no/yes |
| API breaks?     | no/yes |
| Deprecations?   | no/yes |
| Related tickets | fixes #X, partially #Y, mentioned in #Z |
| License         | Apache 2.0 |


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->


### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Implementation tested
- [ ] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [ ] Logging code meets the guideline
- [ ] User guide and development docs updated (if needed)

### To Do
<!-- (Please remove this section if you don't need it.) -->
- [ ] If the PR is not complete but you want to discuss the approach, list what remains to be done here
