### PR TITLE
Add Envoy support for HTTP/1.0 health-check requests

### DIFF
--- a/controllers/tests/kafkacluster_controller_envoy_test.go
+++ b/controllers/tests/kafkacluster_controller_envoy_test.go
@@ -357,6 +357,8 @@ staticResources:
           - name: envoy.filters.http.router
             typedConfig:
               '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+          httpProtocolOptions:
+            acceptHttp10: true
           routeConfig:
             name: local
             virtualHosts:
@@ -693,6 +695,8 @@ staticResources:
           - name: envoy.filters.http.router
             typedConfig:
               '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+          httpProtocolOptions:
+            acceptHttp10: true
           routeConfig:
             name: local
             virtualHosts:
@@ -960,6 +964,8 @@ staticResources:
           - name: envoy.filters.http.router
             typedConfig:
               '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+          httpProtocolOptions:
+            acceptHttp10: true
           routeConfig:
             name: local
             virtualHosts:
@@ -1280,6 +1286,8 @@ staticResources:
           - name: envoy.filters.http.router
             typedConfig:
               '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+          httpProtocolOptions:
+            acceptHttp10: true
           routeConfig:
             name: local
             virtualHosts:
@@ -1600,6 +1608,8 @@ staticResources:
           - name: envoy.filters.http.router
             typedConfig:
               '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+          httpProtocolOptions:
+            acceptHttp10: true
           routeConfig:
             name: local
             virtualHosts:

--- a/pkg/resources/envoy/configmap.go
+++ b/pkg/resources/envoy/configmap.go
@@ -128,6 +128,9 @@ func generateEnvoyHealthCheckListener(ingressConfig v1beta1.IngressConfig, log l
 	}
 
 	healthCheckFilter := &envoyhcm.HttpConnectionManager{
+		HttpProtocolOptions: &envoycore.Http1ProtocolOptions{
+			AcceptHttp_10: true,
+		},
 		StatPrefix: fmt.Sprintf("%s-healthcheck", envoyutils.AllBrokerEnvoyConfigName),
 		RouteSpecifier: &envoyhcm.HttpConnectionManager_RouteConfig{
 			RouteConfig: &envoyroute.RouteConfiguration{


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| New feature?    | yes |
| License         | Apache 2.0 |


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Added Envoy support for HTTP/1.0 health-check requests.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
The default way the LBs in Adobe Datacenters are sending health-check requests to each worker pool is via HTTP/1.0. Not having this support in Envoy results in LB health-check failures and consequently access denies.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
