### PR TITLE
Use local replacement for sub-modules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,8 +10,8 @@ require (
 	github.com/banzaicloud/istio-client-go v0.0.17
 	github.com/banzaicloud/istio-operator/api/v2 v2.15.1
 	github.com/banzaicloud/k8s-objectmatcher v1.8.0
-	github.com/banzaicloud/koperator/api v0.23.2
-	github.com/banzaicloud/koperator/properties v0.4.1
+	github.com/banzaicloud/koperator/api v0.0.0
+	github.com/banzaicloud/koperator/properties v0.0.0
 	github.com/cert-manager/cert-manager v1.9.1
 	github.com/cisco-open/cluster-registry-controller/api v0.2.5
 	github.com/envoyproxy/go-control-plane v0.10.3
@@ -140,6 +140,8 @@ require (
 )
 
 replace (
+	github.com/banzaicloud/koperator/api => ./api
+	github.com/banzaicloud/koperator/properties => ./properties
 	github.com/gogo/protobuf => github.com/waynz0r/protobuf v1.3.3-0.20210811122234-64636cae0910
 	github.com/golang/protobuf => github.com/luciferinlove/protobuf v0.0.0-20220913214010-c63936d75066
 )

--- a/go.sum
+++ b/go.sum
@@ -100,10 +100,6 @@ github.com/banzaicloud/istio-operator/api/v2 v2.15.1 h1:BZg8COvoOJtfx/dgN7KpoOnc
 github.com/banzaicloud/istio-operator/api/v2 v2.15.1/go.mod h1:5qCpwWlIfxiLvBfTvT2mD2wp5RlFCDEt8Xql4sYPNBc=
 github.com/banzaicloud/k8s-objectmatcher v1.8.0 h1:Nugn25elKtPMTA2br+JgHNeSQ04sc05MDPmpJnd1N2A=
 github.com/banzaicloud/k8s-objectmatcher v1.8.0/go.mod h1:p2LSNAjlECf07fbhDyebTkPUIYnU05G+WfGgkTmgeMg=
-github.com/banzaicloud/koperator/api v0.23.2 h1:4K0FbGaefM3673GptjYO0XuthECu0S7zn389IAF5VLU=
-github.com/banzaicloud/koperator/api v0.23.2/go.mod h1:qvpewvjdELAnfO70vg9397CXZ4K4uHxpiWtf5fhKSrQ=
-github.com/banzaicloud/koperator/properties v0.4.1 h1:SB2QgXlcK1Dc7Z1rg65PJifErDa8OQnoWCCJgmC7SGc=
-github.com/banzaicloud/koperator/properties v0.4.1/go.mod h1:TcL+llxuhW3UeQtVEDYEXGouFLF2P+LuZZVudSb6jyA=
 github.com/banzaicloud/operator-tools v0.28.0 h1:GSfc0qZr6zo7WrNxdgWZE1LcTChPU8QFYOTDirYVtIM=
 github.com/banzaicloud/operator-tools v0.28.0/go.mod h1:t0dyFGJUR9Q5CwsUcq1nDJC0wSZqeh6nzUZkUp3vCXg=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | yes? |
| New feature?    | no |
| API breaks?     | no |
| Deprecations?   | no |
| Related tickets |  |
| License         | Apache 2.0 |


### What's in this PR?
As part of [#929](https://github.com/banzaicloud/koperator/pull/929), the local replacement for sub-modules was removed in favor of using valid tags. 

Adobe Koperator fork has some internal changes in the api sub-module, so we need to use the local version of the sub-module instead of the upstream version, this  forces us to revert the changes from [#929](https://github.com/banzaicloud/koperator/pull/929).


### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Implementation tested
- [ ] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [ ] Logging code meets the guideline
- [ ] User guide and development docs updated (if needed)

### To Do
<!-- (Please remove this section if you don't need it.) -->
- [ ] If the PR is not complete but you want to discuss the approach, list what remains to be done here
