### PR TITLE
Handle async response from CC /state endpoint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,8 +10,8 @@ require (
 	github.com/banzaicloud/istio-client-go v0.0.17
 	github.com/banzaicloud/istio-operator/api/v2 v2.15.1
 	github.com/banzaicloud/k8s-objectmatcher v1.8.0
-	github.com/banzaicloud/koperator/api v0.23.2
-	github.com/banzaicloud/koperator/properties v0.4.1
+	github.com/banzaicloud/koperator/api v0.0.0
+	github.com/banzaicloud/koperator/properties v0.0.0
 	github.com/cert-manager/cert-manager v1.9.1
 	github.com/cisco-open/cluster-registry-controller/api v0.2.5
 	github.com/envoyproxy/go-control-plane v0.10.3
@@ -140,6 +140,8 @@ require (
 )
 
 replace (
+	github.com/banzaicloud/koperator/api => ./api
+	github.com/banzaicloud/koperator/properties => ./properties
 	github.com/gogo/protobuf => github.com/waynz0r/protobuf v1.3.3-0.20210811122234-64636cae0910
 	github.com/golang/protobuf => github.com/luciferinlove/protobuf v0.0.0-20220913214010-c63936d75066
 )

--- a/go.sum
+++ b/go.sum
@@ -100,10 +100,6 @@ github.com/banzaicloud/istio-operator/api/v2 v2.15.1 h1:BZg8COvoOJtfx/dgN7KpoOnc
 github.com/banzaicloud/istio-operator/api/v2 v2.15.1/go.mod h1:5qCpwWlIfxiLvBfTvT2mD2wp5RlFCDEt8Xql4sYPNBc=
 github.com/banzaicloud/k8s-objectmatcher v1.8.0 h1:Nugn25elKtPMTA2br+JgHNeSQ04sc05MDPmpJnd1N2A=
 github.com/banzaicloud/k8s-objectmatcher v1.8.0/go.mod h1:p2LSNAjlECf07fbhDyebTkPUIYnU05G+WfGgkTmgeMg=
-github.com/banzaicloud/koperator/api v0.23.2 h1:4K0FbGaefM3673GptjYO0XuthECu0S7zn389IAF5VLU=
-github.com/banzaicloud/koperator/api v0.23.2/go.mod h1:qvpewvjdELAnfO70vg9397CXZ4K4uHxpiWtf5fhKSrQ=
-github.com/banzaicloud/koperator/properties v0.4.1 h1:SB2QgXlcK1Dc7Z1rg65PJifErDa8OQnoWCCJgmC7SGc=
-github.com/banzaicloud/koperator/properties v0.4.1/go.mod h1:TcL+llxuhW3UeQtVEDYEXGouFLF2P+LuZZVudSb6jyA=
 github.com/banzaicloud/operator-tools v0.28.0 h1:GSfc0qZr6zo7WrNxdgWZE1LcTChPU8QFYOTDirYVtIM=
 github.com/banzaicloud/operator-tools v0.28.0/go.mod h1:t0dyFGJUR9Q5CwsUcq1nDJC0wSZqeh6nzUZkUp3vCXg=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=

--- a/pkg/scale/scale.go
+++ b/pkg/scale/scale.go
@@ -16,13 +16,16 @@ package scale
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"math"
 	"strconv"
 	"strings"
+	"time"
 
 	"emperror.dev/errors"
 	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/banzaicloud/go-cruise-control/pkg/api"
 	"github.com/banzaicloud/go-cruise-control/pkg/client"
@@ -112,9 +115,19 @@ func (cc *cruiseControlScaler) Status(ctx context.Context) (CruiseControlStatus,
 		return CruiseControlStatus{}, err
 	}
 
+	result := resp.Result
+	// if the execution takes too much time, then cruise control converts the request into async
+	// and returns the taskID
+	if result == nil {
+		result, err = cc.waitForTaskCompletion(ctx, resp.TaskID)
+		if err != nil {
+			return CruiseControlStatus{}, err
+		}
+	}
+
 	goalsReady := true
-	if len(resp.Result.AnalyzerState.GoalReadiness) > 0 {
-		for _, goal := range resp.Result.AnalyzerState.GoalReadiness {
+	if len(result.AnalyzerState.GoalReadiness) > 0 {
+		for _, goal := range result.AnalyzerState.GoalReadiness {
 			if goal.Status != types.GoalReadinessStatusReady {
 				goalsReady = false
 				break
@@ -123,14 +136,59 @@ func (cc *cruiseControlScaler) Status(ctx context.Context) (CruiseControlStatus,
 	}
 
 	return CruiseControlStatus{
-		MonitorReady:       resp.Result.MonitorState.State == types.MonitorStateRunning,
-		ExecutorReady:      resp.Result.ExecutorState.State == types.ExecutorStateTypeNoTaskInProgress,
-		AnalyzerReady:      resp.Result.AnalyzerState.IsProposalReady && goalsReady,
-		ProposalReady:      resp.Result.AnalyzerState.IsProposalReady,
+		MonitorReady:       result.MonitorState.State == types.MonitorStateRunning,
+		ExecutorReady:      result.ExecutorState.State == types.ExecutorStateTypeNoTaskInProgress,
+		AnalyzerReady:      result.AnalyzerState.IsProposalReady && goalsReady,
+		ProposalReady:      result.AnalyzerState.IsProposalReady,
 		GoalsReady:         goalsReady,
-		MonitoredWindows:   resp.Result.MonitorState.NumMonitoredWindows,
-		MonitoringCoverage: resp.Result.MonitorState.MonitoringCoveragePercentage,
+		MonitoredWindows:   result.MonitorState.NumMonitoredWindows,
+		MonitoringCoverage: result.MonitorState.MonitoringCoveragePercentage,
 	}, nil
+}
+
+func (cc *cruiseControlScaler) waitForTaskCompletion(ctx context.Context, taskID string) (*types.StateResult, error) {
+	result := &types.StateResult{}
+
+	backoff := wait.Backoff{
+		Duration: time.Second,
+		Jitter:   0,
+		Factor:   2,
+		Steps:    5,
+	}
+
+	err := wait.ExponentialBackoff(backoff, func() (bool, error) {
+		req := &api.UserTasksRequest{
+			UserTaskIDs:         []string{taskID},
+			FetchCompletedTasks: true,
+		}
+
+		resp, err := cc.client.UserTasks(ctx, req)
+		if err != nil {
+			return false, err
+		}
+
+		if len(resp.Result.UserTasks) != 1 {
+			return false, fmt.Errorf("could not get the Cruise Control state, expected the response for 1 task (%s), but got %d responses", taskID, len(resp.Result.UserTasks))
+		}
+
+		status := resp.Result.UserTasks[0].Status
+		if status == types.UserTaskStatusCompleted {
+			if err = json.Unmarshal([]byte(resp.Result.UserTasks[0].OriginalResponse), result); err != nil {
+				return false, err
+			}
+			return true, nil
+		} else if status == types.UserTaskStatusActive || status == types.UserTaskStatusInExecution {
+			return false, nil
+		}
+
+		return false, fmt.Errorf("could not get the Cruise Control state, the task finished with `%s` status", status)
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
 }
 
 // IsReady returns true if the Analyzer and Monitor components of Cruise Control are in ready state.


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | yes |
| New feature?    | no |
| API breaks?     | no |
| Deprecations?   | no |
| Related tickets | fixes #828 |
| License         | Apache 2.0 |


### What's in this PR?
When the request on `/state` endpoint of CC takes longer than `webserver.request.maxBlockTimeMs`,
then CC will convert the request into an async task and will respond with the `taskID` instead
of the result. 
The Koperator should handle this case by waiting for CC to complete the task.


### Additional context
In order to reproduce the issue, it's sufficient to set `webserver.request.maxBlockTimeMs` to a small value (e.g.: `webserver.request.maxBlockTimeMs=10`)


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Implementation tested
- [ ] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)

### To Do
<!-- (Please remove this section if you don't need it.) -->
- [ ] Still need to decide how to write tests
