### PR TITLE
Handle async response from CC /state endpoint

### DIFF
--- a/api/v1alpha1/common_types.go
+++ b/api/v1alpha1/common_types.go
@@ -48,6 +48,8 @@ const (
 	OperationRemoveDisks CruiseControlTaskOperation = "remove_disks"
 	// OperationRebalance means a Cruise Control rebalance operation
 	OperationRebalance CruiseControlTaskOperation = "rebalance"
+	// OperationStatus means a Cruise Control status operation
+	OperationStatus CruiseControlTaskOperation = "status"
 	// KafkaAccessTypeRead states that a user wants consume access to a topic
 	KafkaAccessTypeRead KafkaAccessType = "read"
 	// KafkaAccessTypeWrite states that a user wants produce access to a topic

--- a/controllers/cruisecontroloperation_controller.go
+++ b/controllers/cruisecontroloperation_controller.go
@@ -512,7 +512,13 @@ func (r *CruiseControlOperationReconciler) updateCurrentTasks(ctx context.Contex
 	return nil
 }
 
-func (r *CruiseControlOperationReconciler) getStatus(ctx context.Context, log logr.Logger, kafkaCluster *banzaiv1beta1.KafkaCluster, kafkaClusterRef client.ObjectKey, ccOperationListClusterWide banzaiv1alpha1.CruiseControlOperationList) (scale.CruiseControlStatus, error) {
+func (r *CruiseControlOperationReconciler) getStatus(
+	ctx context.Context,
+	log logr.Logger,
+	kafkaCluster *banzaiv1beta1.KafkaCluster,
+	kafkaClusterRef client.ObjectKey,
+	ccOperationListClusterWide banzaiv1alpha1.CruiseControlOperationList,
+) (scale.CruiseControlStatus, error) {
 	var statusOperation *banzaiv1alpha1.CruiseControlOperation
 	for i := range ccOperationListClusterWide.Items {
 		ccOperation := &ccOperationListClusterWide.Items[i]

--- a/controllers/cruisecontroloperation_controller.go
+++ b/controllers/cruisecontroloperation_controller.go
@@ -513,6 +513,14 @@ func (r *CruiseControlOperationReconciler) updateCurrentTasks(ctx context.Contex
 	return nil
 }
 
+// getStatus returns the internal state of Cruise Control.
+//
+// The logic is the following:
+//   - If the Cruise Control makes the Status request sync, then the result will be returned.
+//   - If the Cruise Control makes the Status request async, then a new Status CruiseControlOperation
+//     will be created and an error will be returned to indicate that Cruise Control is not ready yet.
+//   - If there is already a Status CruiseControlOperation in progress, then it will be updated and
+//     the result will be returned.
 func (r *CruiseControlOperationReconciler) getStatus(
 	ctx context.Context,
 	log logr.Logger,

--- a/controllers/tests/cruisecontroloperation_controller_test.go
+++ b/controllers/tests/cruisecontroloperation_controller_test.go
@@ -526,11 +526,12 @@ func getScaleMock6() *mocks.MockCruiseControlScaler {
 		State:     v1beta1.CruiseControlTaskCompletedWithError,
 	})}
 	scaleMock.EXPECT().UserTasks(gomock.Any(), gomock.Any()).Return(userTaskResult, nil).AnyTimes()
-	scaleMock.EXPECT().Status(gomock.Any()).Return(scale.CruiseControlStatus{
-		ExecutorReady: true,
-		MonitorReady:  true,
-		AnalyzerReady: true,
-	}, nil).AnyTimes()
+	scaleMock.EXPECT().Status(gomock.Any()).Return(scale.StatusTaskResult{
+		Status: &scale.CruiseControlStatus{
+			ExecutorReady: true,
+			MonitorReady:  true,
+			AnalyzerReady: true,
+		}}, nil).AnyTimes()
 	scaleMock.EXPECT().RebalanceWithParams(gomock.Any(), gomock.All()).Return(scaleResultPointer(scale.Result{
 		TaskID:    "12346",
 		StartedAt: "Sat, 27 Aug 2022 12:22:21 GMT",

--- a/controllers/tests/cruisecontroloperation_controller_test.go
+++ b/controllers/tests/cruisecontroloperation_controller_test.go
@@ -359,6 +359,34 @@ var _ = Describe("CruiseControlTaskReconciler", func() {
 			}, 10*time.Second, 500*time.Millisecond).Should(BeTrue())
 		})
 	})
+	When("Cruise Control makes the Status operation async", Serial, func() {
+		JustBeforeEach(func(ctx SpecContext) {
+			cruiseControlOperationReconciler.ScaleFactory = NewMockScaleFactory(getScaleMock7())
+			operation := generateCruiseControlOperation("add-broker-operation", namespace, kafkaCluster.GetName())
+			err := k8sClient.Create(ctx, &operation)
+			Expect(err).NotTo(HaveOccurred())
+
+			operation.Status.CurrentTask = &v1alpha1.CruiseControlTask{
+				Operation: v1alpha1.OperationAddBroker,
+				ID:        "11111",
+			}
+			err = k8sClient.Status().Update(ctx, &operation)
+			Expect(err).NotTo(HaveOccurred())
+		})
+		It("should create status CruiseControlOperation and retry", func(ctx SpecContext) {
+			Eventually(ctx, func() v1beta1.CruiseControlUserTaskState {
+				operation := v1alpha1.CruiseControlOperation{}
+				err := k8sClient.Get(ctx, client.ObjectKey{
+					Namespace: kafkaCluster.Namespace,
+					Name:      "add-broker-operation",
+				}, &operation)
+				if err != nil {
+					return ""
+				}
+				return operation.CurrentTaskState()
+			}, 15*time.Second, 500*time.Millisecond).Should(Equal(v1beta1.CruiseControlTaskCompleted))
+		})
+	})
 })
 
 func generateCruiseControlOperation(name, namespace, kafkaRef string) v1alpha1.CruiseControlOperation {
@@ -544,6 +572,38 @@ func getScaleMock6() *mocks.MockCruiseControlScaler {
 		State:     v1beta1.CruiseControlTaskCompletedWithError,
 	}), nil).AnyTimes()
 
+	return scaleMock
+}
+
+func getScaleMock7() *mocks.MockCruiseControlScaler {
+	mockCtrl := gomock.NewController(GinkgoT())
+	scaleMock := mocks.NewMockCruiseControlScaler(mockCtrl)
+	scaleMock.EXPECT().IsUp(gomock.Any()).Return(true).AnyTimes()
+
+	scaleMock.EXPECT().Status(gomock.Any()).Return(scale.StatusTaskResult{
+		TaskResult: &scale.Result{
+			TaskID:    "22222",
+			StartedAt: "Sat, 27 Aug 2022 12:22:21 GMT",
+			State:     v1beta1.CruiseControlTaskActive,
+		}}, nil).AnyTimes()
+	scaleMock.EXPECT().StatusTask(gomock.Any(), "22222").Return(scale.StatusTaskResult{
+		TaskResult: &scale.Result{
+			TaskID:    "22222",
+			StartedAt: "Sat, 27 Aug 2022 12:22:21 GMT",
+			State:     v1beta1.CruiseControlTaskCompleted,
+		},
+		Status: &scale.CruiseControlStatus{
+			ExecutorReady: true,
+			MonitorReady:  true,
+			AnalyzerReady: true,
+		}}, nil).AnyTimes()
+
+	userTaskResult := []*scale.Result{scaleResultPointer(scale.Result{
+		TaskID:    "11111",
+		StartedAt: "Sat, 27 Aug 2022 12:22:21 GMT",
+		State:     v1beta1.CruiseControlTaskCompleted,
+	})}
+	scaleMock.EXPECT().UserTasks(gomock.Any(), gomock.Any()).Return(userTaskResult, nil).AnyTimes()
 	return scaleMock
 }
 

--- a/controllers/tests/cruisecontroloperation_controller_test.go
+++ b/controllers/tests/cruisecontroloperation_controller_test.go
@@ -382,11 +382,12 @@ func getScaleMock2() *mocks.MockCruiseControlScaler {
 		State:     v1beta1.CruiseControlTaskCompletedWithError,
 	})}
 	scaleMock.EXPECT().UserTasks(gomock.Any(), gomock.Any()).Return(userTaskResult, nil).AnyTimes()
-	scaleMock.EXPECT().Status(gomock.Any()).Return(scale.CruiseControlStatus{
-		ExecutorReady: true,
-		MonitorReady:  true,
-		AnalyzerReady: true,
-	}, nil).AnyTimes()
+	scaleMock.EXPECT().Status(gomock.Any()).Return(scale.StatusTaskResult{
+		Status: &scale.CruiseControlStatus{
+			ExecutorReady: true,
+			MonitorReady:  true,
+			AnalyzerReady: true,
+		}}, nil).AnyTimes()
 	scaleMock.EXPECT().AddBrokersWithParams(gomock.Any(), gomock.All()).Return(scaleResultPointer(scale.Result{
 		TaskID:    "12345",
 		StartedAt: "Sat, 27 Aug 2022 12:22:21 GMT",
@@ -405,11 +406,12 @@ func getScaleMock1() *mocks.MockCruiseControlScaler {
 		State:     v1beta1.CruiseControlTaskCompleted,
 	})}
 	scaleMock.EXPECT().UserTasks(gomock.Any(), gomock.Any()).Return(userTaskResult, nil).AnyTimes()
-	scaleMock.EXPECT().Status(gomock.Any()).Return(scale.CruiseControlStatus{
-		ExecutorReady: true,
-		MonitorReady:  true,
-		AnalyzerReady: true,
-	}, nil).AnyTimes()
+	scaleMock.EXPECT().Status(gomock.Any()).Return(scale.StatusTaskResult{
+		Status: &scale.CruiseControlStatus{
+			ExecutorReady: true,
+			MonitorReady:  true,
+			AnalyzerReady: true,
+		}}, nil).AnyTimes()
 	scaleMock.EXPECT().AddBrokersWithParams(gomock.Any(), gomock.All()).Return(scaleResultPointer(scale.Result{
 		TaskID:    "12345",
 		StartedAt: "Sat, 27 Aug 2022 12:22:21 GMT",
@@ -433,11 +435,12 @@ func getScaleMock3() *mocks.MockCruiseControlScaler {
 		State:     v1beta1.CruiseControlTaskCompleted,
 	})}
 	scaleMock.EXPECT().UserTasks(gomock.Any(), gomock.Any()).Return(userTaskResult, nil).AnyTimes()
-	scaleMock.EXPECT().Status(gomock.Any()).Return(scale.CruiseControlStatus{
-		ExecutorReady: true,
-		MonitorReady:  true,
-		AnalyzerReady: true,
-	}, nil).AnyTimes()
+	scaleMock.EXPECT().Status(gomock.Any()).Return(scale.StatusTaskResult{
+		Status: &scale.CruiseControlStatus{
+			ExecutorReady: true,
+			MonitorReady:  true,
+			AnalyzerReady: true,
+		}}, nil).AnyTimes()
 	scaleMock.EXPECT().RemoveBrokersWithParams(gomock.Any(), gomock.All()).Return(scaleResultPointer(scale.Result{
 		TaskID:    "12345",
 		StartedAt: "Sat, 27 Aug 2022 12:22:21 GMT",
@@ -467,11 +470,12 @@ func getScaleMock4() *mocks.MockCruiseControlScaler {
 		State:     v1beta1.CruiseControlTaskCompletedWithError,
 	})}
 	scaleMock.EXPECT().UserTasks(gomock.Any(), gomock.Any()).Return(userTaskResult, nil).AnyTimes()
-	scaleMock.EXPECT().Status(gomock.Any()).Return(scale.CruiseControlStatus{
-		ExecutorReady: true,
-		MonitorReady:  true,
-		AnalyzerReady: true,
-	}, nil).AnyTimes()
+	scaleMock.EXPECT().Status(gomock.Any()).Return(scale.StatusTaskResult{
+		Status: &scale.CruiseControlStatus{
+			ExecutorReady: true,
+			MonitorReady:  true,
+			AnalyzerReady: true,
+		}}, nil).AnyTimes()
 	scaleMock.EXPECT().RemoveBrokersWithParams(gomock.Any(), gomock.All()).Return(scaleResultPointer(scale.Result{
 		TaskID:    "1",
 		StartedAt: "Sat, 27 Aug 2022 12:22:21 GMT",
@@ -497,11 +501,12 @@ func getScaleMock5() *mocks.MockCruiseControlScaler {
 	})}
 	first := scaleMock.EXPECT().UserTasks(gomock.Any(), gomock.Any()).Return(userTaskResult, nil).Times(1)
 	scaleMock.EXPECT().UserTasks(gomock.Any(), gomock.Any()).Return(userTaskResult2, nil).After(first).AnyTimes()
-	scaleMock.EXPECT().Status(gomock.Any()).Return(scale.CruiseControlStatus{
-		ExecutorReady: true,
-		MonitorReady:  true,
-		AnalyzerReady: true,
-	}, nil).AnyTimes()
+	scaleMock.EXPECT().Status(gomock.Any()).Return(scale.StatusTaskResult{
+		Status: &scale.CruiseControlStatus{
+			ExecutorReady: true,
+			MonitorReady:  true,
+			AnalyzerReady: true,
+		}}, nil).AnyTimes()
 	scaleMock.EXPECT().AddBrokersWithParams(gomock.Any(), gomock.All()).Return(scaleResultPointer(scale.Result{
 		TaskID:    "12345",
 		StartedAt: "Sat, 27 Aug 2022 12:22:21 GMT",

--- a/controllers/tests/cruisecontroloperation_controller_test.go
+++ b/controllers/tests/cruisecontroloperation_controller_test.go
@@ -580,16 +580,17 @@ func getScaleMock7() *mocks.MockCruiseControlScaler {
 	scaleMock := mocks.NewMockCruiseControlScaler(mockCtrl)
 	scaleMock.EXPECT().IsUp(gomock.Any()).Return(true).AnyTimes()
 
+	startTime := metav1.Now().Format(time.RFC1123)
 	scaleMock.EXPECT().Status(gomock.Any()).Return(scale.StatusTaskResult{
 		TaskResult: &scale.Result{
 			TaskID:    "22222",
-			StartedAt: "Sat, 27 Aug 2022 12:22:21 GMT",
+			StartedAt: startTime,
 			State:     v1beta1.CruiseControlTaskActive,
 		}}, nil).AnyTimes()
 	scaleMock.EXPECT().StatusTask(gomock.Any(), "22222").Return(scale.StatusTaskResult{
 		TaskResult: &scale.Result{
 			TaskID:    "22222",
-			StartedAt: "Sat, 27 Aug 2022 12:22:21 GMT",
+			StartedAt: startTime,
 			State:     v1beta1.CruiseControlTaskCompleted,
 		},
 		Status: &scale.CruiseControlStatus{

--- a/controllers/tests/mocks/scale.go
+++ b/controllers/tests/mocks/scale.go
@@ -296,10 +296,10 @@ func (mr *MockCruiseControlScalerMockRecorder) RemoveBrokersWithParams(ctx, para
 }
 
 // Status mocks base method.
-func (m *MockCruiseControlScaler) Status(ctx context.Context) (scale.CruiseControlStatus, error) {
+func (m *MockCruiseControlScaler) Status(ctx context.Context) (scale.StatusTaskResult, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Status", ctx)
-	ret0, _ := ret[0].(scale.CruiseControlStatus)
+	ret0, _ := ret[0].(scale.StatusTaskResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -308,6 +308,21 @@ func (m *MockCruiseControlScaler) Status(ctx context.Context) (scale.CruiseContr
 func (mr *MockCruiseControlScalerMockRecorder) Status(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Status", reflect.TypeOf((*MockCruiseControlScaler)(nil).Status), ctx)
+}
+
+// StatusTask mocks base method.
+func (m *MockCruiseControlScaler) StatusTask(ctx context.Context, taskID string) (scale.StatusTaskResult, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "StatusTask", ctx, taskID)
+	ret0, _ := ret[0].(scale.StatusTaskResult)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// StatusTask indicates an expected call of StatusTask.
+func (mr *MockCruiseControlScalerMockRecorder) StatusTask(ctx interface{}, taskID string) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StatusTask", reflect.TypeOf((*MockCruiseControlScaler)(nil).Status), ctx, taskID)
 }
 
 // StopExecution mocks base method.

--- a/pkg/scale/scale.go
+++ b/pkg/scale/scale.go
@@ -107,7 +107,7 @@ type cruiseControlScaler struct {
 	client *client.Client
 }
 
-// Status returns a CruiseControlStatus describing the internal state of Cruise Control.
+// Status returns a StatusTaskResult describing the internal state of Cruise Control.
 func (cc *cruiseControlScaler) Status(ctx context.Context) (StatusTaskResult, error) {
 	req := api.StateRequestWithDefaults()
 	req.Verbose = true
@@ -116,10 +116,9 @@ func (cc *cruiseControlScaler) Status(ctx context.Context) (StatusTaskResult, er
 		return StatusTaskResult{}, err
 	}
 
-	result := resp.Result
-	// if the execution takes too much time, then cruise control converts the request into async
+	// if the execution takes too much time, then Cruise Control converts the request into async
 	// and returns the taskID
-	if result == nil {
+	if resp.Result == nil {
 		return StatusTaskResult{
 			TaskResult: &Result{
 				TaskID:             resp.TaskID,
@@ -131,7 +130,7 @@ func (cc *cruiseControlScaler) Status(ctx context.Context) (StatusTaskResult, er
 		}, nil
 	}
 
-	status := convert(result)
+	status := convert(resp.Result)
 
 	return StatusTaskResult{
 		TaskResult: &Result{
@@ -145,7 +144,7 @@ func (cc *cruiseControlScaler) Status(ctx context.Context) (StatusTaskResult, er
 	}, nil
 }
 
-// StatusTask returns a CruiseControlStatus describing the internal state of Cruise Control.
+// StatusTask returns the latest state of the Status Cruise Control task.
 func (cc *cruiseControlScaler) StatusTask(ctx context.Context, taskID string) (StatusTaskResult, error) {
 	req := &api.UserTasksRequest{
 		UserTaskIDs:         []string{taskID},
@@ -157,7 +156,7 @@ func (cc *cruiseControlScaler) StatusTask(ctx context.Context, taskID string) (S
 		return StatusTaskResult{}, err
 	}
 
-	//CC no longer has the info about the task
+	//CC no longer has the info about the task, mark it as completed with error
 	if len(resp.Result.UserTasks) == 0 {
 		return StatusTaskResult{
 			TaskResult: &Result{

--- a/pkg/scale/scale.go
+++ b/pkg/scale/scale.go
@@ -26,9 +26,10 @@ import (
 	"github.com/banzaicloud/go-cruise-control/pkg/api"
 	"github.com/banzaicloud/go-cruise-control/pkg/client"
 	"github.com/banzaicloud/go-cruise-control/pkg/types"
+	"github.com/go-logr/logr"
+
 	"github.com/banzaicloud/koperator/api/v1alpha1"
 	"github.com/banzaicloud/koperator/api/v1beta1"
-	"github.com/go-logr/logr"
 )
 
 const (
@@ -146,7 +147,6 @@ func (cc *cruiseControlScaler) Status(ctx context.Context) (StatusTaskResult, er
 
 // StatusTask returns a CruiseControlStatus describing the internal state of Cruise Control.
 func (cc *cruiseControlScaler) StatusTask(ctx context.Context, taskID string) (StatusTaskResult, error) {
-
 	req := &api.UserTasksRequest{
 		UserTaskIDs:         []string{taskID},
 		FetchCompletedTasks: true,

--- a/pkg/scale/types.go
+++ b/pkg/scale/types.go
@@ -25,7 +25,8 @@ import (
 
 type CruiseControlScaler interface {
 	IsReady(ctx context.Context) bool
-	Status(ctx context.Context) (CruiseControlStatus, error)
+	Status(ctx context.Context) (StatusTaskResult, error)
+	StatusTask(ctx context.Context, taskId string) (StatusTaskResult, error)
 	UserTasks(ctx context.Context, taskIDs ...string) ([]*Result, error)
 	IsUp(ctx context.Context) bool
 	AddBrokers(ctx context.Context, brokerIDs ...string) (*Result, error)
@@ -60,6 +61,11 @@ const (
 	LogDirStateOnline LogDirState = iota
 	LogDirStateOffline
 )
+
+type StatusTaskResult struct {
+	TaskResult *Result
+	Status     *CruiseControlStatus
+}
 
 // CruiseControlStatus struct is used to describe internal state of Cruise Control.
 type CruiseControlStatus struct {


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | yes |
| New feature?    | no |
| API breaks?     | no |
| Deprecations?   | no |
| Related tickets | fixes #828 |
| License         | Apache 2.0 |


### What's in this PR?
When the request on `/state` endpoint of CC takes longer than `webserver.request.maxBlockTimeMs`,
then CC will convert the request into an async task and will respond with the `taskID` instead
of the result. 
The Koperator should handle this case by waiting for CC to complete the task.


### Additional context
In order to reproduce the issue, it's sufficient to set `webserver.request.maxBlockTimeMs` to a small value (e.g.: `webserver.request.maxBlockTimeMs=10`)


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)