### PR TITLE
Allow concurrent broker restarts from same AZ (broker rack)

### DIFF
--- a/api/v1beta1/kafkacluster_types.go
+++ b/api/v1beta1/kafkacluster_types.go
@@ -141,12 +141,13 @@ type RollingUpgradeConfig struct {
 
 	// ConcurrentBrokerRestartsAllowed controls how many brokers can be restarted in parallel during a rolling upgrade. If
 	// it is set to a value greater than 1, the operator will restart up to that amount of brokers in parallel, if the
-	// brokers are within the same AZ (as specified by "broker.rack" in broker read-only configs). Since using Kafka broker
+	// brokers are within the same rack (as specified by "broker.rack" in broker read-only configs). Since using Kafka broker
 	// racks spreads out the replicas, we know that restarting multiple brokers in the same rack will not cause more than
 	// 1/Nth of the replicas of a topic-partition to be unavailable at the same time, where N is the number of racks used.
-	// This is a safe way to speed up the rolling upgrade.
+	// This is a safe way to speed up the rolling upgrade. Note that for the rack distribution explained above, Cruise Control
+	// requires `com.linkedin.kafka.cruisecontrol.analyzer.goals.RackAwareDistributionGoal` to be configured.
 	// +optional
-	ConcurrentBrokerRestartsAllowed int `json:"parallelBrokerRestarts,omitempty"`
+	ConcurrentBrokerRestartsAllowed int `json:"concurrentBrokerRestartsAllowed,omitempty"`
 }
 
 // DisruptionBudget defines the configuration for PodDisruptionBudget where the workload is managed by the kafka-operator

--- a/api/v1beta1/kafkacluster_types.go
+++ b/api/v1beta1/kafkacluster_types.go
@@ -142,8 +142,9 @@ type RollingUpgradeConfig struct {
 	// ConcurrentBrokerRestartsAllowed controls how many brokers can be restarted in parallel during a rolling upgrade. If
 	// it is set to a value greater than 1, the operator will restart up to that amount of brokers in parallel, if the
 	// brokers are within the same AZ (as specified by "broker.rack" in broker read-only configs). Since using Kafka broker
-	// racks spreads out the replicas, we know that restarting multiple brokers in the same rack will not cause more than 1
-	// replica per topic-partition to be unavailable at the same time. This is a safe way to speed up the rolling upgrade.
+	// racks spreads out the replicas, we know that restarting multiple brokers in the same rack will not cause more than
+	// 1/Nth of the replicas of a topic-partition to be unavailable at the same time, where N is the number of racks used.
+	// This is a safe way to speed up the rolling upgrade.
 	// +optional
 	ConcurrentBrokerRestartsAllowed int `json:"parallelBrokerRestarts,omitempty"`
 }

--- a/api/v1beta1/kafkacluster_types.go
+++ b/api/v1beta1/kafkacluster_types.go
@@ -138,6 +138,14 @@ type RollingUpgradeConfig struct {
 	// distinct broker replicas with either offline replicas or out of sync replicas and the number of alerts triggered by
 	// alerts with 'rollingupgrade'
 	FailureThreshold int `json:"failureThreshold"`
+
+	// ConcurrentBrokerRestartsAllowed controls how many brokers can be restarted in parallel during a rolling upgrade. If
+	// it is set to a value greater than 1, the operator will restart up to that amount of brokers in parallel, if the
+	// brokers are within the same AZ (as specified by "broker.rack" in broker read-only configs). Since using Kafka broker
+	// racks spreads out the replicas, we know that restarting multiple brokers in the same rack will not cause more than 1
+	// replica per topic-partition to be unavailable at the same time. This is a safe way to speed up the rolling upgrade.
+	// +optional
+	ConcurrentBrokerRestartsAllowed int `json:"parallelBrokerRestarts,omitempty"`
 }
 
 // DisruptionBudget defines the configuration for PodDisruptionBudget where the workload is managed by the kafka-operator

--- a/charts/kafka-operator/templates/crds.yaml
+++ b/charts/kafka-operator/templates/crds.yaml
@@ -21177,6 +21177,13 @@ spec:
                       with either offline replicas or out of sync replicas and the
                       number of alerts triggered by alerts with 'rollingupgrade'
                     type: integer
+                  concurrentBrokerRestartsAllowed:
+                    description: ConcurrentBrokerRestartsAllowed controls how many brokers can be restarted in parallel during a rolling upgrade. If
+                      it is set to a value greater than 1, the operator will restart up to that amount of brokers in parallel, if the
+                      brokers are within the same AZ (as specified by "broker.rack" in broker read-only configs). Since using Kafka broker
+                      racks spreads out the replicas, we know that restarting multiple brokers in the same rack will not cause more than 1
+                      replica per topic-partition to be unavailable at the same time. This is a safe way to speed up the rolling upgrade.
+                    type: integer
                 required:
                 - failureThreshold
                 type: object

--- a/charts/kafka-operator/templates/crds.yaml
+++ b/charts/kafka-operator/templates/crds.yaml
@@ -21181,8 +21181,9 @@ spec:
                     description: ConcurrentBrokerRestartsAllowed controls how many brokers can be restarted in parallel during a rolling upgrade. If
                       it is set to a value greater than 1, the operator will restart up to that amount of brokers in parallel, if the
                       brokers are within the same AZ (as specified by "broker.rack" in broker read-only configs). Since using Kafka broker
-                      racks spreads out the replicas, we know that restarting multiple brokers in the same rack will not cause more than 1
-                      replica per topic-partition to be unavailable at the same time. This is a safe way to speed up the rolling upgrade.
+                      racks spreads out the replicas, we know that restarting multiple brokers in the same rack will not cause more than
+                      1/Nth of the replicas of a topic-partition to be unavailable at the same time, where N is the number of racks used.
+                      This is a safe way to speed up the rolling upgrade.
                     type: integer
                 required:
                 - failureThreshold

--- a/config/base/crds/kafka.banzaicloud.io_kafkaclusters.yaml
+++ b/config/base/crds/kafka.banzaicloud.io_kafkaclusters.yaml
@@ -21014,6 +21014,13 @@ spec:
                       with either offline replicas or out of sync replicas and the
                       number of alerts triggered by alerts with 'rollingupgrade'
                     type: integer
+                  concurrentBrokerRestartsAllowed:
+                    description: ConcurrentBrokerRestartsAllowed controls how many brokers can be restarted in parallel during a rolling upgrade. If
+                      it is set to a value greater than 1, the operator will restart up to that amount of brokers in parallel, if the
+                      brokers are within the same AZ (as specified by "broker.rack" in broker read-only configs). Since using Kafka broker
+                      racks spreads out the replicas, we know that restarting multiple brokers in the same rack will not cause more than 1
+                      replica per topic-partition to be unavailable at the same time. This is a safe way to speed up the rolling upgrade.
+                    type: integer
                 required:
                 - failureThreshold
                 type: object

--- a/config/base/crds/kafka.banzaicloud.io_kafkaclusters.yaml
+++ b/config/base/crds/kafka.banzaicloud.io_kafkaclusters.yaml
@@ -21018,8 +21018,9 @@ spec:
                     description: ConcurrentBrokerRestartsAllowed controls how many brokers can be restarted in parallel during a rolling upgrade. If
                       it is set to a value greater than 1, the operator will restart up to that amount of brokers in parallel, if the
                       brokers are within the same AZ (as specified by "broker.rack" in broker read-only configs). Since using Kafka broker
-                      racks spreads out the replicas, we know that restarting multiple brokers in the same rack will not cause more than 1
-                      replica per topic-partition to be unavailable at the same time. This is a safe way to speed up the rolling upgrade.
+                      racks spreads out the replicas, we know that restarting multiple brokers in the same rack will not cause more than
+                      1/Nth of the replicas of a topic-partition to be unavailable at the same time, where N is the number of racks used.
+                      This is a safe way to speed up the rolling upgrade.
                     type: integer
                 required:
                 - failureThreshold

--- a/config/samples/banzaicloud_v1beta1_kafkacluster.yaml
+++ b/config/samples/banzaicloud_v1beta1_kafkacluster.yaml
@@ -55,6 +55,13 @@ spec:
   #	alerts with 'rollingupgrade'
   #  failureThreshold: 1
 
+  # concurrentBrokerRestartsAllowed controls how many brokers can be restarted in parallel during a rolling upgrade. If
+  # it is set to a value greater than 1, the operator will restart up to that amount of brokers in parallel, if the
+  # brokers are within the same AZ (as specified by "broker.rack" in broker read-only configs). Since using Kafka broker
+  # racks spreads out the replicas, we know that restarting multiple brokers in the same rack will not cause more than 1
+  # replica per topic-partition to be unavailable at the same time. This is a safe way to speed up the rolling upgrade.
+  #  concurrentBrokerRestartsAllowed: 1
+
   # brokerConfigGroups specifies multiple broker configs with unique name
   brokerConfigGroups:
     # Specify desired group name (eg., 'default_group')
@@ -189,11 +196,11 @@ spec:
         # which has type per-broker
         # priorityClassName can be used to set the broker pod's priority
         # priorityClassName: "high-priority"
-        
+
         # When "hostNameOverride" and brokerConfig.nodePortExternalIP are empty and NodePort access method is selected for external listener
         # nodePortNodeAdddressType defines the Kafka broker's Kubernetes node's address type that shall be used in the advertised.listeners property
         # when nodeport is used for an external listener.
-        # its values can be Hostname, ExternalIP, InternalIP, InternalDNS,ExternalDNS 
+        # its values can be Hostname, ExternalIP, InternalIP, InternalDNS,ExternalDNS
         #nodePortNodeAddressType: "ExternalIP"
         config: |
           sasl.enabled.mechanisms=PLAIN

--- a/config/samples/banzaicloud_v1beta1_kafkacluster.yaml
+++ b/config/samples/banzaicloud_v1beta1_kafkacluster.yaml
@@ -58,8 +58,9 @@ spec:
   # concurrentBrokerRestartsAllowed controls how many brokers can be restarted in parallel during a rolling upgrade. If
   # it is set to a value greater than 1, the operator will restart up to that amount of brokers in parallel, if the
   # brokers are within the same AZ (as specified by "broker.rack" in broker read-only configs). Since using Kafka broker
-  # racks spreads out the replicas, we know that restarting multiple brokers in the same rack will not cause more than 1
-  # replica per topic-partition to be unavailable at the same time. This is a safe way to speed up the rolling upgrade.
+  # racks spreads out the replicas, we know that restarting multiple brokers in the same rack will not cause more than
+  # 1/Nth of the replicas of a topic-partition to be unavailable at the same time, where N is the number of racks used.
+  # This is a safe way to speed up the rolling upgrade.
   #  concurrentBrokerRestartsAllowed: 1
 
   # brokerConfigGroups specifies multiple broker configs with unique name

--- a/controllers/tests/common_test.go
+++ b/controllers/tests/common_test.go
@@ -124,7 +124,7 @@ func createMinimalKafkaClusterCR(name, namespace string) *v1beta1.KafkaCluster {
 				CCJMXExporterConfig: "custom_property: custom_value",
 			},
 			ReadOnlyConfig:       "cruise.control.metrics.topic.auto.create=true",
-			RollingUpgradeConfig: v1beta1.RollingUpgradeConfig{FailureThreshold: 1},
+			RollingUpgradeConfig: v1beta1.RollingUpgradeConfig{FailureThreshold: 1, ConcurrentBrokerRestartsAllowed: 1},
 		},
 	}
 }

--- a/pkg/kafkaclient/provider.go
+++ b/pkg/kafkaclient/provider.go
@@ -15,6 +15,7 @@
 package kafkaclient
 
 import (
+	"github.com/stretchr/testify/mock"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/banzaicloud/koperator/api/v1beta1"
@@ -44,4 +45,14 @@ func NewDefaultProvider() Provider {
 
 func (dp *defaultProvider) NewFromCluster(client client.Client, cluster *v1beta1.KafkaCluster) (KafkaClient, func(), error) {
 	return NewFromCluster(client, cluster)
+}
+
+// MockerProvider is a Testify mock for providing Kafka clients that can be mocks too
+type MockedProvider struct {
+	mock.Mock
+}
+
+func (m *MockedProvider) NewFromCluster(client client.Client, cluster *v1beta1.KafkaCluster) (KafkaClient, func(), error) {
+	args := m.Called(client, cluster)
+	return args.Get(0).(KafkaClient), args.Get(1).(func()), args.Error(2)
 }

--- a/pkg/resources/kafka/kafka.go
+++ b/pkg/resources/kafka/kafka.go
@@ -969,7 +969,7 @@ func (r *Reconciler) handleRollingUpgrade(log logr.Logger, desiredPod, currentPo
 
 			// If multiple concurrent restarts and broker failures allowed, restart only brokers from the same AZ
 			if concurrentBrokerRestartsAllowed > 1 && r.KafkaCluster.Spec.RollingUpgradeConfig.FailureThreshold > 1 {
-				if r.existsFailedBrokerFromAnotherAz(currentPodAz, impactedReplicas) {
+				if r.existsFailedBrokerFromAnotherRack(currentPodAz, impactedReplicas) {
 					return errorfactory.New(errorfactory.ReconcileRollingUpgrade{}, errors.New("broker is not healthy from another AZ"), "rolling upgrade in progress")
 				}
 			}
@@ -994,7 +994,7 @@ func (r *Reconciler) handleRollingUpgrade(log logr.Logger, desiredPod, currentPo
 	return nil
 }
 
-func (r *Reconciler) existsFailedBrokerFromAnotherAz(currentPodAz string, impactedReplicas map[int32]struct{}) bool {
+func (r *Reconciler) existsFailedBrokerFromAnotherRack(currentPodAz string, impactedReplicas map[int32]struct{}) bool {
 	if currentPodAz == "" && len(impactedReplicas) > 0 {
 		return true
 	}

--- a/pkg/resources/kafka/kafka.go
+++ b/pkg/resources/kafka/kafka.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -87,12 +88,23 @@ const (
 	nonControllerBrokerReconcilePriority
 	// controllerBrokerReconcilePriority the priority used for controller broker used to define its priority in the reconciliation order
 	controllerBrokerReconcilePriority
+
+	// defaultConcurrentBrokerRestartsAllowed the default number of brokers that can be restarted in parallel
+	defaultConcurrentBrokerRestartsAllowed = 1
+)
+
+var (
+	// kafkaConfigBrokerRackRegex the regex to parse the "broker.rack" Kafka property used in read-only configs
+	kafkaConfigBrokerRackRegex = regexp.MustCompile(`broker\.rack\s*=\s*(\w+)`)
 )
 
 // Reconciler implements the Component Reconciler
 type Reconciler struct {
 	resources.Reconciler
+	// kafkaClientProvider is used to create a new KafkaClient
 	kafkaClientProvider kafkaclient.Provider
+	// kafkaBrokerAvailabilityZoneMap is a map of broker id to availability zone used in concurrent broker restarts logic
+	kafkaBrokerAvailabilityZoneMap map[int32]string
 }
 
 // New creates a new reconciler for Kafka
@@ -103,9 +115,39 @@ func New(client client.Client, directClient client.Reader, cluster *v1beta1.Kafk
 			DirectClient: directClient,
 			KafkaCluster: cluster,
 		},
-		kafkaClientProvider: kafkaClientProvider,
+		kafkaClientProvider:            kafkaClientProvider,
+		kafkaBrokerAvailabilityZoneMap: getBrokerAzMap(cluster),
 	}
 }
+
+func getBrokerAzMap(cluster *v1beta1.KafkaCluster) map[int32]string {
+	brokerAzMap := make(map[int32]string)
+	for _, broker := range cluster.Spec.Brokers {
+		brokerRack := getBrokerRack(broker.ReadOnlyConfig)
+		if brokerRack != "" {
+			brokerAzMap[broker.Id] = brokerRack
+		}
+	}
+	// if incomplete broker AZ information, consider all brokers as being in different AZs
+	if len(brokerAzMap) != len(cluster.Spec.Brokers) {
+		for _, broker := range cluster.Spec.Brokers {
+			brokerAzMap[broker.Id] = fmt.Sprintf("%d", broker.Id)
+		}
+	}
+	return brokerAzMap
+}
+
+func getBrokerRack(readOnlyConfig string) string {
+	if readOnlyConfig == "" {
+		return ""
+	}
+	match := kafkaConfigBrokerRackRegex.FindStringSubmatch(readOnlyConfig)
+	if len(match) == 2 {
+		return match[1]
+	}
+	return ""
+}
+
 func getCreatedPvcForBroker(
 	ctx context.Context,
 	c client.Reader,
@@ -877,18 +919,23 @@ func (r *Reconciler) handleRollingUpgrade(log logr.Logger, desiredPod, currentPo
 			if err != nil {
 				return errors.WrapIf(err, "failed to reconcile resource")
 			}
-			for _, pod := range podList.Items {
-				pod := pod
-				if k8sutil.IsMarkedForDeletion(pod.ObjectMeta) {
-					return errorfactory.New(errorfactory.ReconcileRollingUpgrade{}, errors.New("pod is still terminating"), "rolling upgrade in progress")
-				}
-				if k8sutil.IsPodContainsPendingContainer(&pod) {
-					return errorfactory.New(errorfactory.ReconcileRollingUpgrade{}, errors.New("pod is still creating"), "rolling upgrade in progress")
-				}
+			if len(podList.Items) < len(r.KafkaCluster.Spec.Brokers) {
+				return errorfactory.New(errorfactory.ReconcileRollingUpgrade{}, errors.New("pod count differs from brokers spec"), "rolling upgrade in progress")
 			}
 
-			errorCount := r.KafkaCluster.Status.RollingUpgrade.ErrorCount
+			// Check if we support multiple broker restarts and restart only in same AZ, otherwise restart only 1 broker at once
+			concurrentBrokerRestartsAllowed := r.getConcurrentBrokerRestartsAllowed()
+			terminatingOrPendingPods := getPodsInTerminatingOrPendingState(podList.Items)
+			if len(terminatingOrPendingPods) >= concurrentBrokerRestartsAllowed {
+				return errorfactory.New(errorfactory.ReconcileRollingUpgrade{}, errors.New(strconv.Itoa(concurrentBrokerRestartsAllowed)+" pod(s) is still terminating or creating"), "rolling upgrade in progress")
+			}
+			currentPodAz := r.getBrokerAz(currentPod)
+			if concurrentBrokerRestartsAllowed > 1 && r.existsTerminatingPodFromAnotherAz(currentPodAz, terminatingOrPendingPods) {
+				return errorfactory.New(errorfactory.ReconcileRollingUpgrade{}, errors.New("pod is still terminating or creating from another AZ"), "rolling upgrade in progress")
+			}
 
+			// Check broker count with out-of-sync and offline replicas against the rolling upgrade failure threshold
+			errorCount := r.KafkaCluster.Status.RollingUpgrade.ErrorCount
 			kClient, close, err := r.kafkaClientProvider.NewFromCluster(r.Client, r.KafkaCluster)
 			if err != nil {
 				return errorfactory.New(errorfactory.BrokersUnreachable{}, err, "could not connect to kafka brokers")
@@ -908,7 +955,6 @@ func (r *Reconciler) handleRollingUpgrade(log logr.Logger, desiredPod, currentPo
 			if len(outOfSyncReplicas) > 0 {
 				log.Info("out-of-sync replicas", "IDs", outOfSyncReplicas)
 			}
-
 			impactedReplicas := make(map[int32]struct{})
 			for _, brokerID := range allOfflineReplicas {
 				impactedReplicas[brokerID] = struct{}{}
@@ -916,11 +962,16 @@ func (r *Reconciler) handleRollingUpgrade(log logr.Logger, desiredPod, currentPo
 			for _, brokerID := range outOfSyncReplicas {
 				impactedReplicas[brokerID] = struct{}{}
 			}
-
 			errorCount += len(impactedReplicas)
-
 			if errorCount >= r.KafkaCluster.Spec.RollingUpgradeConfig.FailureThreshold {
 				return errorfactory.New(errorfactory.ReconcileRollingUpgrade{}, errors.New("cluster is not healthy"), "rolling upgrade in progress")
+			}
+
+			// If multiple concurrent restarts and broker failures allowed, restart only brokers from the same AZ
+			if concurrentBrokerRestartsAllowed > 1 && r.KafkaCluster.Spec.RollingUpgradeConfig.FailureThreshold > 1 {
+				if r.existsFailedBrokerFromAnotherAz(currentPodAz, impactedReplicas) {
+					return errorfactory.New(errorfactory.ReconcileRollingUpgrade{}, errors.New("broker is not healthy from another AZ"), "rolling upgrade in progress")
+				}
 			}
 		}
 	}
@@ -941,6 +992,37 @@ func (r *Reconciler) handleRollingUpgrade(log logr.Logger, desiredPod, currentPo
 	}
 	log.Info("broker pod deleted", "pod", currentPod.GetName(), v1beta1.BrokerIdLabelKey, currentPod.Labels[v1beta1.BrokerIdLabelKey])
 	return nil
+}
+
+func (r *Reconciler) existsFailedBrokerFromAnotherAz(currentPodAz string, impactedReplicas map[int32]struct{}) bool {
+	if currentPodAz == "" && len(impactedReplicas) > 0 {
+		return true
+	}
+	for brokerWithFailure := range impactedReplicas {
+		if currentPodAz != r.kafkaBrokerAvailabilityZoneMap[brokerWithFailure] {
+			return true
+		}
+	}
+	return false
+}
+
+func (r *Reconciler) getConcurrentBrokerRestartsAllowed() int {
+	if r.KafkaCluster.Spec.RollingUpgradeConfig.ConcurrentBrokerRestartsAllowed > 1 {
+		return r.KafkaCluster.Spec.RollingUpgradeConfig.ConcurrentBrokerRestartsAllowed
+	}
+	return defaultConcurrentBrokerRestartsAllowed
+}
+
+func (r *Reconciler) existsTerminatingPodFromAnotherAz(currentPodAz string, terminatingOrPendingPods []corev1.Pod) bool {
+	if currentPodAz == "" && len(terminatingOrPendingPods) > 0 {
+		return true
+	}
+	for _, terminatingOrPendingPod := range terminatingOrPendingPods {
+		if currentPodAz != r.getBrokerAz(&terminatingOrPendingPod) {
+			return true
+		}
+	}
+	return false
 }
 
 // Checks for match between pod labels and TaintedBrokersSelector
@@ -1380,6 +1462,27 @@ func (r *Reconciler) determineControllerId() (int32, error) {
 	}
 
 	return controllerID, nil
+}
+
+func getPodsInTerminatingOrPendingState(items []corev1.Pod) []corev1.Pod {
+	var pods []corev1.Pod
+	for _, pod := range items {
+		if k8sutil.IsMarkedForDeletion(pod.ObjectMeta) {
+			pods = append(pods, pod)
+		}
+		if k8sutil.IsPodContainsPendingContainer(&pod) {
+			pods = append(pods, pod)
+		}
+	}
+	return pods
+}
+
+func (r *Reconciler) getBrokerAz(pod *corev1.Pod) string {
+	brokerId, err := strconv.ParseInt(pod.Labels[v1beta1.BrokerIdLabelKey], 10, 32)
+	if err != nil {
+		return ""
+	}
+	return r.kafkaBrokerAvailabilityZoneMap[int32(brokerId)]
 }
 
 func getServiceFromExternalListener(client client.Client, cluster *v1beta1.KafkaCluster,

--- a/pkg/resources/kafka/kafka_test.go
+++ b/pkg/resources/kafka/kafka_test.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/onsi/gomega"
@@ -26,6 +27,8 @@ import (
 	"github.com/stretchr/testify/mock"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/banzaicloud/koperator/pkg/kafkaclient"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -1225,5 +1228,350 @@ func createPvc(name, brokerId, mountPath string) *corev1.PersistentVolumeClaim {
 		Status: corev1.PersistentVolumeClaimStatus{
 			Phase: corev1.ClaimBound,
 		},
+	}
+}
+
+// nolint funlen
+func TestReconcileConcurrentBrokerRestartsAllowed(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		testName           string
+		kafkaCluster       v1beta1.KafkaCluster
+		desiredPod         *corev1.Pod
+		currentPod         *corev1.Pod
+		pods               []corev1.Pod
+		allOfflineReplicas []int32
+		outOfSyncReplicas  []int32
+		errorExpected      bool
+	}{
+		{
+			testName: "Pod is not deleted if pod list count different from spec",
+			kafkaCluster: v1beta1.KafkaCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kafka",
+					Namespace: "kafka",
+				},
+				Spec: v1beta1.KafkaClusterSpec{
+					Brokers: []v1beta1.Broker{{Id: 101}, {Id: 201}, {Id: 301}},
+				},
+			},
+			desiredPod:    &corev1.Pod{},
+			currentPod:    &corev1.Pod{},
+			pods:          []corev1.Pod{},
+			errorExpected: true,
+		},
+		{
+			testName: "Pod is not deleted if allowed concurrent restarts not specified (default=1) and another pod is restarting",
+			kafkaCluster: v1beta1.KafkaCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kafka",
+					Namespace: "kafka",
+				},
+				Spec: v1beta1.KafkaClusterSpec{
+					Brokers: []v1beta1.Broker{{Id: 101}, {Id: 201}, {Id: 301}},
+				},
+			},
+			desiredPod: &corev1.Pod{},
+			currentPod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "kafka-201"}},
+			pods: []corev1.Pod{
+				{ObjectMeta: metav1.ObjectMeta{Name: "kafka-101", DeletionTimestamp: &metav1.Time{Time: time.Now()}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "kafka-201"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "kafka-301"}},
+			},
+			errorExpected: true,
+		},
+		{
+			testName: "Pod is not deleted if allowed concurrent restarts equals pods restarting",
+			kafkaCluster: v1beta1.KafkaCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kafka",
+					Namespace: "kafka",
+				},
+				Spec: v1beta1.KafkaClusterSpec{
+					Brokers: []v1beta1.Broker{{Id: 101}, {Id: 201}, {Id: 301}},
+					RollingUpgradeConfig: v1beta1.RollingUpgradeConfig{
+						ConcurrentBrokerRestartsAllowed: 2,
+					},
+				},
+			},
+			desiredPod: &corev1.Pod{},
+			currentPod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "kafka-301"}},
+			pods: []corev1.Pod{
+				{ObjectMeta: metav1.ObjectMeta{Name: "kafka-101", DeletionTimestamp: &metav1.Time{Time: time.Now()}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "kafka-201", DeletionTimestamp: &metav1.Time{Time: time.Now()}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "kafka-301"}},
+			},
+			errorExpected: true,
+		},
+		{
+			testName: "Pod is not deleted if broker.rack is not set in all read-only configs, if another pod is restarting",
+			kafkaCluster: v1beta1.KafkaCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kafka",
+					Namespace: "kafka",
+				},
+				Spec: v1beta1.KafkaClusterSpec{
+					Brokers: []v1beta1.Broker{{Id: 101}, {Id: 102}, {Id: 201}, {Id: 102}, {Id: 301}, {Id: 302}},
+					RollingUpgradeConfig: v1beta1.RollingUpgradeConfig{
+						ConcurrentBrokerRestartsAllowed: 2,
+					},
+				},
+			},
+			desiredPod: &corev1.Pod{},
+			currentPod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "kafka-102", Labels: map[string]string{"brokerId": "102"}}},
+			pods: []corev1.Pod{
+				{ObjectMeta: metav1.ObjectMeta{Name: "kafka-101", Labels: map[string]string{"brokerId": "101"}, DeletionTimestamp: &metav1.Time{Time: time.Now()}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "kafka-102", Labels: map[string]string{"brokerId": "102"}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "kafka-201", Labels: map[string]string{"brokerId": "201"}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "kafka-202", Labels: map[string]string{"brokerId": "202"}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "kafka-301", Labels: map[string]string{"brokerId": "301"}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "kafka-302", Labels: map[string]string{"brokerId": "302"}}},
+			},
+			errorExpected: true,
+		},
+		{
+			testName: "Pod is not deleted if broker.rack is not set in some read-only configs, if another pod is restarting",
+			kafkaCluster: v1beta1.KafkaCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kafka",
+					Namespace: "kafka",
+				},
+				Spec: v1beta1.KafkaClusterSpec{
+					Brokers: []v1beta1.Broker{
+						{Id: 101, ReadOnlyConfig: "broker.rack=az1"},
+						{Id: 102, ReadOnlyConfig: ""},
+						{Id: 201, ReadOnlyConfig: "broker.rack=az2"},
+						{Id: 202, ReadOnlyConfig: ""},
+						{Id: 301, ReadOnlyConfig: "broker.rack=az3"},
+						{Id: 302, ReadOnlyConfig: ""}},
+					RollingUpgradeConfig: v1beta1.RollingUpgradeConfig{
+						ConcurrentBrokerRestartsAllowed: 2,
+					},
+				},
+			},
+			desiredPod: &corev1.Pod{},
+			currentPod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "kafka-102", Labels: map[string]string{"brokerId": "102"}}},
+			pods: []corev1.Pod{
+				{ObjectMeta: metav1.ObjectMeta{Name: "kafka-101", Labels: map[string]string{"brokerId": "101"}, DeletionTimestamp: &metav1.Time{Time: time.Now()}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "kafka-102", Labels: map[string]string{"brokerId": "102"}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "kafka-201", Labels: map[string]string{"brokerId": "201"}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "kafka-202", Labels: map[string]string{"brokerId": "202"}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "kafka-301", Labels: map[string]string{"brokerId": "301"}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "kafka-302", Labels: map[string]string{"brokerId": "302"}}},
+			},
+			errorExpected: true,
+		},
+		{
+			testName: "Pod is not deleted if allowed concurrent restarts is not specified and failure threshold is reached",
+			kafkaCluster: v1beta1.KafkaCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kafka",
+					Namespace: "kafka",
+				},
+				Spec: v1beta1.KafkaClusterSpec{
+					Brokers: []v1beta1.Broker{
+						{Id: 101, ReadOnlyConfig: "broker.rack=az1"},
+						{Id: 102, ReadOnlyConfig: "broker.rack=az1"},
+						{Id: 201, ReadOnlyConfig: "broker.rack=az2"},
+						{Id: 202, ReadOnlyConfig: "broker.rack=az2"},
+						{Id: 301, ReadOnlyConfig: "broker.rack=az3"},
+						{Id: 302, ReadOnlyConfig: "broker.rack=az3"}},
+					RollingUpgradeConfig: v1beta1.RollingUpgradeConfig{
+						FailureThreshold: 1,
+					},
+				},
+			},
+			desiredPod: &corev1.Pod{},
+			currentPod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "kafka-102", Labels: map[string]string{"brokerId": "102"}}},
+			pods: []corev1.Pod{
+				{ObjectMeta: metav1.ObjectMeta{Name: "kafka-101", Labels: map[string]string{"brokerId": "101"}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "kafka-102", Labels: map[string]string{"brokerId": "102"}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "kafka-201", Labels: map[string]string{"brokerId": "201"}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "kafka-202", Labels: map[string]string{"brokerId": "202"}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "kafka-301", Labels: map[string]string{"brokerId": "301"}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "kafka-302", Labels: map[string]string{"brokerId": "302"}}},
+			},
+			outOfSyncReplicas: []int32{101},
+			errorExpected:     true,
+		},
+		{
+			testName: "Pod is deleted if allowed concurrent restarts is not specified and failure threshold is not reached",
+			kafkaCluster: v1beta1.KafkaCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kafka",
+					Namespace: "kafka",
+				},
+				Spec: v1beta1.KafkaClusterSpec{
+					Brokers: []v1beta1.Broker{
+						{Id: 101, ReadOnlyConfig: "broker.rack=az1"},
+						{Id: 102, ReadOnlyConfig: "broker.rack=az1"},
+						{Id: 201, ReadOnlyConfig: "broker.rack=az2"},
+						{Id: 202, ReadOnlyConfig: "broker.rack=az2"},
+						{Id: 301, ReadOnlyConfig: "broker.rack=az3"},
+						{Id: 302, ReadOnlyConfig: "broker.rack=az3"}},
+					RollingUpgradeConfig: v1beta1.RollingUpgradeConfig{
+						FailureThreshold: 1,
+					},
+				},
+			},
+			desiredPod: &corev1.Pod{},
+			currentPod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "kafka-102", Labels: map[string]string{"brokerId": "102"}}},
+			pods: []corev1.Pod{
+				{ObjectMeta: metav1.ObjectMeta{Name: "kafka-101", Labels: map[string]string{"brokerId": "101"}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "kafka-102", Labels: map[string]string{"brokerId": "102"}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "kafka-201", Labels: map[string]string{"brokerId": "201"}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "kafka-202", Labels: map[string]string{"brokerId": "202"}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "kafka-301", Labels: map[string]string{"brokerId": "301"}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "kafka-302", Labels: map[string]string{"brokerId": "302"}}},
+			},
+			errorExpected: false,
+		},
+		{
+			testName: "Pod is not deleted if pod is restarting in another AZ, even if allowed concurrent restarts is not reached",
+			kafkaCluster: v1beta1.KafkaCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kafka",
+					Namespace: "kafka",
+				},
+				Spec: v1beta1.KafkaClusterSpec{
+					Brokers: []v1beta1.Broker{
+						{Id: 101, ReadOnlyConfig: "broker.rack=az1"},
+						{Id: 102, ReadOnlyConfig: "broker.rack=az1"},
+						{Id: 201, ReadOnlyConfig: "broker.rack=az2"},
+						{Id: 202, ReadOnlyConfig: "broker.rack=az2"},
+						{Id: 301, ReadOnlyConfig: "broker.rack=az3"},
+						{Id: 302, ReadOnlyConfig: "broker.rack=az3"}},
+					RollingUpgradeConfig: v1beta1.RollingUpgradeConfig{
+						FailureThreshold:                2,
+						ConcurrentBrokerRestartsAllowed: 2,
+					},
+				},
+			},
+			desiredPod: &corev1.Pod{},
+			currentPod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "kafka-201", Labels: map[string]string{"brokerId": "201"}}},
+			pods: []corev1.Pod{
+				{ObjectMeta: metav1.ObjectMeta{Name: "kafka-101", Labels: map[string]string{"brokerId": "101"}, DeletionTimestamp: &metav1.Time{Time: time.Now()}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "kafka-102", Labels: map[string]string{"brokerId": "102"}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "kafka-201", Labels: map[string]string{"brokerId": "201"}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "kafka-202", Labels: map[string]string{"brokerId": "202"}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "kafka-301", Labels: map[string]string{"brokerId": "301"}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "kafka-302", Labels: map[string]string{"brokerId": "302"}}},
+			},
+			outOfSyncReplicas: []int32{201},
+			errorExpected:     true,
+		},
+		{
+			testName: "Pod is not deleted if failure is in another AZ, even if allowed concurrent restarts is not reached",
+			kafkaCluster: v1beta1.KafkaCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kafka",
+					Namespace: "kafka",
+				},
+				Spec: v1beta1.KafkaClusterSpec{
+					Brokers: []v1beta1.Broker{
+						{Id: 101, ReadOnlyConfig: "broker.rack=az1"},
+						{Id: 102, ReadOnlyConfig: "broker.rack=az1"},
+						{Id: 201, ReadOnlyConfig: "broker.rack=az2"},
+						{Id: 202, ReadOnlyConfig: "broker.rack=az2"},
+						{Id: 301, ReadOnlyConfig: "broker.rack=az3"},
+						{Id: 302, ReadOnlyConfig: "broker.rack=az3"}},
+					RollingUpgradeConfig: v1beta1.RollingUpgradeConfig{
+						FailureThreshold:                2,
+						ConcurrentBrokerRestartsAllowed: 2,
+					},
+				},
+			},
+			desiredPod: &corev1.Pod{},
+			currentPod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "kafka-101", Labels: map[string]string{"brokerId": "101"}}},
+			pods: []corev1.Pod{
+				{ObjectMeta: metav1.ObjectMeta{Name: "kafka-101", Labels: map[string]string{"brokerId": "101"}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "kafka-102", Labels: map[string]string{"brokerId": "102"}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "kafka-201", Labels: map[string]string{"brokerId": "201"}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "kafka-202", Labels: map[string]string{"brokerId": "202"}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "kafka-301", Labels: map[string]string{"brokerId": "301"}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "kafka-302", Labels: map[string]string{"brokerId": "302"}}},
+			},
+			outOfSyncReplicas: []int32{201},
+			errorExpected:     true,
+		},
+		{
+			testName: "Pod is deleted if failure is in same AZ and allowed concurrent restarts is not reached",
+			kafkaCluster: v1beta1.KafkaCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kafka",
+					Namespace: "kafka",
+				},
+				Spec: v1beta1.KafkaClusterSpec{
+					Brokers: []v1beta1.Broker{
+						{Id: 101, ReadOnlyConfig: "broker.rack=az1"},
+						{Id: 102, ReadOnlyConfig: "broker.rack=az1"},
+						{Id: 201, ReadOnlyConfig: "broker.rack=az2"},
+						{Id: 202, ReadOnlyConfig: "broker.rack=az2"},
+						{Id: 301, ReadOnlyConfig: "broker.rack=az3"},
+						{Id: 302, ReadOnlyConfig: "broker.rack=az3"}},
+					RollingUpgradeConfig: v1beta1.RollingUpgradeConfig{
+						FailureThreshold:                2,
+						ConcurrentBrokerRestartsAllowed: 2,
+					},
+				},
+			},
+			desiredPod: &corev1.Pod{},
+			currentPod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "kafka-102", Labels: map[string]string{"brokerId": "102"}}},
+			pods: []corev1.Pod{
+				{ObjectMeta: metav1.ObjectMeta{Name: "kafka-101", Labels: map[string]string{"brokerId": "101"}, DeletionTimestamp: &metav1.Time{Time: time.Now()}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "kafka-102", Labels: map[string]string{"brokerId": "102"}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "kafka-201", Labels: map[string]string{"brokerId": "201"}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "kafka-202", Labels: map[string]string{"brokerId": "202"}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "kafka-301", Labels: map[string]string{"brokerId": "301"}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "kafka-302", Labels: map[string]string{"brokerId": "302"}}},
+			},
+			outOfSyncReplicas: []int32{101},
+			errorExpected:     false,
+		},
+	}
+
+	for _, test := range testCases {
+		mockClient := new(mocks.Client)
+		mockKafkaClientProvider := new(kafkaclient.MockedProvider)
+
+		t.Run(test.testName, func(t *testing.T) {
+			r := New(mockClient, nil, &test.kafkaCluster, mockKafkaClientProvider)
+
+			// Mock client
+			mockClient.On("Status").Return(mockClient)
+			mockClient.On("Update", context.TODO(), mock.AnythingOfType("*v1beta1.KafkaCluster")).Run(func(args mock.Arguments) {
+				arg := args.Get(1).(*v1beta1.KafkaCluster)
+				r.KafkaCluster.Status = arg.Status
+			}).Return(nil)
+			mockClient.On(
+				"List",
+				context.TODO(),
+				mock.IsType(&corev1.PodList{}),
+				client.InNamespace("kafka"),
+				mock.AnythingOfType("client.MatchingLabels"),
+			).Run(func(args mock.Arguments) {
+				arg := args.Get(1).(*corev1.PodList)
+				arg.Items = test.pods
+			}).Return(nil)
+			mockClient.On("Delete", context.TODO(), mock.IsType(&corev1.Pod{})).Return(nil)
+
+			// Mock kafka client
+			mockedKafkaClient := new(mocks.KafkaClient)
+			mockedKafkaClient.On("AllOfflineReplicas").Return(test.outOfSyncReplicas, nil)
+			mockedKafkaClient.On("OutOfSyncReplicas").Return(test.outOfSyncReplicas, nil)
+			mockKafkaClientProvider.On("NewFromCluster", mockClient, &test.kafkaCluster).Return(mockedKafkaClient, func() {}, nil)
+
+			// Call the handleRollingUpgrade function with the provided test.desiredPod and test.currentPod
+			err := r.handleRollingUpgrade(logf.Log, test.desiredPod, test.currentPod, reflect.TypeOf(test.desiredPod))
+
+			// Test that the expected error is returned
+			if test.errorExpected {
+				assert.NotNil(t, err, "Expected an error but got nil")
+				mockClient.AssertNotCalled(t, "Delete", context.TODO(), mock.IsType(&corev1.Pod{}))
+			} else {
+				assert.Nil(t, err, "Expected no error but got one")
+				mockClient.AssertCalled(t, "Delete", context.TODO(), mock.IsType(&corev1.Pod{}))
+			}
+		})
 	}
 }

--- a/pkg/resources/kafka/mocks/KafkaClient.go
+++ b/pkg/resources/kafka/mocks/KafkaClient.go
@@ -1,0 +1,138 @@
+// Copyright © 2023 Cisco Systems, Inc. and/or its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mocks
+
+import (
+	"github.com/Shopify/sarama"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/banzaicloud/koperator/api/v1alpha1"
+	"github.com/banzaicloud/koperator/pkg/kafkaclient"
+)
+
+// KafkaClient is a Testify mock for Kafka client
+type KafkaClient struct {
+	mock.Mock
+}
+
+func (k *KafkaClient) NumBrokers() int {
+	args := k.Called()
+	return args.Int(0)
+}
+
+func (k *KafkaClient) ListTopics() (map[string]sarama.TopicDetail, error) {
+	args := k.Called()
+	return args.Get(0).(map[string]sarama.TopicDetail), args.Error(1)
+}
+
+func (k *KafkaClient) CreateTopic(createTopicOptions *kafkaclient.CreateTopicOptions) error {
+	args := k.Called(createTopicOptions)
+	return args.Error(0)
+}
+
+func (k *KafkaClient) EnsurePartitionCount(topic string, partitionCount int32) (bool, error) {
+	args := k.Called(topic, partitionCount)
+	return args.Bool(0), args.Error(1)
+}
+
+func (k *KafkaClient) EnsureTopicConfig(topic string, config map[string]*string) error {
+	args := k.Called(topic, config)
+	return args.Error(0)
+}
+
+func (k *KafkaClient) DeleteTopic(topic string, force bool) error {
+	args := k.Called(topic, force)
+	return args.Error(0)
+}
+
+func (k *KafkaClient) GetTopic(topic string) (*sarama.TopicDetail, error) {
+	args := k.Called(topic)
+	return args.Get(0).(*sarama.TopicDetail), args.Error(1)
+}
+
+func (k *KafkaClient) DescribeTopic(topic string) (*sarama.TopicMetadata, error) {
+	args := k.Called(topic)
+	return args.Get(0).(*sarama.TopicMetadata), args.Error(1)
+}
+
+func (k *KafkaClient) CreateUserACLs(accessType v1alpha1.KafkaAccessType, patternType v1alpha1.KafkaPatternType, dn string, topic string) (err error) {
+	args := k.Called(accessType, patternType, dn, topic)
+	return args.Error(0)
+}
+
+func (k *KafkaClient) ListUserACLs() (acls []sarama.ResourceAcls, err error) {
+	args := k.Called()
+	return args.Get(0).([]sarama.ResourceAcls), args.Error(1)
+}
+
+func (k *KafkaClient) DeleteUserACLs(dn string) (err error) {
+	args := k.Called(dn)
+	return args.Error(0)
+}
+
+func (k *KafkaClient) Brokers() map[int32]string {
+	args := k.Called()
+	return args.Get(0).(map[int32]string)
+}
+
+func (k *KafkaClient) DescribeCluster() ([]*sarama.Broker, int32, error) {
+	args := k.Called()
+	return args.Get(0).([]*sarama.Broker), args.Get(1).(int32), args.Error(2)
+}
+
+func (k *KafkaClient) AllOfflineReplicas() ([]int32, error) {
+	args := k.Called()
+	return args.Get(0).([]int32), args.Error(1)
+}
+
+func (k *KafkaClient) OutOfSyncReplicas() ([]int32, error) {
+	args := k.Called()
+	return args.Get(0).([]int32), args.Error(1)
+}
+
+func (k *KafkaClient) AlterPerBrokerConfig(brokerId int32, config map[string]*string, validateOnly bool) error {
+	args := k.Called(brokerId, config, validateOnly)
+	return args.Error(0)
+}
+
+func (k *KafkaClient) DescribePerBrokerConfig(brokerId int32, configNames []string) ([]*sarama.ConfigEntry, error) {
+	args := k.Called(brokerId, configNames)
+	return args.Get(0).([]*sarama.ConfigEntry), args.Error(1)
+}
+
+func (k *KafkaClient) AlterClusterWideConfig(config map[string]*string, validateOnly bool) error {
+	args := k.Called(config, validateOnly)
+	return args.Error(0)
+}
+
+func (k *KafkaClient) DescribeClusterWideConfig() ([]sarama.ConfigEntry, error) {
+	args := k.Called()
+	return args.Get(0).([]sarama.ConfigEntry), args.Error(1)
+}
+
+func (k *KafkaClient) TopicMetaToStatus(topicMeta *sarama.TopicMetadata) *v1alpha1.KafkaTopicStatus {
+	args := k.Called(topicMeta)
+	return args.Get(0).(*v1alpha1.KafkaTopicStatus)
+}
+
+func (k *KafkaClient) Open() error {
+	args := k.Called()
+	return args.Error(0)
+}
+
+func (k *KafkaClient) Close() error {
+	args := k.Called()
+	return args.Error(0)
+}


### PR DESCRIPTION
## Description

Cluster restarts are time consuming for big clusters.

Given that we are using Kafka `broker.rack` config to spread replicas across 3 AZs, we can speed up the cluster restart by allowing concurrent broker restarts within the same AZ. Allowing only same AZ concurrent restarts makes sure that we always have at most 1/3rd of the replicas of any topic-partition offline, not more.

## Key changes:
- add configuration parameter `RollingUpgradeConfig.ConcurrentBrokerRestartsAllowed` which is by default 1
- allow concurrent broker restarts only if there are no failures or restarts in other AZs and if there are no more failures or restarts in the same AZ than specified by `RollingUpgradeConfig.ConcurrentBrokerRestartsAllowed` and `RollingUpgradeConfig.FailureThreshold`
- do not change the semantic of `RollingUpgradeConfig.FailureThreshold` by allowing (same as before) multiple failures even if not in the same AZ
- if `broker.rack` is not properly configured for all brokers, consider each broker as being in a separate AZ, meaning we err on the side of caution and restart at most 1 broker at once

**Note**: in order to enable multiple concurrent restarts, we must set both `RollingUpgradeConfig.ConcurrentBrokerRestartsAllowed` and `RollingUpgradeConfig.FailureThreshold` to a value above 1