### PR TITLE
[INTERNAL] Get watched namespaces from env variable

### DIFF
--- a/main.go
+++ b/main.go
@@ -128,6 +128,7 @@ func main() {
 		namespaces = os.Getenv("WATCH_NAMESPACE")
 		namespaceList = strings.Split(namespaces, ",")
 	}
+	fmt.Println("-------------------------namespaces", namespaces)
 	for i := range namespaceList {
 		watchedNamespaces[strings.TrimSpace(namespaceList[i])] = cache.Config{}
 	}

--- a/main.go
+++ b/main.go
@@ -123,9 +123,13 @@ func main() {
 	watchedNamespaces := make(map[string]cache.Config)
 	if namespaces != "" {
 		namespaceList = strings.Split(namespaces, ",")
-		for i := range namespaceList {
-			watchedNamespaces[strings.TrimSpace(namespaceList[i])] = cache.Config{}
+	} else {
+		if namespaces, ok := os.LookupEnv("WATCH_NAMESPACE"); ok {
+			namespaceList = strings.Split(namespaces, ",")
 		}
+	}
+	for i := range namespaceList {
+		watchedNamespaces[strings.TrimSpace(namespaceList[i])] = cache.Config{}
 	}
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{

--- a/main.go
+++ b/main.go
@@ -124,9 +124,8 @@ func main() {
 	if namespaces != "" {
 		namespaceList = strings.Split(namespaces, ",")
 	} else {
-		if namespaces, ok := os.LookupEnv("WATCH_NAMESPACE"); ok {
-			namespaceList = strings.Split(namespaces, ",")
-		}
+		namespaces = os.Getenv("WATCH_NAMESPACE")
+		namespaceList = strings.Split(namespaces, ",")
 	}
 	for i := range namespaceList {
 		watchedNamespaces[strings.TrimSpace(namespaceList[i])] = cache.Config{}

--- a/main.go
+++ b/main.go
@@ -128,7 +128,6 @@ func main() {
 		namespaces = os.Getenv("WATCH_NAMESPACE")
 		namespaceList = strings.Split(namespaces, ",")
 	}
-	fmt.Println("-------------------------namespaces", namespaces)
 	for i := range namespaceList {
 		watchedNamespaces[strings.TrimSpace(namespaceList[i])] = cache.Config{}
 	}


### PR DESCRIPTION
Currently setting the watched namespaces is done with `---namespaces`. This Pr introduces the option to also set the watched namespaces via environment variable WATCH_NAMESPACE.