### PR TITLE
[INTERNAL] Create uniq leader ID per operator deployment

### DIFF
--- a/main.go
+++ b/main.go
@@ -31,10 +31,8 @@ package main
 
 import (
 	"context"
-	"crypto/md5"
 	"flag"
 	"fmt"
-	"io"
 	"os"
 	"strings"
 
@@ -133,9 +131,7 @@ func main() {
 
 	// hash the watched namespaces to allow for more than one operator deployment per namespace
 	// same watched namespaces will return the same hash so only one operator will be active
-	h := md5.New()
-	io.WriteString(h, namespaces)
-	leaderElectionID := fmt.Sprintf("%s-%x", "controller-leader-election-helper", h.Sum(nil))
+	leaderElectionID := fmt.Sprintf("%s-%x", "controller-leader-election-helper", util.GetMD5Hash(namespaces))
 	setupLog.Info("Using leader electrion id", "LeaderElectionID", leaderElectionID, "watched namespaces", namespaceList)
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{

--- a/main.go
+++ b/main.go
@@ -140,7 +140,7 @@ func main() {
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:           scheme,
 		LeaderElection:   enableLeaderElection,
-		LeaderElectionID: fmt.Sprint("%s-%s", "controller-leader-election-helper", leaderElectionHash),
+		LeaderElectionID: fmt.Sprintf("%s-%s", "controller-leader-election-helper", leaderElectionHash),
 		WebhookServer: webhook.NewServer(webhook.Options{
 			Port:    webhookServerPort,
 			CertDir: webhookCertDir,

--- a/main.go
+++ b/main.go
@@ -135,12 +135,13 @@ func main() {
 	// same watched namespaces will return the same hash so only one operator will be active
 	h := md5.New()
 	io.WriteString(h, namespaces)
-	leaderElectionHash := fmt.Sprintf("%x", h.Sum(nil))
+	leaderElectionID := fmt.Sprintf("%s-%x", "controller-leader-election-helper", h.Sum(nil))
+	setupLog.Info("Using leader electrion id", "LeaderElectionID", leaderElectionID, "watched namespaces", namespaceList)
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:           scheme,
 		LeaderElection:   enableLeaderElection,
-		LeaderElectionID: fmt.Sprintf("%s-%s", "controller-leader-election-helper", leaderElectionHash),
+		LeaderElectionID: leaderElectionID,
 		WebhookServer: webhook.NewServer(webhook.Options{
 			Port:    webhookServerPort,
 			CertDir: webhookCertDir,

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -18,9 +18,11 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"crypto/md5"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -550,4 +552,10 @@ func RetryOnConflict(backoff wait.Backoff, fn func() error) error {
 
 func GetExternalPortForBroker(externalStartingPort, brokerId int32) int32 {
 	return externalStartingPort + brokerId
+}
+
+// Generage MD5 hash for a given string
+func GetMD5Hash(text string) string {
+	hash := md5.Sum([]byte(text))
+	return hex.EncodeToString(hash[:])
 }

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -690,3 +690,29 @@ cruise.control.metrics.reporter.kubernetes.mode=true`,
 		}
 	}
 }
+
+func TestGetMD5Hash(t *testing.T) {
+	testCases := []struct {
+		testName string
+		input    string
+		expected string
+	}{
+		{
+			testName: "empty string",
+			input:    "",
+			expected: "d41d8cd98f00b204e9800998ecf8427e",
+		},
+		{
+			testName: "non-empty string",
+			input:    "test",
+			expected: "098f6bcd4621d373cade4e832627b4f6",
+		},
+	}
+
+	for _, test := range testCases {
+		hash := GetMD5Hash(test.input)
+		if hash != test.expected {
+			t.Errorf("Expected: %s  Got: %s", test.expected, hash)
+		}
+	}
+}


### PR DESCRIPTION
Previously the LeaderElectionID was fixed value and in case of having multiple koperator per namespace, only one deployment would had leader elected as all deployments use the same Leases resource to vote.

Before, 4 koperator deployments, 1 lease:
```
kubectl get leases.coordination.k8s.io
NAME                                                                 HOLDER                                                                                                 AGE
controller-leader-election-helper                                    kafka-operator-7bdd0f84-918c-42d0-8c0d-d985c1618eff-67b74bhhwn2_b169f79e-220c-4689-8cee-4eb5367cb2bd   118m
```

With this Pr, 4 koperator deployments, each with its own lease:
```
kubectl get leases.coordination.k8s.io
NAME                                                                 HOLDER                                                                                                 AGE
controller-leader-election-helper-03cbebb919261de2a721099fbb406afa   kafka-operator-778d531e-4581-4280-8ad6-5db17d98c9fa-77d7879h272_890403af-3918-45d3-9864-9da24480b66c   5m31s
controller-leader-election-helper-3f84c0d23228173b493bdd7ae5bd720f   kafka-operator-d80e2ebc-1115-413d-9c33-94e0454dc358-7d9c7c95flj_1e860178-201c-4f9e-9c6b-505d55c519bd   5m31s
controller-leader-election-helper-c89feeb47bb697c7cb7f46b1e8186fef   kafka-operator-eeb8741f-79cc-436b-bb99-38e0cced87df-576c79phrnk_f127c765-6762-4501-86f8-638388c274e5   5m31s
controller-leader-election-helper-d41d8cd98f00b204e9800998ecf8427e   kafka-operator-778d531e-4581-4280-8ad6-5db17d98c9fa-69b755p55jp_2d78cf9d-4ae7-439c-91c5-f1b5069b3c49   21m
``` 