### PR TITLE
Allow property security-inter-broker-protocol 

### DIFF
--- a/api/v1beta1/kafkacluster_types.go
+++ b/api/v1beta1/kafkacluster_types.go
@@ -748,7 +748,9 @@ type CommonListenerSpec struct {
 	// At least one of the listeners should have this flag enabled
 	// +optional
 	UsedForInnerBrokerCommunication bool `json:"usedForInnerBrokerCommunication"`
-	UsedForKafkaAdminCommunication  bool `json:"usedForKafkaAdminCommunication,omitempty"`
+	// UsedForKafkaAdminCommunication allows for a different port to be returned when the koperator is checking for the port to use to check if kafka is operating.
+	// +optional
+	UsedForKafkaAdminCommunication bool `json:"usedForKafkaAdminCommunication,omitempty"`
 }
 
 func (c *CommonListenerSpec) GetServerSSLCertSecretName() string {

--- a/api/v1beta1/kafkacluster_types.go
+++ b/api/v1beta1/kafkacluster_types.go
@@ -748,7 +748,7 @@ type CommonListenerSpec struct {
 	// At least one of the listeners should have this flag enabled
 	// +optional
 	UsedForInnerBrokerCommunication bool `json:"usedForInnerBrokerCommunication"`
-	UsedForKafkaAdminCommunication  bool `json:"usedForKafkaAdminCommunication"`
+	UsedForKafkaAdminCommunication  bool `json:"usedForKafkaAdminCommunication,omitempty"`
 }
 
 func (c *CommonListenerSpec) GetServerSSLCertSecretName() string {

--- a/api/v1beta1/kafkacluster_types.go
+++ b/api/v1beta1/kafkacluster_types.go
@@ -748,6 +748,7 @@ type CommonListenerSpec struct {
 	// At least one of the listeners should have this flag enabled
 	// +optional
 	UsedForInnerBrokerCommunication bool `json:"usedForInnerBrokerCommunication"`
+	UsedForKafkaAdminCommunication  bool `json:"usedForKafkaAdminCommunication"`
 }
 
 func (c *CommonListenerSpec) GetServerSSLCertSecretName() string {

--- a/charts/kafka-operator/crds/kafkaclusters.yaml
+++ b/charts/kafka-operator/crds/kafkaclusters.yaml
@@ -21677,6 +21677,8 @@ spec:
                           description: At least one of the listeners should have this
                             flag enabled
                           type: boolean
+                        usedForKafkaAdminCommunication:
+                          type: boolean
                       required:
                       - containerPort
                       - externalStartingPort
@@ -21752,6 +21754,8 @@ spec:
                         usedForInnerBrokerCommunication:
                           description: At least one of the listeners should have this
                             flag enabled
+                          type: boolean
+                        usedForKafkaAdminCommunication:
                           type: boolean
                       required:
                       - containerPort

--- a/charts/kafka-operator/crds/kafkaclusters.yaml
+++ b/charts/kafka-operator/crds/kafkaclusters.yaml
@@ -21678,6 +21678,9 @@ spec:
                             flag enabled
                           type: boolean
                         usedForKafkaAdminCommunication:
+                          description: UsedForKafkaAdminCommunication allows for a
+                            different port to be returned when the koperator is checking
+                            for the port to use to check if kafka is operating.
                           type: boolean
                       required:
                       - containerPort
@@ -21756,6 +21759,9 @@ spec:
                             flag enabled
                           type: boolean
                         usedForKafkaAdminCommunication:
+                          description: UsedForKafkaAdminCommunication allows for a
+                            different port to be returned when the koperator is checking
+                            for the port to use to check if kafka is operating.
                           type: boolean
                       required:
                       - containerPort

--- a/config/base/crds/kafka.banzaicloud.io_kafkaclusters.yaml
+++ b/config/base/crds/kafka.banzaicloud.io_kafkaclusters.yaml
@@ -21678,7 +21678,6 @@ spec:
                             flag enabled
                           type: boolean
                         usedForKafkaAdminCommunication:
-                          description: override for kafka admin communication if external listeners are being used for broker-to-broker communication
                           type: boolean
                       required:
                       - containerPort
@@ -21757,7 +21756,6 @@ spec:
                             flag enabled
                           type: boolean
                         usedForKafkaAdminCommunication:
-                          description: override for kafka admin communication if external listeners are being used for broker-to-broker communication
                           type: boolean
                       required:
                       - containerPort

--- a/config/base/crds/kafka.banzaicloud.io_kafkaclusters.yaml
+++ b/config/base/crds/kafka.banzaicloud.io_kafkaclusters.yaml
@@ -21757,7 +21757,7 @@ spec:
                             flag enabled
                           type: boolean
                         usedForKafkaAdminCommunication:
-                          description: override for kafkaoadmin communication if external listeners are being used for broker-to-broker communication
+                          description: override for kafka admin communication if external listeners are being used for broker-to-broker communication
                           type: boolean
                       required:
                       - containerPort

--- a/config/base/crds/kafka.banzaicloud.io_kafkaclusters.yaml
+++ b/config/base/crds/kafka.banzaicloud.io_kafkaclusters.yaml
@@ -21677,6 +21677,9 @@ spec:
                           description: At least one of the listeners should have this
                             flag enabled
                           type: boolean
+                        usedForKafkaAdminCommunication:
+                          description: override for kafka admin communication if external listeners are being used for broker-to-broker communication
+                          type: boolean
                       required:
                       - containerPort
                       - externalStartingPort
@@ -21752,6 +21755,9 @@ spec:
                         usedForInnerBrokerCommunication:
                           description: At least one of the listeners should have this
                             flag enabled
+                          type: boolean
+                        usedForKafkaAdminCommunication:
+                          description: override for kafkaoadmin communication if external listeners are being used for broker-to-broker communication
                           type: boolean
                       required:
                       - containerPort

--- a/config/base/crds/kafka.banzaicloud.io_kafkaclusters.yaml
+++ b/config/base/crds/kafka.banzaicloud.io_kafkaclusters.yaml
@@ -21678,6 +21678,9 @@ spec:
                             flag enabled
                           type: boolean
                         usedForKafkaAdminCommunication:
+                          description: UsedForKafkaAdminCommunication allows for a
+                            different port to be returned when the koperator is checking
+                            for the port to use to check if kafka is operating.
                           type: boolean
                       required:
                       - containerPort
@@ -21756,6 +21759,9 @@ spec:
                             flag enabled
                           type: boolean
                         usedForKafkaAdminCommunication:
+                          description: UsedForKafkaAdminCommunication allows for a
+                            different port to be returned when the koperator is checking
+                            for the port to use to check if kafka is operating.
                           type: boolean
                       required:
                       - containerPort

--- a/pkg/resources/kafka/configmap.go
+++ b/pkg/resources/kafka/configmap.go
@@ -87,8 +87,10 @@ func (r *Reconciler) getConfigProperties(bConfig *v1beta1.BrokerConfig, id int32
 		}
 	}
 
-	// Add Cruise Control Metrics Reporter configuration
-	if !strings.Contains(r.KafkaCluster.Spec.ReadOnlyConfig, kafkautils.KafkaConfigSecurityInterBrokerProtocol+"=") {
+	// Add Cruise Control Metrics Reporter configuration.
+	// When "security.inter.broker.protocol" (e.g. inter broker communication is secure) is configured, the operator disables the reporter.
+	_, isSecurityInterBrokerProtocolConfigured := getBrokerReadOnlyConfig(id, r.KafkaCluster, log).Get(kafkautils.KafkaConfigSecurityInterBrokerProtocol)
+	if !isSecurityInterBrokerProtocolConfigured {
 		if err := config.Set(kafkautils.CruiseControlConfigMetricsReporters, "com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsReporter"); err != nil {
 			log.Error(err, fmt.Sprintf("setting '%s' in broker configuration resulted an error", kafkautils.CruiseControlConfigMetricsReporters))
 		}

--- a/pkg/resources/kafka/configmap.go
+++ b/pkg/resources/kafka/configmap.go
@@ -40,7 +40,7 @@ func (r *Reconciler) getConfigProperties(bConfig *v1beta1.BrokerConfig, id int32
 	config := properties.NewProperties()
 
 	// Add listener configuration
-	listenerConf := generateListenerSpecificConfig(&r.KafkaCluster.Spec.ListenersConfig, serverPasses, log)
+	listenerConf := generateListenerSpecificConfig(&r.KafkaCluster.Spec, serverPasses, log)
 	config.Merge(listenerConf)
 
 	// Add listener configuration
@@ -244,12 +244,14 @@ func generateControlPlaneListener(iListeners []v1beta1.InternalListenerConfig) s
 	return controlPlaneListener
 }
 
-func generateListenerSpecificConfig(l *v1beta1.ListenersConfig, serverPasses map[string]string, log logr.Logger) *properties.Properties {
+func generateListenerSpecificConfig(kcs *v1beta1.KafkaClusterSpec, serverPasses map[string]string, log logr.Logger) *properties.Properties {
 	var (
 		interBrokerListenerName   string
 		securityProtocolMapConfig []string
 		listenerConfig            []string
 	)
+	l := kcs.ListenersConfig
+	r := kcs.ReadOnlyConfig
 
 	config := properties.NewProperties()
 
@@ -292,9 +294,12 @@ func generateListenerSpecificConfig(l *v1beta1.ListenersConfig, serverPasses map
 	if err := config.Set(kafkautils.KafkaConfigListenerSecurityProtocolMap, securityProtocolMapConfig); err != nil {
 		log.Error(err, fmt.Sprintf("setting '%s' parameter in broker configuration resulted an error", kafkautils.KafkaConfigListenerSecurityProtocolMap))
 	}
-	if err := config.Set(kafkautils.KafkaConfigInterBrokerListenerName, interBrokerListenerName); err != nil {
-		log.Error(err, fmt.Sprintf("setting '%s' parameter in broker configuration resulted an error", kafkautils.KafkaConfigInterBrokerListenerName))
+	if !strings.Contains(r, kafkautils.KafkaConfigSecurityInterBrokerProtocol+"=") {
+		if err := config.Set(kafkautils.KafkaConfigInterBrokerListenerName, interBrokerListenerName); err != nil {
+			log.Error(err, fmt.Sprintf("setting '%s' parameter in broker configuration resulted an error", kafkautils.KafkaConfigInterBrokerListenerName))
+		}
 	}
+
 	if err := config.Set(kafkautils.KafkaConfigListeners, listenerConfig); err != nil {
 		log.Error(err, fmt.Sprintf("setting '%s' parameter in broker configuration resulted an error", kafkautils.KafkaConfigListeners))
 	}

--- a/pkg/resources/kafka/configmap.go
+++ b/pkg/resources/kafka/configmap.go
@@ -88,8 +88,10 @@ func (r *Reconciler) getConfigProperties(bConfig *v1beta1.BrokerConfig, id int32
 	}
 
 	// Add Cruise Control Metrics Reporter configuration
-	if err := config.Set(kafkautils.CruiseControlConfigMetricsReporters, "com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsReporter"); err != nil {
-		log.Error(err, fmt.Sprintf("setting '%s' in broker configuration resulted an error", kafkautils.CruiseControlConfigMetricsReporters))
+	if !strings.Contains(r.KafkaCluster.Spec.ReadOnlyConfig, kafkautils.KafkaConfigSecurityInterBrokerProtocol+"=") {
+		if err := config.Set(kafkautils.CruiseControlConfigMetricsReporters, "com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsReporter"); err != nil {
+			log.Error(err, fmt.Sprintf("setting '%s' in broker configuration resulted an error", kafkautils.CruiseControlConfigMetricsReporters))
+		}
 	}
 	bootstrapServers, err := kafkautils.GetBootstrapServersService(r.KafkaCluster)
 	if err != nil {

--- a/pkg/resources/kafka/configmap_test.go
+++ b/pkg/resources/kafka/configmap_test.go
@@ -605,6 +605,27 @@ metric.reporters=com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlM
 super.users=User:CN=kafka-headless.kafka.svc.cluster.local
 zookeeper.connect=example.zk:2181/`,
 		},
+		{
+			testName:                  "security_inter_broker_protocol_Set",
+			readOnlyConfig:            `security.inter.broker.protocol=SASL_SSL`,
+			zkAddresses:               []string{"example.zk:2181"},
+			zkPath:                    ``,
+			kubernetesClusterDomain:   ``,
+			clusterWideConfig:         ``,
+			perBrokerConfig:           ``,
+			perBrokerReadOnlyConfig:   ``,
+			advertisedListenerAddress: `kafka-0.kafka.svc.cluster.local:9092`,
+			listenerType:              "plaintext",
+			expectedConfig: `advertised.listeners=INTERNAL://kafka-0.kafka.svc.cluster.local:9092
+broker.id=0
+cruise.control.metrics.reporter.bootstrap.servers=kafka-all-broker.kafka.svc.cluster.local:9092
+cruise.control.metrics.reporter.kubernetes.mode=true
+listener.security.protocol.map=INTERNAL:PLAINTEXT
+listeners=INTERNAL://:9092
+metric.reporters=com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsReporter
+zookeeper.connect=example.zk:2181/
+security.inter.broker.protocol=SASL_SSL`,
+		},
 	}
 
 	t.Parallel()

--- a/pkg/resources/kafka/configmap_test.go
+++ b/pkg/resources/kafka/configmap_test.go
@@ -622,7 +622,6 @@ cruise.control.metrics.reporter.bootstrap.servers=kafka-all-broker.kafka.svc.clu
 cruise.control.metrics.reporter.kubernetes.mode=true
 listener.security.protocol.map=INTERNAL:PLAINTEXT
 listeners=INTERNAL://:9092
-metric.reporters=com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsReporter
 zookeeper.connect=example.zk:2181/
 security.inter.broker.protocol=SASL_SSL`,
 		},

--- a/pkg/resources/kafka/kafka.go
+++ b/pkg/resources/kafka/kafka.go
@@ -1615,7 +1615,7 @@ func generateServicePortForEListeners(listeners []v1beta1.ExternalListenerConfig
 	var usedPorts []corev1.ServicePort
 	for _, eListener := range listeners {
 		usedPorts = append(usedPorts, corev1.ServicePort{
-			Name:       eListener.GetListenerServiceName(),
+			Name:       strings.ReplaceAll(eListener.GetListenerServiceName(), "_", ""),
 			Protocol:   corev1.ProtocolTCP,
 			Port:       eListener.ContainerPort,
 			TargetPort: intstr.FromInt(int(eListener.ContainerPort)),

--- a/pkg/resources/kafka/kafka.go
+++ b/pkg/resources/kafka/kafka.go
@@ -1513,14 +1513,18 @@ func getServiceFromExternalListener(client client.Client, cluster *v1beta1.Kafka
 	case istioingressutils.IngressControllerName:
 		if ingressConfigName == util.IngressConfigGlobalName {
 			iControllerServiceName = fmt.Sprintf(istioingressutils.MeshGatewayNameTemplate, eListenerName, cluster.GetName())
+			iControllerServiceName = strings.ReplaceAll(iControllerServiceName, "_", "-")
 		} else {
 			iControllerServiceName = fmt.Sprintf(istioingressutils.MeshGatewayNameTemplateWithScope, eListenerName, ingressConfigName, cluster.GetName())
+			iControllerServiceName = strings.ReplaceAll(iControllerServiceName, "_", "-")
 		}
 	case envoyutils.IngressControllerName:
 		if ingressConfigName == util.IngressConfigGlobalName {
 			iControllerServiceName = fmt.Sprintf(envoyutils.EnvoyServiceName, eListenerName, cluster.GetName())
+			iControllerServiceName = strings.ReplaceAll(iControllerServiceName, "_", "-")
 		} else {
 			iControllerServiceName = fmt.Sprintf(envoyutils.EnvoyServiceNameWithScope, eListenerName, ingressConfigName, cluster.GetName())
+			iControllerServiceName = strings.ReplaceAll(iControllerServiceName, "_", "-")
 		}
 	case contourutils.IngressControllerName:
 		if ingressConfigName == util.IngressConfigGlobalName {
@@ -1602,7 +1606,7 @@ func generateServicePortForIListeners(listeners []v1beta1.InternalListenerConfig
 	var usedPorts []corev1.ServicePort
 	for _, iListener := range listeners {
 		usedPorts = append(usedPorts, corev1.ServicePort{
-			Name:       strings.ReplaceAll(iListener.GetListenerServiceName(), "_", ""),
+			Name:       strings.ReplaceAll(iListener.GetListenerServiceName(), "_", "-"),
 			Port:       iListener.ContainerPort,
 			TargetPort: intstr.FromInt(int(iListener.ContainerPort)),
 			Protocol:   corev1.ProtocolTCP,
@@ -1615,7 +1619,7 @@ func generateServicePortForEListeners(listeners []v1beta1.ExternalListenerConfig
 	var usedPorts []corev1.ServicePort
 	for _, eListener := range listeners {
 		usedPorts = append(usedPorts, corev1.ServicePort{
-			Name:       strings.ReplaceAll(eListener.GetListenerServiceName(), "_", ""),
+			Name:       strings.ReplaceAll(eListener.GetListenerServiceName(), "_", "-"),
 			Protocol:   corev1.ProtocolTCP,
 			Port:       eListener.ContainerPort,
 			TargetPort: intstr.FromInt(int(eListener.ContainerPort)),

--- a/pkg/resources/kafka/kafka.go
+++ b/pkg/resources/kafka/kafka.go
@@ -1529,8 +1529,10 @@ func getServiceFromExternalListener(client client.Client, cluster *v1beta1.Kafka
 	case contourutils.IngressControllerName:
 		if ingressConfigName == util.IngressConfigGlobalName {
 			iControllerServiceName = fmt.Sprintf(contourutils.ContourServiceName, eListenerName, cluster.GetName())
+			iControllerServiceName = strings.ReplaceAll(iControllerServiceName, "_", "-")
 		} else {
 			iControllerServiceName = fmt.Sprintf(contourutils.ContourServiceNameWithScope, eListenerName, ingressConfigName, cluster.GetName())
+			iControllerServiceName = strings.ReplaceAll(iControllerServiceName, "_", "-")
 		}
 	}
 

--- a/pkg/util/client/common.go
+++ b/pkg/util/client/common.go
@@ -37,7 +37,7 @@ func UseSSL(cluster *v1beta1.KafkaCluster) bool {
 
 func getContainerPortForInnerCom(internalListeners []v1beta1.InternalListenerConfig, extListeners []v1beta1.ExternalListenerConfig) int32 {
 	for _, val := range internalListeners {
-		if val.UsedForKafkaAdminCommunication { // Cannot Currently update the CRD as I do not have permissions
+		if val.UsedForKafkaAdminCommunication { // Optional override to return a port from a different listener. Needed if b2b communication is on an external listener and and you want the koperator to interact with kafka over a different port.
 			return val.ContainerPort
 		}
 		if val.UsedForInnerBrokerCommunication {

--- a/pkg/util/client/common.go
+++ b/pkg/util/client/common.go
@@ -37,20 +37,20 @@ func UseSSL(cluster *v1beta1.KafkaCluster) bool {
 
 func getContainerPortForInnerCom(internalListeners []v1beta1.InternalListenerConfig, extListeners []v1beta1.ExternalListenerConfig) int32 {
 	for _, val := range internalListeners {
-		// if val.UsedForKafkaAdminCommunication { // Cannot Currently update the CRD as I do not have permissions
-		// 	return val.ContainerPort
-		// }
+		if val.UsedForKafkaAdminCommunication { // Cannot Currently update the CRD as I do not have permissions
+			return val.ContainerPort
+		}
 		if val.UsedForInnerBrokerCommunication {
 			return val.ContainerPort
 		}
 	}
 
 	for _, val := range extListeners {
-		// if val.UsedForKafkaAdminCommunication {
-		// 	return val.ContainerPort
-		// }
+		if val.UsedForKafkaAdminCommunication {
+			return val.ContainerPort
+		}
 		if val.UsedForInnerBrokerCommunication {
-			return 29092 // this is a temporary workaround
+			return val.ContainerPort
 		}
 	}
 	return 0

--- a/pkg/util/client/common.go
+++ b/pkg/util/client/common.go
@@ -37,13 +37,20 @@ func UseSSL(cluster *v1beta1.KafkaCluster) bool {
 
 func getContainerPortForInnerCom(internalListeners []v1beta1.InternalListenerConfig, extListeners []v1beta1.ExternalListenerConfig) int32 {
 	for _, val := range internalListeners {
+		// if val.UsedForKafkaAdminCommunication { // Cannot Currently update the CRD as I do not have permissions
+		// 	return val.ContainerPort
+		// }
 		if val.UsedForInnerBrokerCommunication {
 			return val.ContainerPort
 		}
 	}
+
 	for _, val := range extListeners {
+		// if val.UsedForKafkaAdminCommunication {
+		// 	return val.ContainerPort
+		// }
 		if val.UsedForInnerBrokerCommunication {
-			return val.ContainerPort
+			return 29092 // this is a temporary workaround
 		}
 	}
 	return 0

--- a/pkg/util/kafka/common.go
+++ b/pkg/util/kafka/common.go
@@ -193,9 +193,10 @@ func GetBootstrapServersService(cluster *v1beta1.KafkaCluster) (string, error) {
 func GetBrokerContainerPort(cluster *v1beta1.KafkaCluster) (int32, error) {
 	containerPort := int32(0)
 	for _, lc := range cluster.Spec.ListenersConfig.InternalListeners {
-		// if lc.UsedForKafkaAdminCommunication { // Cannot Currently update the CRD as I do not have permissions
-		// 	return val.ContainerPort
-		// }
+		if lc.UsedForKafkaAdminCommunication { // Cannot Currently update the CRD as I do not have permissions
+			containerPort = lc.ContainerPort
+			break
+		}
 		if lc.UsedForInnerBrokerCommunication && !lc.UsedForControllerCommunication {
 			containerPort = lc.ContainerPort
 			break
@@ -203,11 +204,12 @@ func GetBrokerContainerPort(cluster *v1beta1.KafkaCluster) (int32, error) {
 	}
 
 	for _, lc := range cluster.Spec.ListenersConfig.ExternalListeners {
-		// if lc.UsedForKafkaAdminCommunication { // Cannot Currently update the CRD as I do not have permissions
-		// 	return val.ContainerPort
-		// }
+		if lc.UsedForKafkaAdminCommunication { // Cannot Currently update the CRD as I do not have permissions
+			containerPort = lc.ContainerPort
+			break
+		}
 		if lc.UsedForInnerBrokerCommunication {
-			containerPort = 29092 // temporary solution, needs to be reverted
+			containerPort = lc.ContainerPort
 			break
 		}
 	}

--- a/pkg/util/kafka/common.go
+++ b/pkg/util/kafka/common.go
@@ -192,8 +192,10 @@ func GetBootstrapServersService(cluster *v1beta1.KafkaCluster) (string, error) {
 // GetBrokerContainerPort return broker container port
 func GetBrokerContainerPort(cluster *v1beta1.KafkaCluster) (int32, error) {
 	containerPort := int32(0)
-
 	for _, lc := range cluster.Spec.ListenersConfig.InternalListeners {
+		// if lc.UsedForKafkaAdminCommunication { // Cannot Currently update the CRD as I do not have permissions
+		// 	return val.ContainerPort
+		// }
 		if lc.UsedForInnerBrokerCommunication && !lc.UsedForControllerCommunication {
 			containerPort = lc.ContainerPort
 			break
@@ -201,8 +203,11 @@ func GetBrokerContainerPort(cluster *v1beta1.KafkaCluster) (int32, error) {
 	}
 
 	for _, lc := range cluster.Spec.ListenersConfig.ExternalListeners {
+		// if lc.UsedForKafkaAdminCommunication { // Cannot Currently update the CRD as I do not have permissions
+		// 	return val.ContainerPort
+		// }
 		if lc.UsedForInnerBrokerCommunication {
-			containerPort = lc.ContainerPort
+			containerPort = 29092 // temporary solution, needs to be reverted
 			break
 		}
 	}

--- a/pkg/util/kafka/common.go
+++ b/pkg/util/kafka/common.go
@@ -193,7 +193,7 @@ func GetBootstrapServersService(cluster *v1beta1.KafkaCluster) (string, error) {
 func GetBrokerContainerPort(cluster *v1beta1.KafkaCluster) (int32, error) {
 	containerPort := int32(0)
 	for _, lc := range cluster.Spec.ListenersConfig.InternalListeners {
-		if lc.UsedForKafkaAdminCommunication { // Cannot Currently update the CRD as I do not have permissions
+		if lc.UsedForKafkaAdminCommunication { // Optional override to return a port from a different listener. Needed if b2b communication is on an external listener and and you want the koperator to interact with kafka over a different port.
 			containerPort = lc.ContainerPort
 			break
 		}
@@ -204,7 +204,7 @@ func GetBrokerContainerPort(cluster *v1beta1.KafkaCluster) (int32, error) {
 	}
 
 	for _, lc := range cluster.Spec.ListenersConfig.ExternalListeners {
-		if lc.UsedForKafkaAdminCommunication { // Cannot Currently update the CRD as I do not have permissions
+		if lc.UsedForKafkaAdminCommunication {
 			containerPort = lc.ContainerPort
 			break
 		}

--- a/pkg/util/kafka/const.go
+++ b/pkg/util/kafka/const.go
@@ -30,6 +30,7 @@ const (
 	KafkaConfigListenerName                = "listener.name"
 	KafkaConfigListenerSecurityProtocolMap = "listener.security.protocol.map"
 	KafkaConfigInterBrokerListenerName     = "inter.broker.listener.name"
+	KafkaConfigSecurityInterBrokerProtocol = "security.inter.broker.protocol"
 	KafkaConfigAdvertisedListeners         = "advertised.listeners"
 	KafkaConfigControlPlaneListener        = "control.plane.listener.name"
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -236,11 +236,12 @@ func IsIngressConfigInUse(iConfigName, defaultConfigName string, cluster *v1beta
 
 // ConstructEListenerLabelName construct an eListener label name based on ingress config name and listener name
 func ConstructEListenerLabelName(ingressConfigName, eListenerName string) string {
+	externalListenerName := strings.ReplaceAll(eListenerName, "_", "-")
 	if ingressConfigName == IngressConfigGlobalName {
-		return eListenerName
+		return externalListenerName
 	}
 
-	return fmt.Sprintf(ExternalListenerLabelNameTemplate, eListenerName, ingressConfigName)
+	return fmt.Sprintf(ExternalListenerLabelNameTemplate, externalListenerName, ingressConfigName)
 }
 
 // ShouldIncludeBroker returns true if the broker should be included as a resource on external listener resources
@@ -437,10 +438,11 @@ func ConvertConfigEntryListToProperties(config []sarama.ConfigEntry) (*propertie
 func GenerateEnvoyResourceName(resourceNameFormat string, resourceNameWithScopeFormat string, extListener v1beta1.ExternalListenerConfig, ingressConfig v1beta1.IngressConfig,
 	ingressConfigName, clusterName string) string {
 	var resourceName string
+	externalListenerName := strings.ReplaceAll(extListener.Name, "_", "-")
 	if ingressConfigName == IngressConfigGlobalName {
-		resourceName = fmt.Sprintf(resourceNameFormat, extListener.Name, clusterName)
+		resourceName = fmt.Sprintf(resourceNameFormat, externalListenerName, clusterName)
 	} else {
-		resourceName = fmt.Sprintf(resourceNameWithScopeFormat, extListener.Name, ingressConfigName, clusterName)
+		resourceName = fmt.Sprintf(resourceNameWithScopeFormat, externalListenerName, ingressConfigName, clusterName)
 	}
 
 	return resourceName


### PR DESCRIPTION
## Description

Please provide a meaningful description of what this change will do, or is for. Bonus points for including links to
related issues, other PRs, or technical references.

This change is to allow for the kafka property `security.inter.broker.protocol` to be used by the broker pods. Currently, koperator will create the property `inter.broker.listener.name,` which is mutually exclusive with `security.inter.broker.protocol`. 

see kafka documentation on the property: https://kafka.apache.org/documentation/#brokerconfigs_security.inter.broker.protocol 

Note that by _not_ including a description, you are asking reviewers to do extra work to understand the context of this
change, which may lead to your PR taking much longer to review, or result in it not being reviewed at all.

## Type of Change
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [x] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
