### PR TITLE
Run Envoy as root in Openshift as chown is not allowed

### DIFF
--- a/docker/envoy/Dockerfile
+++ b/docker/envoy/Dockerfile
@@ -1,0 +1,3 @@
+FROM envoyproxy/envoy:v1.27.0 AS envoy
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh

--- a/docker/envoy/Makefile
+++ b/docker/envoy/Makefile
@@ -1,8 +1,8 @@
-DOCKER_IMAGE ?= envoyproxy/envoy:v1.27.0-openshift-v2 
+IMG ?= envoyproxy/envoy:v1.27.0-openshift-v2 
 
 docker-buildx:
-	@echo "Building Docker image for ${DOCKER_IMAGE}"
+	@echo "Building Docker image for ${IMG}"
 	- docker buildx create --name envoy-project-builder
 	docker buildx use envoy-project-builder
-	docker buildx build --platform linux/amd64,linux/arm64 --tag ${DOCKER_IMAGE} --push .
+	docker buildx build --platform linux/amd64,linux/arm64 --tag ${IMG} --push .
 	- docker buildx rm envoy-project-builder

--- a/docker/envoy/Makefile
+++ b/docker/envoy/Makefile
@@ -1,0 +1,8 @@
+DOCKER_IMAGE ?= envoyproxy/envoy:v1.27.0-openshift-v2 
+
+docker-buildx:
+	@echo "Building Docker image for ${DOCKER_IMAGE}"
+	- docker buildx create --name envoy-project-builder
+	docker buildx use envoy-project-builder
+	docker buildx build --platform linux/amd64,linux/arm64 --tag ${DOCKER_IMAGE} --push .
+	- docker buildx rm envoy-project-builder

--- a/docker/envoy/docker-entrypoint.sh
+++ b/docker/envoy/docker-entrypoint.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env sh
+set -e
+
+
+loglevel="${loglevel:-}"
+USERID=$(id -u)
+
+
+# if the first argument look like a parameter (i.e. start with '-'), run Envoy
+if [ "${1#-}" != "$1" ]; then
+    set -- envoy "$@"
+fi
+
+if [ "$1" = 'envoy' ]; then
+    # set the log level if the $loglevel variable is set
+    if [ -n "$loglevel" ]; then
+        set -- "$@" --log-level "$loglevel"
+    fi
+fi
+
+# This `docker-entrypoint.sh` disables the su-exec as envoy and only runs envoy as root user.
+# From the envoy git repo:
+# if [ "$ENVOY_UID" != "0" ] && [ "$USERID" = 0 ]; then
+#     if [ -n "$ENVOY_UID" ]; then
+#         usermod -u "$ENVOY_UID" envoy
+#     fi
+#     if [ -n "$ENVOY_GID" ]; then
+#         groupmod -g "$ENVOY_GID" envoy
+#     fi
+#     # Ensure the envoy user is able to write to container logs
+#     chown envoy:envoy /dev/stdout /dev/stderr
+#     exec su-exec envoy "${@}"
+# else
+#     exec "${@}"
+# fi
+
+exec "${@}"

--- a/docker/envoy/docker-entrypoint.sh
+++ b/docker/envoy/docker-entrypoint.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env sh
 set -e
 
-
 loglevel="${loglevel:-}"
 USERID=$(id -u)
 
@@ -18,20 +17,16 @@ if [ "$1" = 'envoy' ]; then
     fi
 fi
 
-# This `docker-entrypoint.sh` disables the su-exec as envoy and only runs envoy as root user.
-# From the envoy git repo:
-# if [ "$ENVOY_UID" != "0" ] && [ "$USERID" = 0 ]; then
-#     if [ -n "$ENVOY_UID" ]; then
-#         usermod -u "$ENVOY_UID" envoy
-#     fi
-#     if [ -n "$ENVOY_GID" ]; then
-#         groupmod -g "$ENVOY_GID" envoy
-#     fi
-#     # Ensure the envoy user is able to write to container logs
-#     chown envoy:envoy /dev/stdout /dev/stderr
-#     exec su-exec envoy "${@}"
-# else
-#     exec "${@}"
-# fi
-
-exec "${@}"
+if [ "$ENVOY_UID" != "0" ] && [ "$USERID" = 0 ]; then
+    if [ -n "$ENVOY_UID" ]; then
+        usermod -u "$ENVOY_UID" envoy
+    fi
+    if [ -n "$ENVOY_GID" ]; then
+        groupmod -g "$ENVOY_GID" envoy
+    fi
+    # Ensure the envoy user is able to write to container logs
+    usermod -a -G tty envoy
+    exec su-exec envoy "${@}"
+else
+    exec "${@}"
+fi


### PR DESCRIPTION
```
kubectl logs -f envoy-secure-secureingress-az2-pipeline-kafka-7c4cc7f497-czjfn
chown: changing ownership of '/dev/stdout': Permission denied
chown: changing ownership of '/dev/stderr': Permission denied
```