### PR TITLE
Exclude controllers from external ingress (e.g. envoy)

### DIFF
--- a/controllers/tests/kafkacluster_controller_kafka_test.go
+++ b/controllers/tests/kafkacluster_controller_kafka_test.go
@@ -671,10 +671,6 @@ func expectKafkaCRStatus(ctx context.Context, kafkaCluster *v1beta1.KafkaCluster
 						Address: "test.host.com:19090",
 					},
 					{
-						Name:    "broker-1",
-						Address: "test.host.com:19091",
-					},
-					{
 						Name:    "broker-2",
 						Address: "test.host.com:19092",
 					},

--- a/controllers/tests/kafkacluster_controller_test.go
+++ b/controllers/tests/kafkacluster_controller_test.go
@@ -543,7 +543,7 @@ var _ = Describe("KafkaCluster with two config external listener", func() {
 			expectBrokerConfigmapForAz2ExternalListener(ctx, kafkaCluster, count)
 
 			expectEnvoyWithConfigAz1(ctx, kafkaClusterKRaft)
-			expectEnvoyWithConfigAz2(ctx, kafkaClusterKRaft)
+			expectEnvoyWithConfigAz2KRaft(ctx, kafkaClusterKRaft)
 			expectBrokerConfigmapForAz1ExternalListener(ctx, kafkaClusterKRaft, count)
 			expectBrokerConfigmapForAz2ExternalListener(ctx, kafkaClusterKRaft, count)
 		})

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -268,14 +268,12 @@ func ConstructEListenerLabelName(ingressConfigName, eListenerName string) string
 // ShouldIncludeBroker returns true if the broker should be included as a resource on external listener resources
 func ShouldIncludeBroker(brokerConfig *v1beta1.BrokerConfig, status v1beta1.KafkaClusterStatus, brokerID int,
 	defaultIngressConfigName, ingressConfigName string) bool {
-	// if brokerConfig != nil && (brokerConfig.Roles == nil || brokerConfig.IsBrokerNode()) {
+	// in KRaft mode, contoller only are excluded
 	if brokerConfig != nil && (len(brokerConfig.Roles) == 0 || brokerConfig.IsBrokerNode()) {
-		// if brokerConfig != nil {
 		if len(brokerConfig.BrokerIngressMapping) == 0 && (ingressConfigName == defaultIngressConfigName || defaultIngressConfigName == "") ||
 			apiutil.StringSliceContains(brokerConfig.BrokerIngressMapping, ingressConfigName) {
 			return true
 		}
-		// }
 		if brokerState, ok := status.BrokersState[strconv.Itoa(brokerID)]; ok {
 			if apiutil.StringSliceContains(brokerState.ExternalListenerConfigNames, ingressConfigName) {
 				return true

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -268,7 +268,7 @@ func ConstructEListenerLabelName(ingressConfigName, eListenerName string) string
 // ShouldIncludeBroker returns true if the broker should be included as a resource on external listener resources
 func ShouldIncludeBroker(brokerConfig *v1beta1.BrokerConfig, status v1beta1.KafkaClusterStatus, brokerID int,
 	defaultIngressConfigName, ingressConfigName string) bool {
-	// in KRaft mode, contoller only are excluded
+	// in KRaft mode, controller only are excluded
 	if brokerConfig != nil && (len(brokerConfig.Roles) == 0 || brokerConfig.IsBrokerNode()) {
 		if len(brokerConfig.BrokerIngressMapping) == 0 && (ingressConfigName == defaultIngressConfigName || defaultIngressConfigName == "") ||
 			apiutil.StringSliceContains(brokerConfig.BrokerIngressMapping, ingressConfigName) {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -268,15 +268,18 @@ func ConstructEListenerLabelName(ingressConfigName, eListenerName string) string
 // ShouldIncludeBroker returns true if the broker should be included as a resource on external listener resources
 func ShouldIncludeBroker(brokerConfig *v1beta1.BrokerConfig, status v1beta1.KafkaClusterStatus, brokerID int,
 	defaultIngressConfigName, ingressConfigName string) bool {
-	if brokerConfig != nil {
+	// if brokerConfig != nil && (brokerConfig.Roles == nil || brokerConfig.IsBrokerNode()) {
+	if brokerConfig != nil && (len(brokerConfig.Roles) == 0 || brokerConfig.IsBrokerNode()) {
+		// if brokerConfig != nil {
 		if len(brokerConfig.BrokerIngressMapping) == 0 && (ingressConfigName == defaultIngressConfigName || defaultIngressConfigName == "") ||
 			apiutil.StringSliceContains(brokerConfig.BrokerIngressMapping, ingressConfigName) {
 			return true
 		}
-	}
-	if brokerState, ok := status.BrokersState[strconv.Itoa(brokerID)]; ok {
-		if apiutil.StringSliceContains(brokerState.ExternalListenerConfigNames, ingressConfigName) {
-			return true
+		// }
+		if brokerState, ok := status.BrokersState[strconv.Itoa(brokerID)]; ok {
+			if apiutil.StringSliceContains(brokerState.ExternalListenerConfigNames, ingressConfigName) {
+				return true
+			}
 		}
 	}
 	return false


### PR DESCRIPTION
## Description

This PR excludes controllers (if in KRaft mode) from external ingress .  `ShouldIncludeBroker` function is used to determine if the broker should be configured for external ingress (e.g. Envoy)

## Type of Change
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [X] Other (please describe)

