### PR TITLE
Zk kraft migration

### DIFF
--- a/api/v1beta1/kafkacluster_types.go
+++ b/api/v1beta1/kafkacluster_types.go
@@ -1102,12 +1102,17 @@ func (bConfig *BrokerConfig) GetBrokerAnnotations() map[string]string {
 
 // GetBrokerLabels returns the labels that are applied to broker pods
 func (bConfig *BrokerConfig) GetBrokerLabels(kafkaClusterName string, brokerId int32, kRaftMode bool) map[string]string {
-	kraftLabels := make(map[string]string, 0)
+	var kraftLabels map[string]string
 	if kRaftMode {
 		kraftLabels = map[string]string{
 			ProcessRolesKey:     strings.Join(bConfig.Roles, "_"),
 			IsControllerNodeKey: fmt.Sprintf("%t", bConfig.IsControllerNode()),
 			IsBrokerNodeKey:     fmt.Sprintf("%t", bConfig.IsBrokerNode()),
+		}
+	} else { // in ZK mode -> new labels for backward compatibility for the headless service when going from ZK to KRaft
+		kraftLabels = map[string]string{
+			IsControllerNodeKey: fmt.Sprintf("%t", false),
+			IsBrokerNodeKey:     fmt.Sprintf("%t", true),
 		}
 	}
 	return util.MergeLabels(

--- a/api/v1beta1/kafkacluster_types_test.go
+++ b/api/v1beta1/kafkacluster_types_test.go
@@ -445,10 +445,12 @@ func TestGetBrokerLabels(t *testing.T) {
 		{
 			testName: "Labels in zookeeper mode",
 			expectedLabels: map[string]string{
-				AppLabelKey:      expectedDefaultLabelApp,
-				BrokerIdLabelKey: strconv.Itoa(expectedBrokerId),
-				KafkaCRLabelKey:  expectedKafkaCRName,
-				"test_label_key": "test_label_value",
+				AppLabelKey:         expectedDefaultLabelApp,
+				BrokerIdLabelKey:    strconv.Itoa(expectedBrokerId),
+				KafkaCRLabelKey:     expectedKafkaCRName,
+				IsBrokerNodeKey:     "true",
+				IsControllerNodeKey: "false",
+				"test_label_key":    "test_label_value",
 			},
 			brokerConfig: &BrokerConfig{
 				Roles: nil,

--- a/controllers/tests/kafkacluster_controller_kafka_test.go
+++ b/controllers/tests/kafkacluster_controller_kafka_test.go
@@ -432,6 +432,14 @@ func expectKafkaBrokerPod(ctx context.Context, kafkaCluster *v1beta1.KafkaCluste
 				Value: "/kafka-logs,/ephemeral-dir1",
 			},
 		))
+
+		// when CLUSTER_ID is set as an ENV, verify the status is not randomly generated
+		for _, env := range kafkaCluster.Spec.Envs {
+			if env.Name == "CLUSTER_ID" {
+				Expect(kafkaCluster.Status.ClusterID).To(Equal("test-cluster-id"))
+				break
+			}
+		}
 	} else {
 		Expect(container.Env).To(ConsistOf(
 			// the exact value is not interesting

--- a/controllers/tests/kafkacluster_controller_test.go
+++ b/controllers/tests/kafkacluster_controller_test.go
@@ -256,6 +256,23 @@ var _ = Describe("KafkaCluster", func() {
 			expectCruiseControl(ctx, kafkaClusterKRaft)
 		})
 	})
+	When("configuring Kafka cluster in KRaft mode with CLUSTER_ID env var", func() {
+		BeforeEach(func() {
+			loadBalancerServiceName = fmt.Sprintf("envoy-loadbalancer-test-%s", kafkaCluster.Name)
+			externalListenerHostName = "test.host.com"
+
+			loadBalancerServiceNameKRaft = fmt.Sprintf("envoy-loadbalancer-test-%s", kafkaClusterKRaft.Name)
+			externalListenerHostNameKRaft = "test.host.com"
+			kafkaClusterKRaft.Spec.Envs = append(kafkaClusterKRaft.Spec.Envs, corev1.EnvVar{
+				Name:  "CLUSTER_ID",
+				Value: "test-cluster-id",
+			})
+		})
+
+		It("should reconciles objects properly", func(ctx SpecContext) {
+			expectKafka(ctx, kafkaClusterKRaft, count)
+		})
+	})
 	When("configuring one ingress envoy controller config inside the external listener without bindings", func() {
 		BeforeEach(func() {
 			testExternalListener := kafkaCluster.Spec.ListenersConfig.ExternalListeners[0]

--- a/pkg/resources/kafka/configmap.go
+++ b/pkg/resources/kafka/configmap.go
@@ -175,6 +175,11 @@ func configureBrokerKRaftMode(bConfig *v1beta1.BrokerConfig, brokerID int32, kaf
 				log.Error(err, fmt.Sprintf(kafkautils.BrokerConfigErrorMsgTemplate, kafkautils.KafkaConfigControlPlaneListener))
 			}
 		}
+
+		if err := config.Set(kafkautils.KafkaConfigZooKeeperConnect, zookeeperutils.PrepareConnectionAddress(
+			kafkaCluster.Spec.ZKAddresses, kafkaCluster.Spec.GetZkPath())); err != nil {
+			log.Error(err, fmt.Sprintf(kafkautils.BrokerConfigErrorMsgTemplate, kafkautils.KafkaConfigZooKeeperConnect))
+		}
 	}
 
 	if shouldConfigureControllerQuorumForBroker(brokerReadOnlyConfig) {

--- a/pkg/resources/kafka/configmap.go
+++ b/pkg/resources/kafka/configmap.go
@@ -152,7 +152,6 @@ func (r *Reconciler) configCCMetricsReporter(broker v1beta1.Broker, config *prop
 func configureBrokerKRaftMode(bConfig *v1beta1.BrokerConfig, brokerID int32, kafkaCluster *v1beta1.KafkaCluster, config *properties.Properties,
 	quorumVoters []string, serverPasses map[string]string, extListenerStatuses, intListenerStatuses map[string]v1beta1.ListenerStatusList, log logr.Logger,
 	brokerReadOnlyConfig *properties.Properties) {
-
 	controllerListenerName := generateControlPlaneListener(kafkaCluster.Spec.ListenersConfig.InternalListeners)
 
 	// when kRaft is enabled for the cluster, brokers can still be configured to use zookeeper for metadata.

--- a/pkg/resources/kafka/configmap.go
+++ b/pkg/resources/kafka/configmap.go
@@ -165,15 +165,10 @@ func configureBrokerKRaftMode(bConfig *v1beta1.BrokerConfig, brokerID int32, kaf
 			log.Error(err, fmt.Sprintf(kafkautils.BrokerConfigErrorMsgTemplate, kafkautils.KafkaConfigProcessRoles))
 		}
 	} else { // use zk mode for broker.
-		// when in zk mode, "broker.id" and "control.plane.listener.name" are configured so it will communicate with zookeeper
+		// when in zk mode, "broker.id" and "zookeeper.connect" are configured so it will communicate with zookeeper
+		// control.plane.listener.name will not be set in zk mode.  There for it will default to the interbroker listener.
 		if err := config.Set(kafkautils.KafkaConfigBrokerID, brokerID); err != nil {
 			log.Error(err, fmt.Sprintf(kafkautils.BrokerConfigErrorMsgTemplate, kafkautils.KafkaConfigBrokerID))
-		}
-
-		if controllerListenerName != "" {
-			if err := config.Set(kafkautils.KafkaConfigControlPlaneListener, controllerListenerName); err != nil {
-				log.Error(err, fmt.Sprintf(kafkautils.BrokerConfigErrorMsgTemplate, kafkautils.KafkaConfigControlPlaneListener))
-			}
 		}
 
 		if err := config.Set(kafkautils.KafkaConfigZooKeeperConnect, zookeeperutils.PrepareConnectionAddress(

--- a/pkg/resources/kafka/configmap_test.go
+++ b/pkg/resources/kafka/configmap_test.go
@@ -729,6 +729,8 @@ func TestGenerateBrokerConfigKRaftMode(t *testing.T) { //nolint funlen
 		listenersConfig          v1beta1.ListenersConfig
 		internalListenerStatuses map[string]v1beta1.ListenerStatusList
 		controllerListenerStatus map[string]v1beta1.ListenerStatusList
+		zkAddresses              []string
+		zkPath                   string
 		expectedBrokerConfigs    []string
 	}{
 		{
@@ -1141,6 +1143,8 @@ process.roles=broker,controller
 					},
 				},
 			},
+			zkAddresses: []string{"example.zk:2181"},
+			zkPath:      "/kafka",
 			expectedBrokerConfigs: []string{
 				`advertised.listeners=INTERNAL://kafka-0.kafka.svc.cluster.local:9092
 controller.listener.names=CONTROLLER
@@ -1177,6 +1181,7 @@ listener.security.protocol.map=INTERNAL:PLAINTEXT,CONTROLLER:PLAINTEXT
 listeners=INTERNAL://:9092,CONTROLLER://:9093
 log.dirs=/test-kafka-logs/kafka,/test-kafka-logs-50/kafka,/test-kafka-logs-100/kafka
 metric.reporters=com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsReporter
+zookeeper.connect=example.zk:2181/kafka
 `,
 				`advertised.listeners=INTERNAL://kafka-200.kafka.svc.cluster.local:9092
 broker.id=200
@@ -1190,6 +1195,7 @@ listener.security.protocol.map=INTERNAL:PLAINTEXT,CONTROLLER:PLAINTEXT
 listeners=INTERNAL://:9092
 log.dirs=/test-kafka-logs/kafka
 metric.reporters=com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsReporter
+zookeeper.connect=example.zk:2181/kafka
 `,
 				`advertised.listeners=INTERNAL://kafka-300.kafka.svc.cluster.local:9092
 cruise.control.metrics.reporter.bootstrap.servers=kafka-all-broker.kafka.svc.cluster.local:9092
@@ -1225,6 +1231,8 @@ process.roles=broker
 							KRaftMode:       true,
 							ListenersConfig: test.listenersConfig,
 							Brokers:         test.brokers,
+							ZKAddresses:     test.zkAddresses,
+							ZKPath:          test.zkPath,
 						},
 					},
 				},

--- a/pkg/resources/kafka/configmap_test.go
+++ b/pkg/resources/kafka/configmap_test.go
@@ -1048,6 +1048,42 @@ process.roles=broker,controller
 					},
 					ReadOnlyConfig: "migration.broker.controllerQuorumConfigEnabled=false\nmigration.broker.kRaftMode=false",
 				},
+				{
+					Id: 200,
+					BrokerConfig: &v1beta1.BrokerConfig{
+						Roles: []string{"broker"},
+						StorageConfigs: []v1beta1.StorageConfig{
+							{
+								MountPath: "/test-kafka-logs",
+							},
+							{
+								MountPath: "/test-kafka-logs-50",
+							},
+							{
+								MountPath: "/test-kafka-logs-100",
+							},
+						},
+					},
+					ReadOnlyConfig: "migration.broker.controllerQuorumConfigEnabled=true\nmigration.broker.kRaftMode=false",
+				},
+				{
+					Id: 300,
+					BrokerConfig: &v1beta1.BrokerConfig{
+						Roles: []string{"broker"},
+						StorageConfigs: []v1beta1.StorageConfig{
+							{
+								MountPath: "/test-kafka-logs",
+							},
+							{
+								MountPath: "/test-kafka-logs-50",
+							},
+							{
+								MountPath: "/test-kafka-logs-100",
+							},
+						},
+					},
+					ReadOnlyConfig: "migration.broker.controllerQuorumConfigEnabled=false\nmigration.broker.kRaftMode=true",
+				},
 			},
 			listenersConfig: v1beta1.ListenersConfig{
 				InternalListeners: []v1beta1.InternalListenerConfig{
@@ -1083,6 +1119,14 @@ process.roles=broker,controller
 						Name:    "broker-100",
 						Address: "kafka-100.kafka.svc.cluster.local:9092",
 					},
+					{
+						Name:    "broker-200",
+						Address: "kafka-100.kafka.svc.cluster.local:9092",
+					},
+					{
+						Name:    "broker-300",
+						Address: "kafka-100.kafka.svc.cluster.local:9092",
+					},
 				},
 			},
 			controllerListenerStatus: map[string]v1beta1.ListenerStatusList{
@@ -1094,6 +1138,14 @@ process.roles=broker,controller
 					{
 						Name:    "broker-50",
 						Address: "kafka-50.kafka.svc.cluster.local:9093",
+					},
+					{
+						Name:    "broker-100",
+						Address: "kafka-100.kafka.svc.cluster.local:9093",
+					},
+					{
+						Name:    "broker-100",
+						Address: "kafka-100.kafka.svc.cluster.local:9093",
 					},
 					{
 						Name:    "broker-100",
@@ -1137,6 +1189,29 @@ listener.security.protocol.map=INTERNAL:PLAINTEXT,CONTROLLER:PLAINTEXT
 listeners=INTERNAL://:9092,CONTROLLER://:9093
 log.dirs=/test-kafka-logs/kafka,/test-kafka-logs-50/kafka,/test-kafka-logs-100/kafka
 metric.reporters=com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsReporter
+`,
+				`advertised.listeners=INTERNAL://kafka-200.kafka.svc.cluster.local:9092
+broker.id=200
+cruise.control.metrics.reporter.bootstrap.servers=kafka-all-broker.kafka.svc.cluster.local:9092
+cruise.control.metrics.reporter.kubernetes.mode=true
+inter.broker.listener.name=INTERNAL
+listener.security.protocol.map=INTERNAL:PLAINTEXT,CONTROLLER:PLAINTEXT
+listeners=INTERNAL://:9092
+log.dirs=/test-kafka-logs/kafka
+metric.reporters=com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsReporter
+`,
+				`advertised.listeners=INTERNAL://kafka-300.kafka.svc.cluster.local:9092
+controller.listener.names=CONTROLLER
+controller.quorum.voters=50@kafka-50.kafka.svc.cluster.local:9093,100@kafka-100.kafka.svc.cluster.local:9093
+cruise.control.metrics.reporter.bootstrap.servers=kafka-all-broker.kafka.svc.cluster.local:9092
+cruise.control.metrics.reporter.kubernetes.mode=true
+inter.broker.listener.name=INTERNAL
+listener.security.protocol.map=INTERNAL:PLAINTEXT,CONTROLLER:PLAINTEXT
+listeners=INTERNAL://:9092
+log.dirs=/test-kafka-logs/kafka
+metric.reporters=com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsReporter
+node.id=300
+process.roles=broker
 `},
 		},
 	}

--- a/pkg/resources/kafka/configmap_test.go
+++ b/pkg/resources/kafka/configmap_test.go
@@ -1004,7 +1004,7 @@ process.roles=broker,controller
 `},
 		},
 		{
-			testName: "a Kafka cluster with a mix of broker-only, controller-only, and combined roles; controller nodes with multiple mount paths, and various migration configs set on each brokers",
+			testName: "a Kafka cluster with a mix of broker-only, controller-only, and combined roles; and various migration configs set on each brokers",
 			brokers: []v1beta1.Broker{
 				{
 					Id: 0,
@@ -1173,7 +1173,6 @@ process.roles=controller
 `,
 				`advertised.listeners=INTERNAL://kafka-100.kafka.svc.cluster.local:9092
 broker.id=100
-control.plane.listener.name=CONTROLLER
 cruise.control.metrics.reporter.bootstrap.servers=kafka-all-broker.kafka.svc.cluster.local:9092
 cruise.control.metrics.reporter.kubernetes.mode=true
 inter.broker.listener.name=INTERNAL
@@ -1185,7 +1184,6 @@ zookeeper.connect=example.zk:2181/kafka
 `,
 				`advertised.listeners=INTERNAL://kafka-200.kafka.svc.cluster.local:9092
 broker.id=200
-control.plane.listener.name=CONTROLLER
 controller.listener.names=CONTROLLER
 controller.quorum.voters=50@kafka-50.kafka.svc.cluster.local:9093,100@kafka-100.kafka.svc.cluster.local:9093
 cruise.control.metrics.reporter.bootstrap.servers=kafka-all-broker.kafka.svc.cluster.local:9092

--- a/pkg/resources/kafka/configmap_test.go
+++ b/pkg/resources/kafka/configmap_test.go
@@ -1056,12 +1056,6 @@ process.roles=broker,controller
 							{
 								MountPath: "/test-kafka-logs",
 							},
-							{
-								MountPath: "/test-kafka-logs-50",
-							},
-							{
-								MountPath: "/test-kafka-logs-100",
-							},
 						},
 					},
 					ReadOnlyConfig: "migration.broker.controllerQuorumConfigEnabled=true\nmigration.broker.kRaftMode=false",
@@ -1073,12 +1067,6 @@ process.roles=broker,controller
 						StorageConfigs: []v1beta1.StorageConfig{
 							{
 								MountPath: "/test-kafka-logs",
-							},
-							{
-								MountPath: "/test-kafka-logs-50",
-							},
-							{
-								MountPath: "/test-kafka-logs-100",
 							},
 						},
 					},
@@ -1121,11 +1109,11 @@ process.roles=broker,controller
 					},
 					{
 						Name:    "broker-200",
-						Address: "kafka-100.kafka.svc.cluster.local:9092",
+						Address: "kafka-200.kafka.svc.cluster.local:9092",
 					},
 					{
 						Name:    "broker-300",
-						Address: "kafka-100.kafka.svc.cluster.local:9092",
+						Address: "kafka-300.kafka.svc.cluster.local:9092",
 					},
 				},
 			},
@@ -1144,12 +1132,12 @@ process.roles=broker,controller
 						Address: "kafka-100.kafka.svc.cluster.local:9093",
 					},
 					{
-						Name:    "broker-100",
-						Address: "kafka-100.kafka.svc.cluster.local:9093",
+						Name:    "broker-200",
+						Address: "kafka-200.kafka.svc.cluster.local:9093",
 					},
 					{
-						Name:    "broker-100",
-						Address: "kafka-100.kafka.svc.cluster.local:9093",
+						Name:    "broker-300",
+						Address: "kafka-300.kafka.svc.cluster.local:9093",
 					},
 				},
 			},
@@ -1192,6 +1180,9 @@ metric.reporters=com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlM
 `,
 				`advertised.listeners=INTERNAL://kafka-200.kafka.svc.cluster.local:9092
 broker.id=200
+control.plane.listener.name=CONTROLLER
+controller.listener.names=CONTROLLER
+controller.quorum.voters=50@kafka-50.kafka.svc.cluster.local:9093,100@kafka-100.kafka.svc.cluster.local:9093
 cruise.control.metrics.reporter.bootstrap.servers=kafka-all-broker.kafka.svc.cluster.local:9092
 cruise.control.metrics.reporter.kubernetes.mode=true
 inter.broker.listener.name=INTERNAL
@@ -1201,8 +1192,6 @@ log.dirs=/test-kafka-logs/kafka
 metric.reporters=com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsReporter
 `,
 				`advertised.listeners=INTERNAL://kafka-300.kafka.svc.cluster.local:9092
-controller.listener.names=CONTROLLER
-controller.quorum.voters=50@kafka-50.kafka.svc.cluster.local:9093,100@kafka-100.kafka.svc.cluster.local:9093
 cruise.control.metrics.reporter.bootstrap.servers=kafka-all-broker.kafka.svc.cluster.local:9092
 cruise.control.metrics.reporter.kubernetes.mode=true
 inter.broker.listener.name=INTERNAL

--- a/pkg/resources/kafka/configmap_test.go
+++ b/pkg/resources/kafka/configmap_test.go
@@ -722,7 +722,7 @@ zookeeper.connect=example.zk:2181/`,
 
 // TestGenerateBrokerConfigKRaftMode serves as an aggregated test on top of TestGenerateBrokerConfig to verify basic broker configurations under KRaft mode
 // Note: most of the test cases under TestGenerateBrokerConfig are not replicated here since running KRaft mode doesn't affect things like SSL and storage configurations
-func TestGenerateBrokerConfigKRaftMode(t *testing.T) {
+func TestGenerateBrokerConfigKRaftMode(t *testing.T) { //nolint funlen
 	testCases := []struct {
 		testName                 string
 		brokers                  []v1beta1.Broker

--- a/pkg/resources/kafka/kafka.go
+++ b/pkg/resources/kafka/kafka.go
@@ -366,7 +366,6 @@ func (r *Reconciler) Reconcile(log logr.Logger) error {
 	if r.KafkaCluster.Spec.KRaftMode {
 		// all broker nodes under the same Kafka cluster must use the same cluster UUID
 		if r.KafkaCluster.Status.ClusterID == "" {
-
 			// CLUSTER_ID can be overridden with ENV (e.g for migration from ZK to KRaft so it matches the value for ZK cluster)
 			for _, env := range r.KafkaCluster.Spec.Envs {
 				if env.Name == "CLUSTER_ID" {

--- a/pkg/resources/kafka/kafka.go
+++ b/pkg/resources/kafka/kafka.go
@@ -366,7 +366,19 @@ func (r *Reconciler) Reconcile(log logr.Logger) error {
 	if r.KafkaCluster.Spec.KRaftMode {
 		// all broker nodes under the same Kafka cluster must use the same cluster UUID
 		if r.KafkaCluster.Status.ClusterID == "" {
-			r.KafkaCluster.Status.ClusterID = generateRandomClusterID()
+
+			// CLUSTER_ID can be overridden with ENV (e.g for migration from ZK to KRaft so it matches the value for ZK cluster)
+			for _, env := range r.KafkaCluster.Spec.Envs {
+				if env.Name == "CLUSTER_ID" {
+					r.KafkaCluster.Status.ClusterID = env.Value
+					break
+				}
+			}
+
+			if r.KafkaCluster.Status.ClusterID == "" {
+				r.KafkaCluster.Status.ClusterID = generateRandomClusterID()
+			}
+
 			err = r.Client.Status().Update(ctx, r.KafkaCluster)
 			if apierrors.IsNotFound(err) {
 				err = r.Client.Update(ctx, r.KafkaCluster)

--- a/pkg/resources/kafka/pod.go
+++ b/pkg/resources/kafka/pod.go
@@ -131,7 +131,6 @@ fi`},
 	if r.KafkaCluster.Spec.KRaftMode {
 		for i, container := range pod.Spec.Containers {
 			if container.Name == kafkaContainerName {
-
 				// in KRaft mode, all broker nodes within the same Kafka cluster need to use the same cluster ID to format the storage
 				addClusterIdEnv(r, pod, i)
 

--- a/pkg/util/kafka/const.go
+++ b/pkg/util/kafka/const.go
@@ -51,6 +51,12 @@ const (
 	KafkaConfigSSLKeyStorePassword   = "ssl.keystore.password"
 )
 
+// used for zk to kraft migration
+const (
+	MigrationBrokerControllerQuorumConfigEnabled = "migration.broker.controllerQuorumConfigEnabled"
+	MigrationBrokerKRaftMode                     = "migration.broker.kRaftMode"
+)
+
 // used for Cruise Control configurations
 const (
 	CruiseControlConfigMetricsReporters                  = "metric.reporters"


### PR DESCRIPTION
To support zk to kraft migration:

- enhancement to configure CLUSTER_ID
- enable brokers to use ZK or kraft for metadata by using `migration.broker.kRaftMode` property in the readOnlyConfig
- enable brokers to add/remove the controller quorum (`controller.quorum.voters`/`controller.listener.names`) by using `migration.broker.controllerQuorumConfigEnabled`