### PR TITLE
Upgrade jmx-exporter to v1.4.0

### DIFF
--- a/.github/workflows/publish-kafka-docker.yml
+++ b/.github/workflows/publish-kafka-docker.yml
@@ -13,8 +13,9 @@ env:
   # GitHub Container Registry
   GHCR_REGISTRY: ghcr.io
   # github.repository as <account>/<repo>
-  GHCR_IMAGE_NAME: ${{ github.repository }}/kafka
-  # Docker Hub image name
+  GHCR_KAFKA_IMAGE_NAME: ${{ github.repository }}/kafka
+  GHCR_JMX_IMAGE_NAME: ${{ github.repository }}/jmx-javaagent
+  # Docker Hub image name (only for Kafka)
   DOCKERHUB_IMAGE: adobe/kafka
 
 jobs:
@@ -34,7 +35,7 @@ jobs:
         run: |
           echo "built_at=$(date --rfc-3339=date)" >> $GITHUB_OUTPUT
 
-  build-kafka:
+  build-and-push-kafka-image:
     runs-on: ubuntu-latest
     needs: prepare
     permissions:
@@ -47,36 +48,57 @@ jobs:
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+      - name: Extract Kafka version from tag
+        id: kafka_version
+        run: |
+          KAFKA_VERSION=$(echo "${{ needs.prepare.outputs.tag }}" | sed 's/kafka-//')
+          echo "kafka_version=$KAFKA_VERSION" >> $GITHUB_OUTPUT
+      - name: Check if Kafka image already exists
+        id: image_exists
+        run: |
+          IMAGE_NAME="${{ env.GHCR_REGISTRY }}/${{ env.GHCR_KAFKA_IMAGE_NAME }}:${{ steps.kafka_version.outputs.kafka_version }}"
+          echo "Checking if image exists: $IMAGE_NAME"
+
+          # Try to inspect the manifest using docker
+          if docker manifest inspect "$IMAGE_NAME" > /dev/null 2>&1; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "Image $IMAGE_NAME already exists, skipping build"
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "Image $IMAGE_NAME does not exist, will build"
+          fi
       - name: Login to DockerHub Registry
-        if: startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/') && github.repository == 'adobe/koperator' && steps.image_exists.outputs.exists == 'false'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Log into GitHub Container Registry ${{ env.GHCR_REGISTRY }}
-        if: startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/') && steps.image_exists.outputs.exists == 'false'
         uses: docker/login-action@v3
         with:
           registry: ${{ env.GHCR_REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Extract Docker metadata
+        if: steps.image_exists.outputs.exists == 'false'
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: |
-            ${{ env.DOCKERHUB_IMAGE }}
-            ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_IMAGE_NAME }}
+            ${{ github.repository == 'adobe/koperator' && env.DOCKERHUB_IMAGE || '' }}
+            ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_KAFKA_IMAGE_NAME }}
           tags: |
             type=match,pattern=kafka-(.*),group=1
           labels: |
             org.opencontainers.image.description=Apache Kafka with OpenJDK 21
       - name: Build and push kafka image
+        if: startsWith(github.ref, 'refs/tags/') && steps.image_exists.outputs.exists == 'false'
         uses: docker/build-push-action@v6
         with:
           context: docker/kafka
           platforms: linux/amd64,linux/arm64
-          push: ${{ startsWith(github.ref, 'refs/tags/') }}
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           annotations: ${{ steps.meta.outputs.annotations }}
@@ -84,3 +106,64 @@ jobs:
             VERSION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}
             BUILT_AT=${{ needs.prepare.outputs.built_at }}
             COMMIT=${{ github.sha }}
+
+  build-and-push-jmx-agent-image:
+    runs-on: ubuntu-latest
+    needs: prepare
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Extract JMX exporter version from Dockerfile
+        id: jmx_exporter_version
+        run: |
+          JMX_VERSION=$(grep "ARG JMX_EXPORTER_VERSION=" docker/jmx_exporter/Dockerfile | cut -d'=' -f2 | cut -d' ' -f1)
+          echo "jmx_version=$JMX_VERSION" >> $GITHUB_OUTPUT
+      - name: Check if JMX exporter image already exists
+        id: image_exists
+        run: |
+          IMAGE_NAME="${{ env.GHCR_REGISTRY }}/${{ env.GHCR_JMX_IMAGE_NAME }}:${{ steps.jmx_exporter_version.outputs.jmx_version }}"
+          echo "Checking if image exists: $IMAGE_NAME"
+
+          # Try to inspect the manifest using docker
+          if docker manifest inspect "$IMAGE_NAME" > /dev/null 2>&1; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "Image $IMAGE_NAME already exists, skipping build"
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "Image $IMAGE_NAME does not exist, will build"
+          fi
+      - name: Log into GitHub Container Registry ${{ env.GHCR_REGISTRY }}
+        if: startsWith(github.ref, 'refs/tags/') && steps.image_exists.outputs.exists == 'false'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.GHCR_REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract Docker metadata for JMX exporter
+        if: steps.image_exists.outputs.exists == 'false'
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_JMX_IMAGE_NAME }}
+          tags: |
+            type=raw,value=${{ steps.jmx_exporter_version.outputs.jmx_version }}
+          labels: |
+            org.opencontainers.image.description=Prometheus JMX Exporter for Kafka monitoring
+      - name: Build and push JMX exporter image
+        if: startsWith(github.ref, 'refs/tags/') && steps.image_exists.outputs.exists == 'false'
+        uses: docker/build-push-action@v6
+        with:
+          context: docker/jmx_exporter
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          annotations: ${{ steps.meta.outputs.annotations }}

--- a/api/assets/kafka/jmx-exporter.yml
+++ b/api/assets/kafka/jmx-exporter.yml
@@ -1,3 +1,7 @@
+httpServer:
+  threads:
+    minimum: 5
+    maximum: 10
 lowercaseOutputName: true
 rules:
   # Special cases and very specific rules

--- a/api/v1beta1/kafkacluster_types.go
+++ b/api/v1beta1/kafkacluster_types.go
@@ -145,7 +145,7 @@ const (
 
 	// KafkaBrokerPod.spec.initContainer[jmx-exporter].image
 	// kafkaClusterDeployment.spec.template.spec.initContainer["jmx-exporter"].image
-	defaultMonitorImage = "ghcr.io/amuraru/jmx-javaagent:0.19.2"
+	defaultMonitorImage = "ghcr.io/amuraru/koperator/jmx-javaagent:1.4.0"
 
 	// KafkaBrokerPod.spec.initContainer["jmx-exporter"].command
 	// kafkaClusterDeployment.spec.template.spec.initContainer["jmx-exporter"].command

--- a/config/samples/banzaicloud_v1beta1_kafkacluster.yaml
+++ b/config/samples/banzaicloud_v1beta1_kafkacluster.yaml
@@ -708,7 +708,7 @@ spec:
   # monitoringConfig describes the monitoring related configs
   #monitoringConfig:
   # jmxImage describes the used prometheus jmx exporter agent container
-  #  jmxImage: "ghcr.io/amuraru/jmx-javaagent:0.19.2"
+  #  jmxImage: "ghcr.io/amuraru/koperator/jmx-javaagent:1.4.0"
   # pathToJar describes the path to the jar file in the given image
   #  pathToJar: "/jmx_prometheus_javaagent.jar"
   # kafkaJMXExporterConfig describes jmx exporter config for Kafka

--- a/config/samples/kraft/simplekafkacluster_kraft.yaml
+++ b/config/samples/kraft/simplekafkacluster_kraft.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   kRaft: true
   monitoringConfig:
-    jmxImage: "ghcr.io/amuraru/jmx-javaagent:0.19.2"
+    jmxImage: "ghcr.io/amuraru/koperator/jmx-javaagent:1.4.0"
   headlessServiceEnabled: true
   propagateLabels: false
   oneBrokerPerNode: false

--- a/config/samples/simplekafkacluster.yaml
+++ b/config/samples/simplekafkacluster.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   kRaft: false
   monitoringConfig:
-    jmxImage: "ghcr.io/amuraru/jmx-javaagent:0.19.2"
+    jmxImage: "ghcr.io/amuraru/koperator/jmx-javaagent:1.4.0"
   headlessServiceEnabled: true
   zkAddresses:
     - "zookeeper-server-client.zookeeper:2181"

--- a/config/samples/simplekafkacluster_with_contour.yaml
+++ b/config/samples/simplekafkacluster_with_contour.yaml
@@ -6,7 +6,7 @@ metadata:
   name: kafka
 spec:
   monitoringConfig:
-    jmxImage: "ghcr.io/amuraru/jmx-javaagent:0.19.2"
+    jmxImage: "ghcr.io/amuraru/koperator/jmx-javaagent:1.4.0"
   headlessServiceEnabled: true
   zkAddresses:
     - "zookeeper-server-client.zookeeper:2181"

--- a/controllers/tests/kafkacluster_controller_cruisecontrol_test.go
+++ b/controllers/tests/kafkacluster_controller_cruisecontrol_test.go
@@ -277,7 +277,7 @@ func expectCruiseControlDeployment(ctx context.Context, kafkaCluster *v1beta1.Ka
 	Expect(deployment.Spec.Template.Spec.InitContainers).To(HaveLen(1))
 	initContainer := deployment.Spec.Template.Spec.InitContainers[0]
 	Expect(initContainer.Name).To(Equal("jmx-exporter"))
-	Expect(initContainer.Image).To(Equal("ghcr.io/amuraru/jmx-javaagent:0.19.2"))
+	Expect(initContainer.Image).To(Equal("ghcr.io/amuraru/koperator/jmx-javaagent:1.4.0"))
 	Expect(initContainer.Command).To(Equal([]string{"cp", "/jmx_prometheus_javaagent.jar", "/opt/jmx-exporter/jmx_prometheus.jar"}))
 	Expect(initContainer.VolumeMounts).To(ConsistOf(corev1.VolumeMount{
 		Name:      "jmx-jar-data",

--- a/docker/jmx_exporter/Dockerfile
+++ b/docker/jmx_exporter/Dockerfile
@@ -1,0 +1,24 @@
+ARG JMX_EXPORTER_VERSION=1.4.0 # renovate: datasource=github-releases depName=prometheus/jmx_exporter
+
+FROM maven:3-amazoncorretto-21 AS build
+ARG JMX_EXPORTER_VERSION
+
+# Install wget to download the release tarball
+RUN yum install -y wget && yum clean all
+
+# Download and extract the JMX exporter release
+RUN wget https://github.com/prometheus/jmx_exporter/archive/refs/tags/${JMX_EXPORTER_VERSION}.tar.gz \
+    -O /tmp/jmx_exporter.tar.gz && \
+    tar -xzf /tmp/jmx_exporter.tar.gz -C /tmp && \
+    mv /tmp/jmx_exporter-${JMX_EXPORTER_VERSION} /src && \
+    rm /tmp/jmx_exporter.tar.gz
+
+WORKDIR /src
+RUN mvn -B -Dmaven.javadoc.skip=true -Dskip.javadoc=true \
+    -Dmaven.compiler.source=21 -Dmaven.compiler.target=21 -Dmaven.compiler.release=21 \
+    clean package -pl jmx_prometheus_javaagent -am
+
+FROM scratch
+ARG JMX_EXPORTER_VERSION
+
+COPY --from=build /src/jmx_prometheus_javaagent/target/jmx_prometheus_javaagent-${JMX_EXPORTER_VERSION}.jar /jmx_prometheus_javaagent.jar

--- a/docker/kafka/Dockerfile
+++ b/docker/kafka/Dockerfile
@@ -1,36 +1,41 @@
+ARG scala_version=2.13
+ARG kafka_version=3.9.1 # renovate: datasource=github-tags depName=apache/kafka
+ARG java_version=21
+
 FROM alpine:latest AS kafka_dist
 
-ARG scala_version=2.13
-ARG kafka_version=3.9.1
+ARG scala_version
+ARG kafka_version
 ARG kafka_distro_base_url=https://downloads.apache.org/kafka
 
 ENV kafka_distro=kafka_$scala_version-$kafka_version.tgz
 ENV kafka_distro_asc=$kafka_distro.asc
 
-RUN apk add --no-cache gnupg
-
 WORKDIR /var/tmp
 
-RUN wget -q $kafka_distro_base_url/$kafka_version/$kafka_distro
-RUN wget -q $kafka_distro_base_url/$kafka_version/$kafka_distro_asc
-RUN wget -q $kafka_distro_base_url/KEYS
-
-RUN gpg --import KEYS
-RUN gpg --verify $kafka_distro_asc $kafka_distro
-
-RUN tar -xzf $kafka_distro
-RUN rm -r kafka_$scala_version-$kafka_version/bin/windows
+# Download, verify, extract and clean up Kafka in single layer
+RUN apk add --no-cache gnupg wget && \
+    wget -q $kafka_distro_base_url/$kafka_version/$kafka_distro && \
+    wget -q $kafka_distro_base_url/$kafka_version/$kafka_distro_asc && \
+    wget -q $kafka_distro_base_url/KEYS && \
+    gpg --import KEYS && \
+    gpg --verify $kafka_distro_asc $kafka_distro && \
+    tar -xzf $kafka_distro && \
+    rm -rf kafka_$scala_version-$kafka_version/bin/windows \
+           kafka_$scala_version-$kafka_version/site-docs \
+           $kafka_distro $kafka_distro_asc KEYS && \
+    find kafka_$scala_version-$kafka_version -name "*.bat" -delete
 
 
 # backported from https://github.com/docker-library/openjdk/blob/master/18/jdk/slim-bullseye/Dockerfile
 FROM debian:bullseye-slim
 
-ARG scala_version=2.13
-ARG kafka_version=3.9.1
+ARG scala_version
+ARG kafka_version
+ARG java_version
 ARG VERSION
 ARG BUILT_AT
 ARG COMMIT
-
 
 RUN set -eux; \
 	apt-get update; \
@@ -39,24 +44,24 @@ RUN set -eux; \
 	; \
 	rm -rf /var/lib/apt/lists/*
 
-ENV JAVA_HOME /usr/local/openjdk-21
-ENV PATH $JAVA_HOME/bin:$PATH
+ENV JAVA_HOME=/usr/local/openjdk-${java_version}
+ENV PATH=$JAVA_HOME/bin:$PATH
 
 # Default to UTF-8 file.encoding
-ENV LANG C.UTF-8
-ENV JAVA_VERSION 21
+ENV LANG=C.UTF-8
+ENV JAVA_VERSION=${java_version}
 
 RUN set -eux; \
 	\
 	arch="$(dpkg --print-architecture)"; \
 	case "$arch" in \
 		'amd64') \
-			downloadUrl='https://download.oracle.com/java/21/latest/jdk-21_linux-x64_bin.tar.gz'; \
-			downloadSha256='https://download.oracle.com/java/21/latest/jdk-21_linux-x64_bin.tar.gz.sha256'; \
+			downloadUrl="https://download.oracle.com/java/${java_version}/latest/jdk-${java_version}_linux-x64_bin.tar.gz"; \
+			downloadSha256="https://download.oracle.com/java/${java_version}/latest/jdk-${java_version}_linux-x64_bin.tar.gz.sha256"; \
 			;; \
 		'arm64') \
-			downloadUrl='https://download.oracle.com/java/21/latest/jdk-21_linux-aarch64_bin.tar.gz'; \
-			downloadSha256='https://download.oracle.com/java/21/latest/jdk-21_linux-aarch64_bin.tar.gz.sha256'; \
+			downloadUrl="https://download.oracle.com/java/${java_version}/latest/jdk-${java_version}_linux-aarch64_bin.tar.gz"; \
+			downloadSha256="https://download.oracle.com/java/${java_version}/latest/jdk-${java_version}_linux-aarch64_bin.tar.gz.sha256"; \
 			;; \
 		*) echo >&2 "error: unsupported architecture: '$arch'"; exit 1 ;; \
 	esac; \
@@ -80,6 +85,9 @@ RUN set -eux; \
 		--no-same-owner \
 	; \
 	rm openjdk.tgz*; \
+	\
+# Remove JMODs (not needed for runtime, only for jlink custom images)
+	rm -rf "$JAVA_HOME/jmods"; \
 	\
 	apt-mark auto '.*' > /dev/null; \
 	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
@@ -117,18 +125,25 @@ ENV KAFKA_VERSION=$kafka_version \
 
 ENV PATH=${PATH}:${KAFKA_HOME}/bin
 
-RUN mkdir ${KAFKA_HOME} && apt-get update && apt-get -y upgrade && apt-get install curl -y && apt-get clean
+# Install minimal dependencies, setup Kafka, and clean up in single layer
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends curl && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    mkdir -p ${KAFKA_HOME}/libs/extensions
 
 COPY --from=kafka_dist /var/tmp/kafka_$scala_version-$kafka_version ${KAFKA_HOME}
 COPY opt/kafka/config/log4j.properties ${KAFKA_HOME}/config/log4j.properties
 
-
-RUN chmod a+x ${KAFKA_HOME}/bin/*.sh
-RUN chmod g+rwX ${KAFKA_HOME} && mkdir -p ${KAFKA_HOME}/libs/extensions && chmod g+rwX ${KAFKA_HOME}/libs/extensions
+# Optimize Kafka installation: remove unnecessary files and set permissions
+RUN chmod a+x ${KAFKA_HOME}/bin/*.sh && \
+    chmod g+rwX ${KAFKA_HOME} ${KAFKA_HOME}/libs/extensions && \
+    rm -rf ${KAFKA_HOME}/bin/windows ${KAFKA_HOME}/site-docs && \
+    find ${KAFKA_HOME} -name "*.bat" -delete
 
 # Add metadata labels
 LABEL org.opencontainers.image.title="Apache Kafka"
-LABEL org.opencontainers.image.description="Apache Kafka with OpenJDK 21"
+LABEL org.opencontainers.image.description="Apache Kafka with Oracle JDK ${java_version}"
 LABEL org.opencontainers.image.vendor="Adobe"
 LABEL org.opencontainers.image.licenses="Apache-2.0"
 LABEL org.opencontainers.image.source="https://github.com/adobe/koperator"

--- a/docs/benchmarks/infrastructure/kafka_202001_3brokers.yaml
+++ b/docs/benchmarks/infrastructure/kafka_202001_3brokers.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   kRaft: false
   monitoringConfig:
-    jmxImage: "ghcr.io/amuraru/jmx-javaagent:0.19.2"
+    jmxImage: "ghcr.io/amuraru/koperator/jmx-javaagent:1.4.0"
     pathToJar: "/jmx_prometheus_javaagent.jar"
     kafkaJMXExporterConfig: |2
       lowercaseOutputName: true

--- a/renovate.json
+++ b/renovate.json
@@ -22,7 +22,8 @@
     {
       "customType": "regex",
       "managerFilePatterns": [
-        "/Makefile/"
+        "/Makefile/",
+        "/Dockerfile$/"
       ],
       "matchStrings": [
         "(?<depName>\\w+)_VERSION\\s*=\\s*(?<currentValue>[^\\s]+)\\s*#\\s*renovate:\\s*datasource=(?<datasource>[^\\s]+)\\s*depName=(?<packageName>[^\\s]+)"
@@ -46,6 +47,35 @@
       "pinDigests": true
     },
     {
+      "groupName": "kafka docker images (major)",
+      "groupSlug": "kafka-docker-major",
+      "matchFilePatterns": [
+        "docker/**"
+      ],
+      "matchManagers": [
+        "dockerfile",
+        "custom.regex"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ]
+    },
+    {
+      "groupName": "kafka docker images (minor/patch)",
+      "groupSlug": "kafka-docker-minor-patch",
+      "matchFilePatterns": [
+        "docker/**"
+      ],
+      "matchManagers": [
+        "dockerfile",
+        "custom.regex"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ]
+    },
+    {
       "groupName": "all major dependencies",
       "groupSlug": "all-major",
       "matchUpdateTypes": [
@@ -59,6 +89,9 @@
         "docker-compose",
         "custom.regex",
         "helm-values"
+      ],
+      "excludeFilePatterns": [
+        "docker/**"
       ]
     },
     {
@@ -78,6 +111,9 @@
         "custom.regex",
         "helm-values",
         "docker"
+      ],
+      "excludeFilePatterns": [
+        "docker/**"
       ]
     }
   ]


### PR DESCRIPTION
Currently the jmx-javaagent docker image is built from https://github.com/amuraru/jmx_exporter (and it's an old/unmantained version)

In order to bring that dependency in-tree here, this PR extends kafka image(s) release (kafka-*) action to also build a docker image directly from https://github.com/prometheus/jmx_exporter

The image is published to:
https://github.com/adobe/koperator/pkgs/container/koperator%2Fjmx-javaagent