### PR TITLE
fix: use proper context instead of context.TODO()

### DIFF
--- a/internal/alertmanager/currentalert/process.go
+++ b/internal/alertmanager/currentalert/process.go
@@ -322,8 +322,7 @@ func downScale(ctx context.Context, log logr.Logger, labels model.LabelSet, clie
 		brokerID = string(broker)
 	} else {
 		cruiseControlURL := scale.CruiseControlURLFromKafkaCluster(cr)
-		// FIXME: we should reuse the context of passed to AController.Start() here
-		cc, err := scale.NewCruiseControlScaler(context.TODO(), cruiseControlURL)
+		cc, err := scale.NewCruiseControlScaler(ctx, cruiseControlURL)
 		if err != nil {
 			return errors.WrapIfWithDetails(err, "failed to initialize Cruise Control Scaler",
 				"cruise control url", cruiseControlURL)

--- a/pkg/resources/kafka/kafka.go
+++ b/pkg/resources/kafka/kafka.go
@@ -505,7 +505,7 @@ func (r *Reconciler) Reconcile(log logr.Logger) error {
 
 func (r *Reconciler) reconcileKafkaPodDelete(ctx context.Context, log logr.Logger) error {
 	podList := &corev1.PodList{}
-	err := r.List(context.TODO(), podList,
+	err := r.List(ctx, podList,
 		client.InNamespace(r.KafkaCluster.Namespace),
 		client.MatchingLabels(apiutil.LabelsForKafka(r.KafkaCluster.Name)),
 	)
@@ -533,8 +533,7 @@ func (r *Reconciler) reconcileKafkaPodDelete(ctx context.Context, log logr.Logge
 
 	if len(podsDeletedFromSpec) > 0 {
 		if !arePodsAlreadyDeleted(podsDeletedFromSpec, log) {
-			// FIXME: we should reuse the context of the Kafka Controller
-			cc, err := r.CruiseControlScalerFactory(context.TODO(), r.KafkaCluster)
+			cc, err := r.CruiseControlScalerFactory(ctx, r.KafkaCluster)
 			if err != nil {
 				return errorfactory.New(errorfactory.CruiseControlNotReady{}, err,
 					"failed to initialize Cruise Control Scaler", "cruise control url", scale.CruiseControlURLFromKafkaCluster(r.KafkaCluster))


### PR DESCRIPTION
Replace context.TODO() with the proper context parameter in three locations:
- pkg/resources/kafka/kafka.go: reconcileKafkaPodDelete() now uses ctx for List() and CruiseControlScalerFactory()
- internal/alertmanager/currentalert/process.go: downScale() now uses ctx for NewCruiseControlScaler()

This fix enables:
- Proper cancellation propagation when operations need to be stopped
- Better observability (tracing, logging) through context values
- Prevention of potential resource leaks from uncancelable operations

Resolves FIXME comments in both files.

