### PR TITLE
fix(kafka): resolve disk-removal deadlock during rolling upgrade

### DIFF
--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -102,6 +102,18 @@ func (s CruiseControlVolumeState) IsDiskRemoval() bool {
 	return s.IsDiskRemovalRunning() || s == GracefulDiskRemovalRequired
 }
 
+// IsDiskOperationStalled returns true when a disk removal or rebalance task is in a
+// non-progressing state: CompletedWithError (the Cruise Control task finished with an
+// error) or Paused (halted, awaiting manual resume). In these states Cruise Control is
+// doing no work, so waiting on them to "finish" would block the reconcile indefinitely.
+// Mirrors IsDownscaleStalled at the broker-operation level.
+func (s CruiseControlVolumeState) IsDiskOperationStalled() bool {
+	return s == GracefulDiskRemovalCompletedWithError ||
+		s == GracefulDiskRebalanceCompletedWithError ||
+		s == GracefulDiskRemovalPaused ||
+		s == GracefulDiskRebalancePaused
+}
+
 // IsUpscale returns true if CruiseControlState in GracefulUpscale* state.
 func (r CruiseControlState) IsUpscale() bool {
 	return r == GracefulUpscaleRequired ||

--- a/config/samples/simplekafkacluster_1disk_configchange.yaml
+++ b/config/samples/simplekafkacluster_1disk_configchange.yaml
@@ -1,0 +1,300 @@
+apiVersion: kafka.banzaicloud.io/v1beta1
+kind: KafkaCluster
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: kafka
+spec:
+  kRaft: false
+  monitoringConfig:
+    jmxImage: "ghcr.io/adobe/koperator/jmx-javaagent:1.5.0" # renovate: datasource=docker depName=ghcr.io/adobe/koperator/jmx-javaagent
+  headlessServiceEnabled: true
+  zkAddresses:
+    - "zookeeper-server-client.zookeeper:2181"
+  propagateLabels: false
+  oneBrokerPerNode: false
+  clusterImage: "ghcr.io/adobe/koperator/kafka:2.13-3.9.2-jdk21.0.11" # renovate: datasource=docker depName=ghcr.io/adobe/koperator/kafka
+  readOnlyConfig: |
+    auto.create.topics.enable=false
+    cruise.control.metrics.topic.auto.create=true
+    cruise.control.metrics.topic.num.partitions=1
+    cruise.control.metrics.topic.replication.factor=2
+    # e2e: publish CruiseControl metrics every 15s (default 60s) so CC warms up quickly for the disk-removal test
+    cruise.control.metrics.reporter.metrics.reporting.interval.ms=15000
+    # e2e: read-only broker config changed together with the disk removal below. Because it is a
+    # read-only property it forces a rolling restart, exercising config-change + disk-removal in the
+    # same reconcile (the deadlock scenario). Non-default value (Kafka default is 168).
+    log.retention.hours=170
+  brokerConfigGroups:
+    default:
+      # podSecurityContext:
+      #  runAsNonRoot: false
+      # securityContext:
+      #  privileged: true
+      storageConfigs:
+        - mountPath: "/kafka-logs1"
+          pvcSpec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 1Gi
+      brokerAnnotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9020"
+      # brokerLabels:
+      #   kafka_broker_group: "default_group"
+  brokers:
+    - id: 0
+      brokerConfigGroup: "default"
+      # brokerConfig:
+      #   envs:
+      #     - name: +CLASSPATH
+      #       value: "/opt/kafka/libs/dev/*:"
+      #     - name: CLASSPATH+
+      #       value: ":/opt/kafka/libs/extra-jars/*"
+    - id: 1
+      brokerConfigGroup: "default"
+    - id: 2
+      brokerConfigGroup: "default"
+  rollingUpgradeConfig:
+    failureThreshold: 1
+  listenersConfig:
+    internalListeners:
+      - type: "plaintext"
+        name: "internal"
+        containerPort: 29092
+        usedForInnerBrokerCommunication: true
+      - type: "plaintext"
+        name: "controller"
+        containerPort: 29093
+        usedForInnerBrokerCommunication: false
+        usedForControllerCommunication: true
+  cruiseControlConfig:
+    # podSecurityContext:
+    #  runAsNonRoot: false
+    # securityContext:
+    #  privileged: true
+    cruiseControlTaskSpec:
+      RetryDurationMinutes: 5
+    topicConfig:
+      # e2e: fewer partitions => faster CC monitoring coverage and less data movement during disk removal
+      partitions: 3
+      replicationFactor: 3
+#    resourceRequirements:
+#      requests:
+#        cpu: 500m
+#        memory: 1Gi
+#      limits:
+#        cpu: 500m
+#        memory: 1Gi
+    image: "adobe/cruise-control:3.0.3-adbe-20260722" # renovate: datasource=docker depName=adobe/cruise-control
+    config: |
+      # Copyright 2017 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+      #
+      # This is an example property file for Kafka Cruise Control. See KafkaCruiseControlConfig for more details.
+      # Configuration for the metadata client.
+      # =======================================
+      # The maximum interval in milliseconds between two metadata refreshes.
+      # Must be <= metric.sampling.interval.ms (CruiseControl sanityCheckSamplingPeriod);
+      # kept low here so the fast e2e sampling interval (15s) is allowed.
+      metadata.max.age.ms=10000
+      # Client id for the Cruise Control. It is used for the metadata client.
+      #client.id=kafka-cruise-control
+      # The size of TCP send buffer bytes for the metadata client.
+      #send.buffer.bytes=131072
+      # The size of TCP receive buffer size for the metadata client.
+      #receive.buffer.bytes=131072
+      # The time to wait before disconnect an idle TCP connection.
+      #connections.max.idle.ms=540000
+      # The time to wait before reconnect to a given host.
+      #reconnect.backoff.ms=50
+      # The time to wait for a response from a host after sending a request.
+      #request.timeout.ms=30000
+      # Configurations for the load monitor
+      # =======================================
+      # The number of metric fetcher thread to fetch metrics for the Kafka cluster
+      num.metric.fetchers=1
+      # The metric sampler class
+      metric.sampler.class=com.linkedin.kafka.cruisecontrol.monitor.sampling.CruiseControlMetricsReporterSampler
+      # Configurations for CruiseControlMetricsReporterSampler
+      metric.reporter.topic.pattern=__CruiseControlMetrics
+      # The sample store class name
+      sample.store.class=com.linkedin.kafka.cruisecontrol.monitor.sampling.KafkaSampleStore
+      # The config for the Kafka sample store to save the partition metric samples
+      partition.metric.sample.store.topic=__KafkaCruiseControlPartitionMetricSamples
+      # The config for the Kafka sample store to save the model training samples
+      broker.metric.sample.store.topic=__KafkaCruiseControlModelTrainingSamples
+      # The replication factor of Kafka metric sample store topic
+      sample.store.topic.replication.factor=2
+      # e2e: shrink CC's sample-store topics from their 32-partitions-each default so broker/disk removal
+      # reshuffles only a few partitions (not 64) and the CC execution completes quickly; not production defaults.
+      # NOTE: CC only ever increases these partition counts (never shrinks), so this only takes effect on a fresh cluster.
+      partition.sample.store.topic.partition.count=3
+      broker.sample.store.topic.partition.count=3
+      # The config for the number of Kafka sample store consumer threads
+      num.sample.loading.threads=8
+      # The partition assignor class for the metric samplers
+      metric.sampler.partition.assignor.class=com.linkedin.kafka.cruisecontrol.monitor.sampling.DefaultMetricSamplerPartitionAssignor
+      # The metric sampling interval in milliseconds
+      # NOTE: the metrics sampling interval and window sizes below are tuned low for fast
+      # Cruise Control warmup in e2e (tiny test data); not production-appropriate defaults.
+      metric.sampling.interval.ms=15000
+      # CruiseControl reads the reporter interval from its own config (default 60000) for its
+      # sanity check and requires it <= the sampling interval, so declare it here too
+      # (mirrors the broker-side value in readOnlyConfig).
+      cruise.control.metrics.reporter.metrics.reporting.interval.ms=15000
+      metric.anomaly.detection.interval.ms=180000
+      # The partition metrics window size in milliseconds
+      # e2e: shrink window to the 15s sampling interval so CC accrues a valid window fast; not production defaults
+      partition.metrics.window.ms=15000
+      # The number of partition metric windows to keep in memory
+      num.partition.metrics.windows=1
+      # The minimum partition metric samples required for a partition in each window
+      min.samples.per.partition.metrics.window=1
+      # The broker metrics window size in milliseconds
+      # e2e: shrink window to the 15s sampling interval to speed up CC warmup; not production defaults
+      broker.metrics.window.ms=15000
+      # The number of broker metric windows to keep in memory
+      # e2e: only 2 broker windows needed for warmup on a tiny static cluster (was 5); not production defaults
+      num.broker.metrics.windows=2
+      # The minimum broker metric samples required for a partition in each window
+      min.samples.per.broker.metrics.window=1
+      # The configuration for the BrokerCapacityConfigFileResolver (supports JBOD and non-JBOD broker capacities)
+      capacity.config.file=config/capacity.json
+      #capacity.config.file=config/capacityJBOD.json
+      # Configurations for the analyzer
+      # =======================================
+      # The list of goals to optimize the Kafka cluster for with pre-computed proposals
+      default.goals=com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaDistributionGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.PotentialNwOutGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskUsageDistributionGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundUsageDistributionGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundUsageDistributionGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuUsageDistributionGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.TopicReplicaDistributionGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.LeaderBytesInDistributionGoal
+      # The list of supported goals
+      goals=com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaDistributionGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.PotentialNwOutGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskUsageDistributionGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundUsageDistributionGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundUsageDistributionGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuUsageDistributionGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.TopicReplicaDistributionGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.LeaderBytesInDistributionGoal,com.linkedin.kafka.cruisecontrol.analyzer.kafkaassigner.KafkaAssignerDiskUsageDistributionGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.PreferredLeaderElectionGoal
+      # The list of supported hard goals
+      hard.goals=com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuCapacityGoal
+      # The minimum percentage of well monitored partitions out of all the partitions
+      # e2e: lowered from CC's 0.995 default so the load model becomes valid quickly on a tiny cluster
+      # with few partitions/windows; not production defaults
+      min.valid.partition.ratio=0.5
+      # The balance threshold for CPU
+      cpu.balance.threshold=1.1
+      # The balance threshold for disk
+      disk.balance.threshold=1.1
+      # The balance threshold for network inbound utilization
+      network.inbound.balance.threshold=1.1
+      # The balance threshold for network outbound utilization
+      network.outbound.balance.threshold=1.1
+      # The balance threshold for the replica count
+      replica.count.balance.threshold=1.1
+      # The capacity threshold for CPU in percentage
+      cpu.capacity.threshold=0.8
+      # The capacity threshold for disk in percentage
+      disk.capacity.threshold=0.8
+      # The capacity threshold for network inbound utilization in percentage
+      network.inbound.capacity.threshold=0.8
+      # The capacity threshold for network outbound utilization in percentage
+      network.outbound.capacity.threshold=0.8
+      # The threshold to define the cluster to be in a low CPU utilization state
+      cpu.low.utilization.threshold=0.0
+      # The threshold to define the cluster to be in a low disk utilization state
+      disk.low.utilization.threshold=0.0
+      # The threshold to define the cluster to be in a low network inbound utilization state
+      network.inbound.low.utilization.threshold=0.0
+      # The threshold to define the cluster to be in a low disk utilization state
+      network.outbound.low.utilization.threshold=0.0
+      # The metric anomaly percentile upper threshold
+      metric.anomaly.percentile.upper.threshold=90.0
+      # The metric anomaly percentile lower threshold
+      metric.anomaly.percentile.lower.threshold=10.0
+      # How often should the cached proposal be expired and recalculated if necessary
+      proposal.expiration.ms=60000
+      # The maximum number of replicas that can reside on a broker at any given time.
+      max.replicas.per.broker=10000
+      # The number of threads to use for proposal candidate precomputing.
+      num.proposal.precompute.threads=1
+      # the topics that should be excluded from the partition movement.
+      #topics.excluded.from.partition.movement
+      # Configurations for the executor
+      # =======================================
+      # The max number of partitions to move in/out on a given broker at a given time.
+      num.concurrent.partition.movements.per.broker=10
+      # The interval between two execution progress checks.
+      # e2e: poll execution progress every 5s (was 10s) so disk removal/rebalance completion is detected sooner; not production defaults
+      execution.progress.check.interval.ms=5000
+      # Configurations for anomaly detector
+      # =======================================
+      # The goal violation notifier class
+      anomaly.notifier.class=com.linkedin.kafka.cruisecontrol.detector.notifier.SelfHealingNotifier
+      # The metric anomaly finder class
+      metric.anomaly.finder.class=com.linkedin.kafka.cruisecontrol.detector.KafkaMetricAnomalyFinder
+      # The anomaly detection interval
+      anomaly.detection.interval.ms=10000
+      # The goal violation to detect.
+      anomaly.detection.goals=com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuCapacityGoal
+      # The interested metrics for metric anomaly analyzer.
+      metric.anomaly.analyzer.metrics=BROKER_PRODUCE_LOCAL_TIME_MS_MAX,BROKER_PRODUCE_LOCAL_TIME_MS_MEAN,BROKER_CONSUMER_FETCH_LOCAL_TIME_MS_MAX,BROKER_CONSUMER_FETCH_LOCAL_TIME_MS_MEAN,BROKER_FOLLOWER_FETCH_LOCAL_TIME_MS_MAX,BROKER_FOLLOWER_FETCH_LOCAL_TIME_MS_MEAN,BROKER_LOG_FLUSH_TIME_MS_MAX,BROKER_LOG_FLUSH_TIME_MS_MEAN
+      ## Adjust accordingly if your metrics reporter is an older version and does not produce these metrics.
+      #metric.anomaly.analyzer.metrics=BROKER_PRODUCE_LOCAL_TIME_MS_50TH,BROKER_PRODUCE_LOCAL_TIME_MS_999TH,BROKER_CONSUMER_FETCH_LOCAL_TIME_MS_50TH,BROKER_CONSUMER_FETCH_LOCAL_TIME_MS_999TH,BROKER_FOLLOWER_FETCH_LOCAL_TIME_MS_50TH,BROKER_FOLLOWER_FETCH_LOCAL_TIME_MS_999TH,BROKER_LOG_FLUSH_TIME_MS_50TH,BROKER_LOG_FLUSH_TIME_MS_999TH
+      # The zk path to store failed broker information.
+      failed.brokers.zk.path=/CruiseControlBrokerList
+      # Topic config provider class
+      topic.config.provider.class=com.linkedin.kafka.cruisecontrol.config.KafkaTopicConfigProvider
+      # The cluster configurations for the KafkaTopicConfigProvider
+      cluster.configs.file=config/clusterConfigs.json
+      # The maximum time in milliseconds to store the response and access details of a completed user task.
+      completed.user.task.retention.time.ms=21600000
+      # The maximum time in milliseconds to retain the demotion history of brokers.
+      demotion.history.retention.time.ms=86400000
+      # The maximum number of completed user tasks for which the response and access details will be cached.
+      max.cached.completed.user.tasks=500
+      # The maximum number of user tasks for concurrently running in async endpoints across all users.
+      max.active.user.tasks=25
+      # Enable self healing for all anomaly detectors, unless the particular anomaly detector is explicitly disabled
+      self.healing.enabled=true
+      # Enable self healing for broker failure detector
+      #self.healing.broker.failure.enabled=true
+      # Enable self healing for goal violation detector
+      #self.healing.goal.violation.enabled=true
+      # Enable self healing for metric anomaly detector
+      #self.healing.metric.anomaly.enabled=true
+      # configurations for the webserver
+      # ================================
+      # HTTP listen port
+      webserver.http.port=9090
+      # HTTP listen address
+      webserver.http.address=0.0.0.0
+      # Whether CORS support is enabled for API or not
+      webserver.http.cors.enabled=false
+      # Value for Access-Control-Allow-Origin
+      webserver.http.cors.origin=http://localhost:8080/
+      # Value for Access-Control-Request-Method
+      webserver.http.cors.allowmethods=OPTIONS,GET,POST
+      # Headers that should be exposed to the Browser (Webapp)
+      # This is a special header that is used by the
+      # User Tasks subsystem and should be explicitly
+      # Enabled when CORS mode is used as part of the
+      # Admin Interface
+      webserver.http.cors.exposeheaders=User-Task-ID
+      # REST API default prefix
+      # (dont forget the ending *)
+      webserver.api.urlprefix=/kafkacruisecontrol/*
+      # Location where the Cruise Control frontend is deployed
+      webserver.ui.diskpath=./cruise-control-ui/dist/
+      # URL path prefix for UI
+      # (dont forget the ending *)
+      webserver.ui.urlprefix=/*
+      # Time After which request is converted to Async
+      webserver.request.maxBlockTimeMs=10000
+      # Default Session Expiry Period
+      webserver.session.maxExpiryTimeMs=60000
+      # Session cookie path
+      webserver.session.path=/
+      # Server Access Logs
+      webserver.accesslog.enabled=true
+      # Location of HTTP Request Logs
+      webserver.accesslog.path=access.log
+      # HTTP Request Log retention days
+      webserver.accesslog.retention.days=14
+    clusterConfig: |
+      {
+        "min.insync.replicas": 3
+      }

--- a/openspec/changes/fix-disk-removal-deadlock/design.md
+++ b/openspec/changes/fix-disk-removal-deadlock/design.md
@@ -1,0 +1,98 @@
+# Design: Fix Disk Removal Deadlock
+
+## Architecture Context
+
+The koperator reconcile loop in `pkg/resources/kafka/kafka.go` (main `Reconcile` function) runs these steps sequentially:
+
+```
+reconcileKafkaPodDelete()     // Line 265 - delete pods removed from spec
+    ↓
+reconcileKafkaPvc()           // Line 326 - PVC lifecycle (create, resize, disk removal)
+    ↓  ← BLOCKS HERE when disk removal pending
+build runningBrokers map      // Line 332 - query pod list
+    ↓
+reconcileKafkaPod()           // Line 448 - per-broker pod create/update/rolling upgrade
+```
+
+When `reconcileKafkaPvc` returns an error, all subsequent steps are skipped.
+
+Inside `reconcileKafkaPvc`:
+- Iterates ALL brokers' PVCs
+- Calls `handleDiskRemoval()` when existing PVCs > desired PVCs
+- `handleDiskRemoval` sets `waitForDiskRemovalToFinish = true` for any non-succeeded removal state
+- At the end, if `waitForDiskRemovalToFinish` → returns `CruiseControlTaskRunning` error
+
+Inside `reconcileKafkaPod`:
+- When `len(podList.Items) == 0` → creates pod (line 831-836)
+- When `len(podList.Items) == 1` → handles rolling upgrade via `handleRollingUpgrade()`
+
+## Design Decision
+
+### Where to put the check
+
+**Option A**: Inside `handleDiskRemoval` — skip `waitForDiskRemovalToFinish = true` per-broker if pod missing.
+**Option B**: At the end of `reconcileKafkaPvc` — override the error if any broker with removal has missing pod.
+**Option C**: In the main reconcile — catch the error and decide whether to proceed.
+
+**Chosen: Option B.** Reasons:
+- Minimal change surface (only the blocking decision at line 1278)
+- `handleDiskRemoval` still correctly tracks state and logs — no behavior change inside it
+- The main reconcile doesn't need to understand PVC internals
+- Easy to test: one function, one new parameter
+
+### What data is needed
+
+`reconcileKafkaPvc` needs to know which broker pods exist. The `runningBrokers` map (currently built at line 332) provides this. Move it earlier and pass it in.
+
+### Behavioral change
+
+| Scenario | Current | After Fix |
+|---|---|---|
+| Disk removal pending, all pods running | Block (error) | Block (error) — unchanged |
+| Disk removal pending, broker pod missing | Block (error) — DEADLOCK | Allow (nil) — pod gets created |
+| No disk removal pending | Allow (nil) | Allow (nil) — unchanged |
+
+## Key Code Paths
+
+### `handleDiskRemoval` (line 1285-1339)
+
+```
+for each existing PVC not in desired:
+    if volumeState not found → continue (removal done)
+    if IsDiskRemovalSucceeded → delete PVC, delete status
+    if IsDiskRemoval → waitForDiskRemovalToFinish = true    ← these are the blocking states
+    if IsDiskRebalance → waitForDiskRemovalToFinish = true   ← (rebalance before removal)
+    default → mark GracefulDiskRemovalRequired, wait = true  ← initial marking
+return waitForDiskRemovalToFinish
+```
+
+### `reconcileKafkaPvc` blocking (line 1278-1280)
+
+```go
+if waitForDiskRemovalToFinish {
+    return errorfactory.New(CruiseControlTaskRunning{}, "Disk removal pending", ...)
+}
+```
+
+The fix adds a check before this return:
+```go
+if waitForDiskRemovalToFinish {
+    // Check if any broker with pending removal has a missing pod
+    for brokerId := range brokersDesiredPvcs {
+        if _, podExists := runningBrokers[brokerId]; !podExists {
+            if state has IsDiskRemoval volume → return nil
+        }
+    }
+    return error  // all relevant pods exist, block normally
+}
+```
+
+## Edge Cases
+
+1. **Multiple brokers with missing pods**: Still returns nil. All missing pods will be created on this reconcile cycle.
+
+2. **Broker pod missing but NO disk removal for that broker**: `runningBrokers` missing + no IsDiskRemoval volume state → doesn't trigger the override. The error is still returned. This is intentional — we only bypass when the deadlock condition is present.
+
+3. **Pod deleted between runningBrokers check and reconcileKafkaPod**: Possible but harmless — `reconcileKafkaPod` re-queries the pod list per broker (line 826).
+
+4. **Disk removal completes while pod is being created**: The next reconcile cycle will see `IsDiskRemovalSucceeded` and clean up the PVC. No conflict.

--- a/openspec/changes/fix-disk-removal-deadlock/design.md
+++ b/openspec/changes/fix-disk-removal-deadlock/design.md
@@ -96,3 +96,39 @@ if waitForDiskRemovalToFinish {
 3. **Pod deleted between runningBrokers check and reconcileKafkaPod**: Possible but harmless — `reconcileKafkaPod` re-queries the pod list per broker (line 826).
 
 4. **Disk removal completes while pod is being created**: The next reconcile cycle will see `IsDiskRemovalSucceeded` and clean up the PVC. No conflict.
+
+## Follow-up: narrow the blocking wait to genuinely-progressing states
+
+The missing-pod bypass above fixes the deadlock only while a pod is *missing*. A live incident (`pipeline-kafka`, 3 brokers, all `GracefulDiskRemovalCompletedWithError` on the removed disk) showed a second failure mode: with all pods **present** but the CC removal task terminally failed, `reconcileKafkaPvc` still blocks forever and the rolling upgrade (brokers `ConfigOutOfSync`) can never start a restart, because it lives downstream of the PVC block.
+
+### Root cause
+
+`GracefulDiskRemovalCompletedWithError` is bucketed under `IsDiskRemovalRunning()` (`common_types.go:83`), so a **failed** CC task is treated as "in progress" and blocks the reconcile indefinitely. There is no self-healing path unless the volume is on `ErrorPolicyIgnore` (`cruisecontroltask_types.go:147-148`).
+
+### Why relaxing the block is data-safe
+
+The blanket block is **not** what protects `log.dirs` integrity — two independent mechanisms already do, and both key off *success*, not the desired spec:
+
+- **`log.dirs` retention**: `shouldKeepRemovedLogDirInConfig` (`configmap.go:312-335`) keeps the removed disk's mount path in `log.dirs` while the state is `IsDiskRemoval()`/`IsDiskRebalance()` (which includes `CompletedWithError`), dropping it only on `…Succeeded`. The KRaft path writes the shrunk set at `configmap.go:202`, but the protective merge at `configmap.go:90-97` runs afterward and overwrites it.
+- **PVC mount retention**: the pod mounts the *actually existing* PVCs (`generateDataVolumeAndVolumeMount`, `pod.go:438`; `getCreatedPvcForBroker`, `kafka.go:143` returns all existing PVCs). The removed disk's PVC is deleted only in `handleDiskRemoval`'s `IsDiskRemovalSucceeded()` branch.
+
+So a `ConfigOutOfSync` broker can restart mid-removal with the disk still in `log.dirs` and still mounted — no stranded data.
+
+### Cruise Control does not hang on a dead broker (verified against CC source)
+
+`remove_disks` executes as intra-broker replica movement. If the broker (hence its destination disk) is down, CC's progress check marks the task DEAD ("Killing execution for task … because the destination disk is down", `Executor.java:2145-2151`), the wait loop exits (`Executor.java:2009`), and the user task reaches a terminal state — mapped by koperator to `…CompletedWithError`. It does **not** stay pinned in `IN_EXECUTION`. This is why the external-termination variant also lands in `CompletedWithError` and, pre-fix, deadlocks permanently.
+
+### The change
+
+Add `CruiseControlVolumeState.IsDiskOperationStalled()` (`CompletedWithError`/`Paused`, mirroring `IsDownscaleStalled`) and, in `handleDiskRemoval`, set `waitForDiskRemovalToFinish = true` only for non-stalled `IsDiskRemoval()`/`IsDiskRebalance()` states. Branch selection (PVC deletion, state marking) is unchanged. The `default`/`Required` branch still blocks (conservative; covered by the missing-pod bypass when the pod is also gone).
+
+The two fixes are complementary:
+
+| Scenario | Fixed by |
+|---|---|
+| Removal failed/paused, pods up | state-narrowing (`IsDiskOperationStalled`) |
+| Removal genuinely Running/Scheduled, this broker's pod missing | missing-pod bypass |
+
+### Not fixed here
+
+The failed removal itself (`CompletedWithError`) is not retried/cleared by this change — it stops that failure from freezing the cluster. Driving the removal to success (or surfacing it for manual action) is a separate concern in the CC task reconciler.

--- a/openspec/changes/fix-disk-removal-deadlock/proposal.md
+++ b/openspec/changes/fix-disk-removal-deadlock/proposal.md
@@ -1,0 +1,63 @@
+# Fix: Disk Removal Deadlock During Rolling Upgrade
+
+**Status**: proposed
+**Created**: 2026-05-18
+
+## Problem
+
+When a broker's pod is deleted during a rolling upgrade AND a disk removal is pending (`GracefulDiskRemovalScheduled`), the operator enters a deadlock:
+
+1. `reconcileKafkaPvc` blocks the entire reconcile with "Disk removal pending" error
+2. `reconcileKafkaPod` is never reached, so the pod is never recreated
+3. Cruise Control cannot complete the disk removal because the broker isn't running
+4. The cluster is stuck in `ClusterRollingUpgrading` indefinitely
+
+This was observed in production: broker 103 of a 9-broker cluster (`pipeline-kafka`) had its pod deleted at 14:27:33 and was never recreated. The operator looped every ~20s for 10+ minutes with "Disk removal pending".
+
+## Root Cause
+
+In `pkg/resources/kafka/kafka.go`, the main reconcile function processes steps sequentially:
+
+```
+Line 326: reconcileKafkaPvc()   ← blocks here with "Disk removal pending"
+Line 332: build runningBrokers  ← never reached
+Line 448: reconcileKafkaPod()   ← never reached (this creates missing pods)
+```
+
+`reconcileKafkaPvc` checks disk removal for ALL brokers. If ANY broker has pending removal, it returns a `CruiseControlTaskRunning` error that aborts the ENTIRE reconcile — including pod creation for brokers whose pods are missing.
+
+The deadlock emerges across reconcile cycles:
+- **Cycle N**: PVC check passes (states not set yet) → rolling upgrade deletes pod → returns
+- **Cycle N+1**: PVC check sets `GracefulDiskRemovalRequired` → blocks → pod never recreated
+- **Cycle N+2...∞**: Same. Deadlock.
+
+## Proposed Fix
+
+**Don't block on disk removal when a broker's pod doesn't exist.**
+
+CC disk removal REQUIRES the broker to be running (it moves partition replicas off the disk). Blocking pod creation while waiting for CC is counterproductive. The disk removal check is re-evaluated every reconcile cycle, so once the pod is back up, the check will correctly block again if still needed.
+
+### Changes
+
+**`pkg/resources/kafka/kafka.go`**:
+
+1. Move the `runningBrokers` map building (lines 332-343) to BEFORE `reconcileKafkaPvc` (line 326)
+2. Pass `runningBrokers` to `reconcileKafkaPvc`
+3. In `reconcileKafkaPvc` (line 1278), before returning "Disk removal pending" error: check if any broker with pending disk removal has a missing pod. If yes, return `nil` instead.
+
+**`pkg/resources/kafka/kafka_test.go`**:
+
+- Update existing `reconcileKafkaPvc` tests for new signature
+- Add test: disk removal pending + broker pod missing → returns `nil`
+- Add test: disk removal pending + all pods running → returns error (unchanged behavior)
+
+## Scope
+
+- This fix is purely in the reconcile ordering/blocking logic
+- No changes to Cruise Control integration, disk removal flow, or rolling upgrade semantics
+- Existing behavior is preserved when all broker pods are running
+- Only changes behavior when a broker pod is missing AND disk removal is pending
+
+## Risk
+
+**Low.** The fix only relaxes a blocking condition in a specific scenario (missing pod + pending disk removal) where the current behavior is provably wrong (deadlock). The disk removal check continues to work normally once the pod is recreated.

--- a/openspec/changes/fix-disk-removal-deadlock/tasks.md
+++ b/openspec/changes/fix-disk-removal-deadlock/tasks.md
@@ -1,0 +1,26 @@
+# Tasks: Fix Disk Removal Deadlock
+
+## Task 1: Move `runningBrokers` before `reconcileKafkaPvc` [x]
+- **File**: `pkg/resources/kafka/kafka.go`
+- **What**: Move the broker pod list query (lines 332-343) to before `reconcileKafkaPvc` call (line 326). Remove the duplicate query at its original location.
+- **Details**: The `var brokerPods` / `runningBrokers` block currently runs AFTER `reconcileKafkaPvc`. Move it before. Pass `runningBrokers` to `reconcileKafkaPvc`.
+
+## Task 2: Update `reconcileKafkaPvc` to accept and use `runningBrokers` [x]
+- **File**: `pkg/resources/kafka/kafka.go`
+- **What**:
+  1. Add `runningBrokers map[string]struct{}` parameter to `reconcileKafkaPvc`
+  2. At line 1278, before returning "Disk removal pending" error: check if any broker in `brokersDesiredPvcs` has a missing pod AND has a `IsDiskRemoval()` volume state. If so, return nil.
+- **Details**: This is the core fix. The check iterates `brokersDesiredPvcs` keys, looks up `runningBrokers`, and if a pod is missing checks the broker's volume states for active disk removal.
+
+## Task 3: Update tests [x]
+- **File**: `pkg/resources/kafka/kafka_test.go`
+- **What**:
+  1. Update all existing callers of `reconcileKafkaPvc` to pass the new `runningBrokers` parameter
+  2. Add test case: disk removal pending + broker pod missing → returns nil
+  3. Add test case: disk removal pending + all pods present → returns CruiseControlTaskRunning error
+- **Details**: The new test cases should set up a KafkaCluster with a broker whose volume state is `GracefulDiskRemovalScheduled`, then call `reconcileKafkaPvc` with/without the broker in `runningBrokers`.
+
+## Task 4: Verify [x]
+- Run `go test ./pkg/resources/kafka/...`
+- Run `make test` for full suite
+- Run `go vet ./...` and `go build ./...`

--- a/pkg/resources/kafka/kafka.go
+++ b/pkg/resources/kafka/kafka.go
@@ -1276,17 +1276,17 @@ func (r *Reconciler) reconcileKafkaPvc(ctx context.Context, log logr.Logger, bro
 	}
 
 	if waitForDiskRemovalToFinish {
-		// Don't block if any broker with pending disk removal has a missing pod.
+		// Don't block if any broker with pending disk removal/rebalance has a missing pod.
 		// Blocking prevents pod recreation, creating a deadlock where CC can't
-		// complete the disk removal because the broker isn't running.
+		// complete the disk removal or rebalance because the broker isn't running.
 		for brokerId := range brokersDesiredPvcs {
 			if _, podExists := runningBrokers[brokerId]; !podExists {
 				if brokerState, ok := r.KafkaCluster.Status.BrokersState[brokerId]; ok {
-					for _, volumeState := range brokerState.GracefulActionState.VolumeStates {
-						if volumeState.CruiseControlVolumeState.IsDiskRemoval() {
+					for mountPath, volumeState := range brokerState.GracefulActionState.VolumeStates {
+						if volumeState.CruiseControlVolumeState.IsDiskRemoval() || volumeState.CruiseControlVolumeState.IsDiskRebalance() {
 							log.Info("Disk removal pending but broker pod is missing, "+
 								"allowing reconcile to proceed for pod recreation",
-								"brokerId", brokerId)
+								"brokerId", brokerId, "mountPath", mountPath)
 							return nil
 						}
 					}

--- a/pkg/resources/kafka/kafka.go
+++ b/pkg/resources/kafka/kafka.go
@@ -322,13 +322,6 @@ func (r *Reconciler) Reconcile(log logr.Logger) error {
 			brokersVolumes[strconv.Itoa(int(broker.Id))] = brokerVolumes
 		}
 	}
-	if len(brokersVolumes) > 0 {
-		err := r.reconcileKafkaPvc(ctx, log, brokersVolumes)
-		if err != nil {
-			return errors.WrapIfWithDetails(err, "failed to reconcile resource", "resources", "PersistentVolumeClaim")
-		}
-	}
-
 	var brokerPods corev1.PodList
 	matchingLabels := client.MatchingLabels(apiutil.LabelsForKafka(r.KafkaCluster.Name))
 	err = r.List(ctx, &brokerPods, client.ListOption(client.InNamespace(r.KafkaCluster.Namespace)), client.ListOption(matchingLabels))
@@ -340,6 +333,13 @@ func (r *Reconciler) Reconcile(log logr.Logger) error {
 	for _, b := range brokerPods.Items {
 		brokerID := b.GetLabels()[banzaiv1beta1.BrokerIdLabelKey]
 		runningBrokers[brokerID] = struct{}{}
+	}
+
+	if len(brokersVolumes) > 0 {
+		err := r.reconcileKafkaPvc(ctx, log, brokersVolumes, runningBrokers)
+		if err != nil {
+			return errors.WrapIfWithDetails(err, "failed to reconcile resource", "resources", "PersistentVolumeClaim")
+		}
 	}
 
 	var pvcList corev1.PersistentVolumeClaimList
@@ -1137,7 +1137,7 @@ func (r *Reconciler) isPodTainted(log logr.Logger, pod *corev1.Pod) bool {
 }
 
 //nolint:funlen
-func (r *Reconciler) reconcileKafkaPvc(ctx context.Context, log logr.Logger, brokersDesiredPvcs map[string][]*corev1.PersistentVolumeClaim) error {
+func (r *Reconciler) reconcileKafkaPvc(ctx context.Context, log logr.Logger, brokersDesiredPvcs map[string][]*corev1.PersistentVolumeClaim, runningBrokers map[string]struct{}) error {
 	brokersVolumesState := make(map[string]map[string]banzaiv1beta1.VolumeState)
 	var brokerIds []string
 	waitForDiskRemovalToFinish := false
@@ -1276,6 +1276,23 @@ func (r *Reconciler) reconcileKafkaPvc(ctx context.Context, log logr.Logger, bro
 	}
 
 	if waitForDiskRemovalToFinish {
+		// Don't block if any broker with pending disk removal has a missing pod.
+		// Blocking prevents pod recreation, creating a deadlock where CC can't
+		// complete the disk removal because the broker isn't running.
+		for brokerId := range brokersDesiredPvcs {
+			if _, podExists := runningBrokers[brokerId]; !podExists {
+				if brokerState, ok := r.KafkaCluster.Status.BrokersState[brokerId]; ok {
+					for _, volumeState := range brokerState.GracefulActionState.VolumeStates {
+						if volumeState.CruiseControlVolumeState.IsDiskRemoval() {
+							log.Info("Disk removal pending but broker pod is missing, "+
+								"allowing reconcile to proceed for pod recreation",
+								"brokerId", brokerId)
+							return nil
+						}
+					}
+				}
+			}
+		}
 		return errorfactory.New(errorfactory.CruiseControlTaskRunning{}, errors.New("Disk removal pending"), "Disk removal pending")
 	}
 

--- a/pkg/resources/kafka/kafka.go
+++ b/pkg/resources/kafka/kafka.go
@@ -1393,11 +1393,26 @@ func handleDiskRemoval(ctx context.Context, pvcList *corev1.PersistentVolumeClai
 					return false, errors.WrapIfWithDetails(err, "could not delete volume status for broker volume", "brokerId", brokerId, mountPathAnnotationKey, mountPathToRemove)
 				}
 			case ccVolumeState.IsDiskRemoval():
-				log.Info("Graceful disk removal is in progress", "brokerId", brokerId, mountPathAnnotationKey, mountPathToRemove)
-				waitForDiskRemovalToFinish = true
+				// Only block the reconcile while the CC task is actively progressing. When it has
+				// stalled (CompletedWithError/Paused) there is no in-flight work a broker restart
+				// could disrupt, and the removed disk stays in log.dirs and mounted until removal
+				// is confirmed succeeded (shouldKeepRemovedLogDirInConfig), so proceeding is
+				// data-safe. Blocking on a stalled task would freeze rolling upgrades indefinitely.
+				if ccVolumeState.IsDiskOperationStalled() {
+					log.Info("Graceful disk removal is not progressing (error/paused); not blocking reconcile",
+						"brokerId", brokerId, mountPathAnnotationKey, mountPathToRemove, "volumeState", ccVolumeState)
+				} else {
+					log.Info("Graceful disk removal is in progress", "brokerId", brokerId, mountPathAnnotationKey, mountPathToRemove)
+					waitForDiskRemovalToFinish = true
+				}
 			case ccVolumeState.IsDiskRebalance():
-				log.Info("Graceful disk rebalance is in progress, waiting for it to finish before marking disk for removal", "brokerId", brokerId, mountPathAnnotationKey, mountPathToRemove)
-				waitForDiskRemovalToFinish = true
+				if ccVolumeState.IsDiskOperationStalled() {
+					log.Info("Graceful disk rebalance is not progressing (error/paused); not blocking reconcile",
+						"brokerId", brokerId, mountPathAnnotationKey, mountPathToRemove, "volumeState", ccVolumeState)
+				} else {
+					log.Info("Graceful disk rebalance is in progress, waiting for it to finish before marking disk for removal", "brokerId", brokerId, mountPathAnnotationKey, mountPathToRemove)
+					waitForDiskRemovalToFinish = true
+				}
 			default:
 				brokerVolumesState[mountPathToRemove] = banzaiv1beta1.VolumeState{CruiseControlVolumeState: banzaiv1beta1.GracefulDiskRemovalRequired}
 				log.Info("Marked the volume for removal", "brokerId", brokerId, mountPathAnnotationKey, mountPathToRemove)

--- a/pkg/resources/kafka/kafka.go
+++ b/pkg/resources/kafka/kafka.go
@@ -327,13 +327,6 @@ func (r *Reconciler) Reconcile(log logr.Logger) error {
 			brokersVolumes[strconv.Itoa(int(broker.Id))] = brokerVolumes
 		}
 	}
-	if len(brokersVolumes) > 0 {
-		err := r.reconcileKafkaPvc(ctx, log, brokersVolumes)
-		if err != nil {
-			return errors.WrapIfWithDetails(err, "failed to reconcile resource", "resources", "PersistentVolumeClaim")
-		}
-	}
-
 	var brokerPods corev1.PodList
 	matchingLabels := client.MatchingLabels(apiutil.LabelsForKafka(r.KafkaCluster.Name))
 	err = r.List(ctx, &brokerPods, client.ListOption(client.InNamespace(r.KafkaCluster.Namespace)), client.ListOption(matchingLabels))
@@ -345,6 +338,13 @@ func (r *Reconciler) Reconcile(log logr.Logger) error {
 	for _, b := range brokerPods.Items {
 		brokerID := b.GetLabels()[banzaiv1beta1.BrokerIdLabelKey]
 		runningBrokers[brokerID] = struct{}{}
+	}
+
+	if len(brokersVolumes) > 0 {
+		err := r.reconcileKafkaPvc(ctx, log, brokersVolumes, runningBrokers)
+		if err != nil {
+			return errors.WrapIfWithDetails(err, "failed to reconcile resource", "resources", "PersistentVolumeClaim")
+		}
 	}
 
 	var pvcList corev1.PersistentVolumeClaimList
@@ -1203,7 +1203,7 @@ func (r *Reconciler) isPodTainted(log logr.Logger, pod *corev1.Pod) bool {
 }
 
 //nolint:funlen
-func (r *Reconciler) reconcileKafkaPvc(ctx context.Context, log logr.Logger, brokersDesiredPvcs map[string][]*corev1.PersistentVolumeClaim) error {
+func (r *Reconciler) reconcileKafkaPvc(ctx context.Context, log logr.Logger, brokersDesiredPvcs map[string][]*corev1.PersistentVolumeClaim, runningBrokers map[string]struct{}) error {
 	brokersVolumesState := make(map[string]map[string]banzaiv1beta1.VolumeState)
 	var brokerIds []string
 	waitForDiskRemovalToFinish := false
@@ -1342,6 +1342,23 @@ func (r *Reconciler) reconcileKafkaPvc(ctx context.Context, log logr.Logger, bro
 	}
 
 	if waitForDiskRemovalToFinish {
+		// Don't block if any broker with pending disk removal has a missing pod.
+		// Blocking prevents pod recreation, creating a deadlock where CC can't
+		// complete the disk removal because the broker isn't running.
+		for brokerId := range brokersDesiredPvcs {
+			if _, podExists := runningBrokers[brokerId]; !podExists {
+				if brokerState, ok := r.KafkaCluster.Status.BrokersState[brokerId]; ok {
+					for _, volumeState := range brokerState.GracefulActionState.VolumeStates {
+						if volumeState.CruiseControlVolumeState.IsDiskRemoval() {
+							log.Info("Disk removal pending but broker pod is missing, "+
+								"allowing reconcile to proceed for pod recreation",
+								"brokerId", brokerId)
+							return nil
+						}
+					}
+				}
+			}
+		}
 		return errorfactory.New(errorfactory.CruiseControlTaskRunning{}, errors.New("Disk removal pending"), "Disk removal pending")
 	}
 

--- a/pkg/resources/kafka/kafka.go
+++ b/pkg/resources/kafka/kafka.go
@@ -1342,17 +1342,17 @@ func (r *Reconciler) reconcileKafkaPvc(ctx context.Context, log logr.Logger, bro
 	}
 
 	if waitForDiskRemovalToFinish {
-		// Don't block if any broker with pending disk removal has a missing pod.
+		// Don't block if any broker with pending disk removal/rebalance has a missing pod.
 		// Blocking prevents pod recreation, creating a deadlock where CC can't
-		// complete the disk removal because the broker isn't running.
+		// complete the disk removal or rebalance because the broker isn't running.
 		for brokerId := range brokersDesiredPvcs {
 			if _, podExists := runningBrokers[brokerId]; !podExists {
 				if brokerState, ok := r.KafkaCluster.Status.BrokersState[brokerId]; ok {
-					for _, volumeState := range brokerState.GracefulActionState.VolumeStates {
-						if volumeState.CruiseControlVolumeState.IsDiskRemoval() {
+					for mountPath, volumeState := range brokerState.GracefulActionState.VolumeStates {
+						if volumeState.CruiseControlVolumeState.IsDiskRemoval() || volumeState.CruiseControlVolumeState.IsDiskRebalance() {
 							log.Info("Disk removal pending but broker pod is missing, "+
 								"allowing reconcile to proceed for pod recreation",
-								"brokerId", brokerId)
+								"brokerId", brokerId, "mountPath", mountPath)
 							return nil
 						}
 					}

--- a/pkg/resources/kafka/kafka_test.go
+++ b/pkg/resources/kafka/kafka_test.go
@@ -47,6 +47,7 @@ type PvcTestCase struct {
 	testName            string
 	brokersDesiredPvcs  map[string][]*corev1.PersistentVolumeClaim
 	existingPvcs        []*corev1.PersistentVolumeClaim
+	runningBrokers      map[string]struct{}
 	kafkaClusterSpec    v1beta1.KafkaClusterSpec
 	kafkaClusterStatus  v1beta1.KafkaClusterStatus
 	expectedError       bool
@@ -1002,6 +1003,7 @@ func TestReconcileKafkaPvcDiskRemoval(t *testing.T) {
 				createPvc("test-pvc-1", "0", "/path/to/mount1"),
 				createPvc("test-pvc-2", "0", "/path/to/mount2"),
 			},
+			runningBrokers: map[string]struct{}{"0": {}},
 			kafkaClusterStatus: v1beta1.KafkaClusterStatus{
 				BrokersState: map[string]v1beta1.BrokerState{
 					"0": {
@@ -1032,6 +1034,7 @@ func TestReconcileKafkaPvcDiskRemoval(t *testing.T) {
 				createPvc("test-pvc-1", "0", "/path/to/mount1"),
 				createPvc("test-pvc-2", "0", "/path/to/mount2"),
 			},
+			runningBrokers: map[string]struct{}{"0": {}},
 			kafkaClusterStatus: v1beta1.KafkaClusterStatus{
 				BrokersState: map[string]v1beta1.BrokerState{
 					"0": {
@@ -1062,6 +1065,7 @@ func TestReconcileKafkaPvcDiskRemoval(t *testing.T) {
 				createPvc("test-pvc-1", "0", "/path/to/mount1"),
 				createPvc("test-pvc-2", "0", "/path/to/mount2"),
 			},
+			runningBrokers: map[string]struct{}{"0": {}},
 			kafkaClusterStatus: v1beta1.KafkaClusterStatus{
 				BrokersState: map[string]v1beta1.BrokerState{
 					"0": {
@@ -1079,6 +1083,37 @@ func TestReconcileKafkaPvcDiskRemoval(t *testing.T) {
 			expectedDeletePvc: false,
 			expectedVolumeState: map[string]v1beta1.CruiseControlVolumeState{
 				"/path/to/mount2": v1beta1.GracefulDiskRemovalRunning,
+			},
+		},
+		{
+			testName: "Disk removal pending but broker pod missing - allow reconcile to proceed",
+			brokersDesiredPvcs: map[string][]*corev1.PersistentVolumeClaim{
+				"0": {
+					createPvc("test-pvc-1", "0", "/path/to/mount1"),
+				},
+			},
+			existingPvcs: []*corev1.PersistentVolumeClaim{
+				createPvc("test-pvc-1", "0", "/path/to/mount1"),
+				createPvc("test-pvc-2", "0", "/path/to/mount2"),
+			},
+			runningBrokers: map[string]struct{}{}, // broker pod is missing
+			kafkaClusterStatus: v1beta1.KafkaClusterStatus{
+				BrokersState: map[string]v1beta1.BrokerState{
+					"0": {
+						GracefulActionState: v1beta1.GracefulActionState{
+							VolumeStates: map[string]v1beta1.VolumeState{
+								"/path/to/mount2": {
+									CruiseControlVolumeState: v1beta1.GracefulDiskRemovalScheduled,
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedError:     false,
+			expectedDeletePvc: false,
+			expectedVolumeState: map[string]v1beta1.CruiseControlVolumeState{
+				"/path/to/mount2": v1beta1.GracefulDiskRemovalScheduled,
 			},
 		},
 		{
@@ -1291,8 +1326,12 @@ func execPvcTest(t *testing.T, testCases []PvcTestCase) {
 			// Set up the r.KafkaCluster.Status with the provided test.kafkaClusterStatus
 			r.KafkaCluster.Status = test.kafkaClusterStatus
 
+			runningBrokers := test.runningBrokers
+			if runningBrokers == nil {
+				runningBrokers = make(map[string]struct{})
+			}
 			// Call the reconcileKafkaPvc function with the provided test.brokersDesiredPvcs
-			err := r.reconcileKafkaPvc(context.TODO(), logf.Log, test.brokersDesiredPvcs)
+			err := r.reconcileKafkaPvc(context.TODO(), logf.Log, test.brokersDesiredPvcs, runningBrokers)
 
 			// Test that the expected error is returned
 			if test.expectedError {

--- a/pkg/resources/kafka/kafka_test.go
+++ b/pkg/resources/kafka/kafka_test.go
@@ -1117,6 +1117,71 @@ func TestReconcileKafkaPvcDiskRemoval(t *testing.T) {
 			},
 		},
 		{
+			testName: "Disk rebalance pending but broker pod missing - allow reconcile to proceed",
+			brokersDesiredPvcs: map[string][]*corev1.PersistentVolumeClaim{
+				"0": {
+					createPvc("test-pvc-1", "0", "/path/to/mount1"),
+				},
+			},
+			existingPvcs: []*corev1.PersistentVolumeClaim{
+				createPvc("test-pvc-1", "0", "/path/to/mount1"),
+				createPvc("test-pvc-2", "0", "/path/to/mount2"),
+			},
+			runningBrokers: map[string]struct{}{}, // broker pod is missing
+			kafkaClusterStatus: v1beta1.KafkaClusterStatus{
+				BrokersState: map[string]v1beta1.BrokerState{
+					"0": {
+						GracefulActionState: v1beta1.GracefulActionState{
+							VolumeStates: map[string]v1beta1.VolumeState{
+								"/path/to/mount2": {
+									CruiseControlVolumeState: v1beta1.GracefulDiskRebalanceScheduled,
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedError:     false,
+			expectedDeletePvc: false,
+			expectedVolumeState: map[string]v1beta1.CruiseControlVolumeState{
+				"/path/to/mount2": v1beta1.GracefulDiskRebalanceScheduled,
+			},
+		},
+		{
+			testName: "Disk newly marked for removal with pod missing - allow reconcile to proceed",
+			brokersDesiredPvcs: map[string][]*corev1.PersistentVolumeClaim{
+				"0": {
+					createPvc("test-pvc-1", "0", "/path/to/mount1"),
+				},
+			},
+			existingPvcs: []*corev1.PersistentVolumeClaim{
+				createPvc("test-pvc-1", "0", "/path/to/mount1"),
+				createPvc("test-pvc-2", "0", "/path/to/mount2"),
+			},
+			runningBrokers: map[string]struct{}{}, // broker pod is missing
+			kafkaClusterStatus: v1beta1.KafkaClusterStatus{
+				BrokersState: map[string]v1beta1.BrokerState{
+					"0": {
+						GracefulActionState: v1beta1.GracefulActionState{
+							VolumeStates: map[string]v1beta1.VolumeState{
+								"/path/to/mount2": {
+									// GracefulDiskRebalanceSucceeded triggers the default case in
+									// handleDiskRemoval which marks GracefulDiskRemovalRequired.
+									// With pod missing, the override should still allow proceeding.
+									CruiseControlVolumeState: v1beta1.GracefulDiskRebalanceSucceeded,
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedError:     false,
+			expectedDeletePvc: false,
+			expectedVolumeState: map[string]v1beta1.CruiseControlVolumeState{
+				"/path/to/mount2": v1beta1.GracefulDiskRemovalRequired,
+			},
+		},
+		{
 			testName: "If disk removal successful, do not return error and delete pvc and volume state",
 			brokersDesiredPvcs: map[string][]*corev1.PersistentVolumeClaim{
 				"0": {

--- a/pkg/resources/kafka/kafka_test.go
+++ b/pkg/resources/kafka/kafka_test.go
@@ -1018,7 +1018,7 @@ func TestGetServerPasswordKeysAndUsers(t *testing.T) { //nolint funlen
 	}
 }
 
-func TestReconcileKafkaPvcDiskRemoval(t *testing.T) {
+func TestReconcileKafkaPvcDiskRemoval(t *testing.T) { //nolint:funlen
 	t.Parallel()
 	testCases := []PvcTestCase{
 		{

--- a/pkg/resources/kafka/kafka_test.go
+++ b/pkg/resources/kafka/kafka_test.go
@@ -47,6 +47,7 @@ type PvcTestCase struct {
 	testName            string
 	brokersDesiredPvcs  map[string][]*corev1.PersistentVolumeClaim
 	existingPvcs        []*corev1.PersistentVolumeClaim
+	runningBrokers      map[string]struct{}
 	kafkaClusterSpec    v1beta1.KafkaClusterSpec
 	kafkaClusterStatus  v1beta1.KafkaClusterStatus
 	expectedError       bool
@@ -1048,6 +1049,7 @@ func TestReconcileKafkaPvcDiskRemoval(t *testing.T) {
 				createPvc("test-pvc-1", "0", "/path/to/mount1"),
 				createPvc("test-pvc-2", "0", "/path/to/mount2"),
 			},
+			runningBrokers: map[string]struct{}{"0": {}},
 			kafkaClusterStatus: v1beta1.KafkaClusterStatus{
 				BrokersState: map[string]v1beta1.BrokerState{
 					"0": {
@@ -1078,6 +1080,7 @@ func TestReconcileKafkaPvcDiskRemoval(t *testing.T) {
 				createPvc("test-pvc-1", "0", "/path/to/mount1"),
 				createPvc("test-pvc-2", "0", "/path/to/mount2"),
 			},
+			runningBrokers: map[string]struct{}{"0": {}},
 			kafkaClusterStatus: v1beta1.KafkaClusterStatus{
 				BrokersState: map[string]v1beta1.BrokerState{
 					"0": {
@@ -1108,6 +1111,7 @@ func TestReconcileKafkaPvcDiskRemoval(t *testing.T) {
 				createPvc("test-pvc-1", "0", "/path/to/mount1"),
 				createPvc("test-pvc-2", "0", "/path/to/mount2"),
 			},
+			runningBrokers: map[string]struct{}{"0": {}},
 			kafkaClusterStatus: v1beta1.KafkaClusterStatus{
 				BrokersState: map[string]v1beta1.BrokerState{
 					"0": {
@@ -1125,6 +1129,37 @@ func TestReconcileKafkaPvcDiskRemoval(t *testing.T) {
 			expectedDeletePvc: false,
 			expectedVolumeState: map[string]v1beta1.CruiseControlVolumeState{
 				"/path/to/mount2": v1beta1.GracefulDiskRemovalRunning,
+			},
+		},
+		{
+			testName: "Disk removal pending but broker pod missing - allow reconcile to proceed",
+			brokersDesiredPvcs: map[string][]*corev1.PersistentVolumeClaim{
+				"0": {
+					createPvc("test-pvc-1", "0", "/path/to/mount1"),
+				},
+			},
+			existingPvcs: []*corev1.PersistentVolumeClaim{
+				createPvc("test-pvc-1", "0", "/path/to/mount1"),
+				createPvc("test-pvc-2", "0", "/path/to/mount2"),
+			},
+			runningBrokers: map[string]struct{}{}, // broker pod is missing
+			kafkaClusterStatus: v1beta1.KafkaClusterStatus{
+				BrokersState: map[string]v1beta1.BrokerState{
+					"0": {
+						GracefulActionState: v1beta1.GracefulActionState{
+							VolumeStates: map[string]v1beta1.VolumeState{
+								"/path/to/mount2": {
+									CruiseControlVolumeState: v1beta1.GracefulDiskRemovalScheduled,
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedError:     false,
+			expectedDeletePvc: false,
+			expectedVolumeState: map[string]v1beta1.CruiseControlVolumeState{
+				"/path/to/mount2": v1beta1.GracefulDiskRemovalScheduled,
 			},
 		},
 		{
@@ -1337,8 +1372,12 @@ func execPvcTest(t *testing.T, testCases []PvcTestCase) {
 			// Set up the r.KafkaCluster.Status with the provided test.kafkaClusterStatus
 			r.KafkaCluster.Status = test.kafkaClusterStatus
 
+			runningBrokers := test.runningBrokers
+			if runningBrokers == nil {
+				runningBrokers = make(map[string]struct{})
+			}
 			// Call the reconcileKafkaPvc function with the provided test.brokersDesiredPvcs
-			err := r.reconcileKafkaPvc(context.TODO(), logf.Log, test.brokersDesiredPvcs)
+			err := r.reconcileKafkaPvc(context.TODO(), logf.Log, test.brokersDesiredPvcs, runningBrokers)
 
 			// Test that the expected error is returned
 			if test.expectedError {

--- a/pkg/resources/kafka/kafka_test.go
+++ b/pkg/resources/kafka/kafka_test.go
@@ -1163,6 +1163,71 @@ func TestReconcileKafkaPvcDiskRemoval(t *testing.T) {
 			},
 		},
 		{
+			testName: "Disk rebalance pending but broker pod missing - allow reconcile to proceed",
+			brokersDesiredPvcs: map[string][]*corev1.PersistentVolumeClaim{
+				"0": {
+					createPvc("test-pvc-1", "0", "/path/to/mount1"),
+				},
+			},
+			existingPvcs: []*corev1.PersistentVolumeClaim{
+				createPvc("test-pvc-1", "0", "/path/to/mount1"),
+				createPvc("test-pvc-2", "0", "/path/to/mount2"),
+			},
+			runningBrokers: map[string]struct{}{}, // broker pod is missing
+			kafkaClusterStatus: v1beta1.KafkaClusterStatus{
+				BrokersState: map[string]v1beta1.BrokerState{
+					"0": {
+						GracefulActionState: v1beta1.GracefulActionState{
+							VolumeStates: map[string]v1beta1.VolumeState{
+								"/path/to/mount2": {
+									CruiseControlVolumeState: v1beta1.GracefulDiskRebalanceScheduled,
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedError:     false,
+			expectedDeletePvc: false,
+			expectedVolumeState: map[string]v1beta1.CruiseControlVolumeState{
+				"/path/to/mount2": v1beta1.GracefulDiskRebalanceScheduled,
+			},
+		},
+		{
+			testName: "Disk newly marked for removal with pod missing - allow reconcile to proceed",
+			brokersDesiredPvcs: map[string][]*corev1.PersistentVolumeClaim{
+				"0": {
+					createPvc("test-pvc-1", "0", "/path/to/mount1"),
+				},
+			},
+			existingPvcs: []*corev1.PersistentVolumeClaim{
+				createPvc("test-pvc-1", "0", "/path/to/mount1"),
+				createPvc("test-pvc-2", "0", "/path/to/mount2"),
+			},
+			runningBrokers: map[string]struct{}{}, // broker pod is missing
+			kafkaClusterStatus: v1beta1.KafkaClusterStatus{
+				BrokersState: map[string]v1beta1.BrokerState{
+					"0": {
+						GracefulActionState: v1beta1.GracefulActionState{
+							VolumeStates: map[string]v1beta1.VolumeState{
+								"/path/to/mount2": {
+									// GracefulDiskRebalanceSucceeded triggers the default case in
+									// handleDiskRemoval which marks GracefulDiskRemovalRequired.
+									// With pod missing, the override should still allow proceeding.
+									CruiseControlVolumeState: v1beta1.GracefulDiskRebalanceSucceeded,
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedError:     false,
+			expectedDeletePvc: false,
+			expectedVolumeState: map[string]v1beta1.CruiseControlVolumeState{
+				"/path/to/mount2": v1beta1.GracefulDiskRemovalRequired,
+			},
+		},
+		{
 			testName: "If disk removal successful, do not return error and delete pvc and volume state",
 			brokersDesiredPvcs: map[string][]*corev1.PersistentVolumeClaim{
 				"0": {

--- a/pkg/resources/kafka/kafka_test.go
+++ b/pkg/resources/kafka/kafka_test.go
@@ -1286,6 +1286,99 @@ func TestReconcileKafkaPvcDiskRemoval(t *testing.T) {
 				"/path/to/mount2": v1beta1.GracefulDiskRebalanceRequired,
 			},
 		},
+		{
+			testName: "Disk removal failed (CompletedWithError) with pod present - do not block",
+			brokersDesiredPvcs: map[string][]*corev1.PersistentVolumeClaim{
+				"0": {
+					createPvc("test-pvc-1", "0", "/path/to/mount1"),
+				},
+			},
+			existingPvcs: []*corev1.PersistentVolumeClaim{
+				createPvc("test-pvc-1", "0", "/path/to/mount1"),
+				createPvc("test-pvc-2", "0", "/path/to/mount2"),
+			},
+			runningBrokers: map[string]struct{}{"0": {}}, // pod present - old behavior would BLOCK
+			kafkaClusterStatus: v1beta1.KafkaClusterStatus{
+				BrokersState: map[string]v1beta1.BrokerState{
+					"0": {
+						GracefulActionState: v1beta1.GracefulActionState{
+							VolumeStates: map[string]v1beta1.VolumeState{
+								"/path/to/mount2": {
+									CruiseControlVolumeState: v1beta1.GracefulDiskRemovalCompletedWithError,
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedError:     false, // stalled task must not freeze the reconcile
+			expectedDeletePvc: false,
+			expectedVolumeState: map[string]v1beta1.CruiseControlVolumeState{
+				"/path/to/mount2": v1beta1.GracefulDiskRemovalCompletedWithError,
+			},
+		},
+		{
+			testName: "Disk removal paused with pod present - do not block",
+			brokersDesiredPvcs: map[string][]*corev1.PersistentVolumeClaim{
+				"0": {
+					createPvc("test-pvc-1", "0", "/path/to/mount1"),
+				},
+			},
+			existingPvcs: []*corev1.PersistentVolumeClaim{
+				createPvc("test-pvc-1", "0", "/path/to/mount1"),
+				createPvc("test-pvc-2", "0", "/path/to/mount2"),
+			},
+			runningBrokers: map[string]struct{}{"0": {}},
+			kafkaClusterStatus: v1beta1.KafkaClusterStatus{
+				BrokersState: map[string]v1beta1.BrokerState{
+					"0": {
+						GracefulActionState: v1beta1.GracefulActionState{
+							VolumeStates: map[string]v1beta1.VolumeState{
+								"/path/to/mount2": {
+									CruiseControlVolumeState: v1beta1.GracefulDiskRemovalPaused,
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedError:     false,
+			expectedDeletePvc: false,
+			expectedVolumeState: map[string]v1beta1.CruiseControlVolumeState{
+				"/path/to/mount2": v1beta1.GracefulDiskRemovalPaused,
+			},
+		},
+		{
+			testName: "Disk rebalance failed (CompletedWithError) with pod present - do not block",
+			brokersDesiredPvcs: map[string][]*corev1.PersistentVolumeClaim{
+				"0": {
+					createPvc("test-pvc-1", "0", "/path/to/mount1"),
+				},
+			},
+			existingPvcs: []*corev1.PersistentVolumeClaim{
+				createPvc("test-pvc-1", "0", "/path/to/mount1"),
+				createPvc("test-pvc-2", "0", "/path/to/mount2"),
+			},
+			runningBrokers: map[string]struct{}{"0": {}},
+			kafkaClusterStatus: v1beta1.KafkaClusterStatus{
+				BrokersState: map[string]v1beta1.BrokerState{
+					"0": {
+						GracefulActionState: v1beta1.GracefulActionState{
+							VolumeStates: map[string]v1beta1.VolumeState{
+								"/path/to/mount2": {
+									CruiseControlVolumeState: v1beta1.GracefulDiskRebalanceCompletedWithError,
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedError:     false,
+			expectedDeletePvc: false,
+			expectedVolumeState: map[string]v1beta1.CruiseControlVolumeState{
+				"/path/to/mount2": v1beta1.GracefulDiskRebalanceCompletedWithError,
+			},
+		},
 	}
 
 	execPvcTest(t, testCases)

--- a/tests/e2e/koperator_suite_test.go
+++ b/tests/e2e/koperator_suite_test.go
@@ -84,6 +84,7 @@ var _ = ginkgo.When("Testing e2e test altogether", ginkgo.Ordered, func() {
 	testUninstallKafkaCluster()
 	testInstallKafkaCluster("../../config/samples/simplekafkacluster_4disk.yaml")
 	testMultiDiskRemoval()
+	testConfigChangeWithDiskRemoval()
 	testUninstallKafkaCluster()
 	testInstallKafkaCluster("../../config/samples/simplekafkacluster_5broker.yaml")
 	testBatchedBrokerRemoval()

--- a/tests/e2e/test_config_change_with_disk_removal.go
+++ b/tests/e2e/test_config_change_with_disk_removal.go
@@ -1,0 +1,151 @@
+// Copyright 2025 Adobe. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	ginkgo "github.com/onsi/ginkgo/v2"
+	gomega "github.com/onsi/gomega"
+
+	kafkautils "github.com/banzaicloud/koperator/pkg/util/kafka"
+)
+
+const (
+	// This scenario waits for both a disk removal (Cruise Control rebalance + removal) and a
+	// rolling restart, so it can take long — reuse the multidisk timeout budget.
+	configChangeDiskRemovalTimeout      = 1800 * time.Second
+	configChangeDiskRemovalPollInterval = 5 * time.Second
+
+	// A read-only broker property changed together with the disk removal. Read-only properties
+	// require a rolling restart, so its presence in the broker ConfigMap plus the cluster
+	// returning to ClusterRunning proves the config change was reconciled (not just written).
+	// Non-default value (Kafka default for log.retention.hours is 168).
+	configChangeProperty = "log.retention.hours=170"
+)
+
+// configChangeRemovedLogDirPath is the log dir dropped by simplekafkacluster_1disk_configchange.yaml
+// (it keeps only /kafka-logs1). This test chains after testMultiDiskRemoval, which leaves the cluster
+// with /kafka-logs1 and /kafka-logs3.
+var configChangeRemovedLogDirPath = []string{"/kafka-logs3/kafka"}
+
+// testConfigChangeWithDiskRemoval applies a single manifest that BOTH changes a read-only broker
+// config property (forcing a rolling restart) AND removes a disk. This is the scenario that
+// previously deadlocked: reconcileKafkaPvc blocked the whole reconcile on the pending disk removal,
+// so reconcileKafkaPod never ran to restart the brokers for the config change, and the cluster was
+// stuck in ClusterRollingUpgrading indefinitely. The test asserts the cluster reconciles correctly:
+// the config change propagates, the disk is removed, Cruise Control goes quiescent, and the cluster
+// returns to ClusterRunning within the timeout (a deadlock would make the final wait time out).
+func testConfigChangeWithDiskRemoval() bool {
+	return ginkgo.When("Config change + disk removal in one manifest: cluster reconciles correctly", func() {
+		var kubectlOptions k8s.KubectlOptions
+		var err error
+
+		ginkgo.It("Acquiring K8s config and context", func() {
+			kubectlOptions, err = kubectlOptionsForCurrentContext()
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			kubectlOptions.Namespace = koperatorLocalHelmDescriptor.Namespace
+		})
+
+		ginkgo.It("Applying manifest that changes broker config AND removes a disk", func() {
+			ginkgo.By("Patching KafkaCluster: single storageConfig (removes /kafka-logs3) + changed readOnlyConfig")
+			applyK8sResourceManifest(kubectlOptions, "../../config/samples/simplekafkacluster_1disk_configchange.yaml")
+		})
+
+		ginkgo.It("Waiting for the broker config change to propagate to broker ConfigMaps", func() {
+			ginkgo.By(fmt.Sprintf("Waiting until all broker ConfigMaps contain %q", configChangeProperty))
+			gomega.Eventually(context.Background(), func() (bool, error) {
+				return brokerConfigMapsContainProperty(kubectlOptions, kafkaClusterName, configChangeProperty)
+			}, configChangeDiskRemovalTimeout, configChangeDiskRemovalPollInterval).Should(gomega.BeTrue())
+		})
+
+		ginkgo.It("Waiting for disk removal and PVC cleanup (log.dirs excludes removed path)", func() {
+			ginkgo.By("Waiting until broker ConfigMaps' log.dirs no longer contain the removed path")
+			gomega.Eventually(context.Background(), func() (bool, error) {
+				return brokerConfigMapsLogDirsExcludePath(kubectlOptions, kafkaClusterName, configChangeRemovedLogDirPath)
+			}, configChangeDiskRemovalTimeout, configChangeDiskRemovalPollInterval).Should(gomega.BeTrue())
+		})
+
+		ginkgo.It("Waiting for the Cruise Control disk removal to complete", func() {
+			ginkgo.By("Waiting until no Cruise Control operation is in flight")
+			gomega.Eventually(context.Background(), func() (bool, error) {
+				return hasNoInFlightCruiseControlOperation(kubectlOptions)
+			}, configChangeDiskRemovalTimeout, configChangeDiskRemovalPollInterval).Should(gomega.BeTrue())
+		})
+
+		ginkgo.It("Asserting the cluster reconciles to ClusterRunning (no deadlock)", func() {
+			// The core regression assertion: a config change while a disk removal is pending must not
+			// wedge the reconcile. If the deadlock regressed, the cluster would stay in
+			// ClusterRollingUpgrading and this wait would time out.
+			err := waitForKafkaClusterWithPodStatusCheck(kubectlOptions, kafkaClusterName, kafkaClusterResourceReadinessTimeout)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("Asserting broker ConfigMaps still carry the config change and not the removed disk", func() {
+			hasProperty, err := brokerConfigMapsContainProperty(kubectlOptions, kafkaClusterName, configChangeProperty)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(hasProperty).To(gomega.BeTrue(), "broker config must contain %q after reconcile", configChangeProperty)
+
+			exclude, err := brokerConfigMapsLogDirsExcludePath(kubectlOptions, kafkaClusterName, configChangeRemovedLogDirPath)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(exclude).To(gomega.BeTrue(), "broker log.dirs must not contain removed path %s", configChangeRemovedLogDirPath)
+		})
+	})
+}
+
+// brokerConfigMapsContainProperty returns true if every broker ConfigMap's broker-config contains
+// the given "key=value" property line.
+func brokerConfigMapsContainProperty(kubectlOptions k8s.KubectlOptions, clusterName string, property string) (bool, error) {
+	for _, brokerID := range []int{0, 1, 2} {
+		configMapName := fmt.Sprintf(brokerConfigTemplateFormat, clusterName, brokerID)
+		contains, err := brokerConfigMapContainsProperty(kubectlOptions, configMapName, kubectlOptions.Namespace, property)
+		if err != nil {
+			return false, err
+		}
+		if !contains {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+// brokerConfigMapContainsProperty returns true if the broker ConfigMap's broker-config data contains
+// the given "key=value" property line (whitespace-trimmed, exact match).
+func brokerConfigMapContainsProperty(kubectlOptions k8s.KubectlOptions, configMapName string, namespace string, property string) (bool, error) {
+	args := []string{
+		"get", "configmap", configMapName,
+		"-n", namespace,
+		"-o", fmt.Sprintf("jsonpath={.data.%s}", kafkautils.ConfigPropertyName),
+	}
+	// Fetch broker-config silently: it is the entire multi-line broker configuration and this runs on
+	// every poll iteration for each broker, so logging the full value would flood the output.
+	output, err := runKubectlSilent(kubectlOptions, args...)
+	if err != nil {
+		return false, fmt.Errorf("getting configmap %s: %w", configMapName, err)
+	}
+	want := strings.TrimSpace(property)
+	for _, line := range strings.Split(output, "\n") {
+		if strings.TrimSpace(line) == want {
+			return true, nil
+		}
+	}
+	return false, nil
+}


### PR DESCRIPTION
## Problem

Two related deadlocks left clusters stuck in ClusterRollingUpgrading indefinitely, because reconcileKafkaPvc aborts the entire reconcile with CruiseControlTaskRunning ("Disk removal pending") before reconcileKafkaPod — which creates/restarts pods — ever runs.

1. Missing pod + pending removal (original report): a broker pod deleted during a rolling upgrade while a disk removal is pending is never recreated. Cruise Control can't finish the removal (it needs the broker running), and the block prevents the pod from coming back. Observed in production: broker 103 of a 9-broker cluster deleted and never recreated, looping every ~20s for 10+ minutes.
2. Stalled removal + pods present (found via a second live incident): with all pods up but the CC removal task terminally failed, the reconcile stays frozen forever. GracefulDisk{Removal,Rebalance}CompletedWithError / Paused are bucketed under IsDiskRemovalRunning() (common_types.go:83), so a failed task is treated as in-progress and blocks config rollout to healthy brokers. Observed on a 3-broker cluster with every removed disk in GracefulDiskRemovalCompletedWithError, ConfigOutOfSync brokers unable to restart.

## Fix

(1) Missing-pod bypass — build runningBrokers before reconcileKafkaPvc and pass it in; before returning the blocking error, if a broker with pending removal/rebalance has no pod, return nil so the pod can be recreated.

(2) Narrow the blocking wait — add CruiseControlVolumeState.IsDiskOperationStalled() (CompletedWithError / Paused, mirroring IsDownscaleStalled) and, in handleDiskRemoval, set waitForDiskRemovalToFinish only for genuinely-progressing states. Branch selection (PVC deletion, state marking) is unchanged.

The two are complementary.

Why relaxing the block is data-safe

The block is not what protects log.dirs integrity — two independent mechanisms already do, both keyed off success, not the desired spec:

- log.dirs retention (shouldKeepRemovedLogDirInConfig, configmap.go:312-335): the removed disk stays in log.dirs until the state is …Succeeded; the KRaft path's shrink (configmap.go:202) is overwritten by the protective merge (configmap.go:90-97).
- PVC mount retention (pod.go:438, getCreatedPvcForBroker): the pod mounts all existing PVCs; the removed disk's PVC is deleted only on IsDiskRemovalSucceeded().

So a ConfigOutOfSync broker can restart mid-removal with the disk still in log.dirs and mounted — no stranded data.

Verified against Cruise Control source: remove_disks runs as intra-broker replica movement; a dead broker causes CC to mark the task DEAD ("destination disk is down", Executor.java:2145-2151) and complete — it does not hang in execution — so a stalled state is genuinely terminal, not in-flight work a restart could disrupt.

## Testing

- go build ./..., go vet, and unit tests pass in both modules (main + api/v1beta1).
- New TestReconcileKafkaPvcDiskRemoval cases: removal CompletedWithError, removal Paused, and rebalance CompletedWithError with pod present now proceed; Running + pod present still blocks (regression guard); existing missing-pod cases unchanged.

Not in scope

Driving a CompletedWithError removal to actually retry/succeed (vs. just no longer blocking) — a follow-up in the CC task reconciler.

## Type of Change
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
