### PR TITLE
test(e2e): de-flake & ~2x speed up multi-disk removal; failure diagnostics; CC getStatus nil-panic fix

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -87,3 +87,39 @@ jobs:
           # Clean any existing go.work files to avoid workspace conflicts
           rm -f go.work go.work.sum
           IMG_E2E=$REPOSITORY:$GITHUB_SHA make test-e2e
+
+      # Dump cluster diagnostics on failure so e2e failures (e.g. a dependency Helm
+      # install that times out under `--atomic`) are debuggable from the job log
+      # without needing a live tmate session.
+      - name: Dump diagnostics on failure
+        if: failure()
+        env:
+          KUBECONFIG: ${{ steps.setup-kind.outputs.kubeconfig }}
+        run: |
+          set +e
+          echo "::group::nodes"
+          kubectl get nodes -o wide
+          echo "::endgroup::"
+          echo "::group::all pods"
+          kubectl get pods -A -o wide
+          echo "::endgroup::"
+          for ns in cert-manager projectcontour zookeeper prometheus kafka; do
+            echo "::group::namespace ${ns}"
+            kubectl get pods -n "${ns}" -o wide
+            echo "----- events (${ns}) -----"
+            kubectl get events -n "${ns}" --sort-by=.lastTimestamp | tail -50
+            echo "----- describe pods (${ns}) -----"
+            kubectl describe pods -n "${ns}"
+            echo "----- container logs (${ns}) -----"
+            for pod in $(kubectl get pods -n "${ns}" -o name); do
+              echo ">>> ${pod} (current) <<<"
+              kubectl logs -n "${ns}" "${pod}" --all-containers --tail=150 --timestamps
+              echo ">>> ${pod} (previous, if the container restarted) <<<"
+              kubectl logs -n "${ns}" "${pod}" --all-containers --previous --tail=150 --timestamps
+            done
+            echo "::endgroup::"
+          done
+          echo "::group::warning events (all namespaces)"
+          kubectl get events -A --field-selector type=Warning --sort-by=.lastTimestamp | tail -80
+          echo "::endgroup::"
+          exit 0

--- a/config/samples/simplekafkacluster_2disk.yaml
+++ b/config/samples/simplekafkacluster_2disk.yaml
@@ -19,6 +19,8 @@ spec:
     cruise.control.metrics.topic.auto.create=true
     cruise.control.metrics.topic.num.partitions=1
     cruise.control.metrics.topic.replication.factor=2
+    # e2e: publish CruiseControl metrics every 15s (default 60s) so CC warms up quickly for the disk-removal test
+    cruise.control.metrics.reporter.metrics.reporting.interval.ms=15000
   brokerConfigGroups:
     default:
       # podSecurityContext:
@@ -96,7 +98,9 @@ spec:
       # Configuration for the metadata client.
       # =======================================
       # The maximum interval in milliseconds between two metadata refreshes.
-      #metadata.max.age.ms=300000
+      # Must be <= metric.sampling.interval.ms (CruiseControl sanityCheckSamplingPeriod);
+      # kept low here so the fast e2e sampling interval (15s) is allowed.
+      metadata.max.age.ms=10000
       # Client id for the Cruise Control. It is used for the metadata client.
       #client.id=kafka-cruise-control
       # The size of TCP send buffer bytes for the metadata client.
@@ -130,18 +134,24 @@ spec:
       # The partition assignor class for the metric samplers
       metric.sampler.partition.assignor.class=com.linkedin.kafka.cruisecontrol.monitor.sampling.DefaultMetricSamplerPartitionAssignor
       # The metric sampling interval in milliseconds
-      metric.sampling.interval.ms=120000
+      # NOTE: the metrics sampling interval and window sizes below are tuned low for fast
+      # Cruise Control warmup in e2e (tiny test data); not production-appropriate defaults.
+      metric.sampling.interval.ms=15000
+      # CruiseControl reads the reporter interval from its own config (default 60000) for its
+      # sanity check and requires it <= the sampling interval, so declare it here too
+      # (mirrors the broker-side value in readOnlyConfig).
+      cruise.control.metrics.reporter.metrics.reporting.interval.ms=15000
       metric.anomaly.detection.interval.ms=180000
       # The partition metrics window size in milliseconds
-      partition.metrics.window.ms=300000
+      partition.metrics.window.ms=30000
       # The number of partition metric windows to keep in memory
       num.partition.metrics.windows=1
       # The minimum partition metric samples required for a partition in each window
       min.samples.per.partition.metrics.window=1
       # The broker metrics window size in milliseconds
-      broker.metrics.window.ms=300000
+      broker.metrics.window.ms=30000
       # The number of broker metric windows to keep in memory
-      num.broker.metrics.windows=20
+      num.broker.metrics.windows=5
       # The minimum broker metric samples required for a partition in each window
       min.samples.per.broker.metrics.window=1
       # The configuration for the BrokerCapacityConfigFileResolver (supports JBOD and non-JBOD broker capacities)

--- a/config/samples/simplekafkacluster_4disk.yaml
+++ b/config/samples/simplekafkacluster_4disk.yaml
@@ -19,6 +19,8 @@ spec:
     cruise.control.metrics.topic.auto.create=true
     cruise.control.metrics.topic.num.partitions=1
     cruise.control.metrics.topic.replication.factor=2
+    # e2e: publish CruiseControl metrics every 15s (default 60s) so CC warms up quickly for the disk-removal test
+    cruise.control.metrics.reporter.metrics.reporting.interval.ms=15000
   brokerConfigGroups:
     default:
       # podSecurityContext:
@@ -110,7 +112,9 @@ spec:
       # Configuration for the metadata client.
       # =======================================
       # The maximum interval in milliseconds between two metadata refreshes.
-      #metadata.max.age.ms=300000
+      # Must be <= metric.sampling.interval.ms (CruiseControl sanityCheckSamplingPeriod);
+      # kept low here so the fast e2e sampling interval (15s) is allowed.
+      metadata.max.age.ms=10000
       # Client id for the Cruise Control. It is used for the metadata client.
       #client.id=kafka-cruise-control
       # The size of TCP send buffer bytes for the metadata client.
@@ -144,18 +148,24 @@ spec:
       # The partition assignor class for the metric samplers
       metric.sampler.partition.assignor.class=com.linkedin.kafka.cruisecontrol.monitor.sampling.DefaultMetricSamplerPartitionAssignor
       # The metric sampling interval in milliseconds
-      metric.sampling.interval.ms=120000
+      # NOTE: the metrics sampling interval and window sizes below are tuned low for fast
+      # Cruise Control warmup in e2e (tiny test data); not production-appropriate defaults.
+      metric.sampling.interval.ms=15000
+      # CruiseControl reads the reporter interval from its own config (default 60000) for its
+      # sanity check and requires it <= the sampling interval, so declare it here too
+      # (mirrors the broker-side value in readOnlyConfig).
+      cruise.control.metrics.reporter.metrics.reporting.interval.ms=15000
       metric.anomaly.detection.interval.ms=180000
       # The partition metrics window size in milliseconds
-      partition.metrics.window.ms=300000
+      partition.metrics.window.ms=30000
       # The number of partition metric windows to keep in memory
       num.partition.metrics.windows=1
       # The minimum partition metric samples required for a partition in each window
       min.samples.per.partition.metrics.window=1
       # The broker metrics window size in milliseconds
-      broker.metrics.window.ms=300000
+      broker.metrics.window.ms=30000
       # The number of broker metric windows to keep in memory
-      num.broker.metrics.windows=20
+      num.broker.metrics.windows=5
       # The minimum broker metric samples required for a partition in each window
       min.samples.per.broker.metrics.window=1
       # The configuration for the BrokerCapacityConfigFileResolver (supports JBOD and non-JBOD broker capacities)

--- a/controllers/cruisecontroloperation_controller.go
+++ b/controllers/cruisecontroloperation_controller.go
@@ -580,11 +580,11 @@ func (r *CruiseControlOperationReconciler) getStatus(
 			return scale.CruiseControlStatus{}, errors.WrapIfWithDetails(err, "could not create a new Status CruiseControlOperation")
 		}
 		if err = updateResult(log, res.TaskResult, operation, true); err != nil {
-			return scale.CruiseControlStatus{}, errors.WrapIfWithDetails(err, "could not update the state of Status CruiseControlOperation", "name", statusOperation.GetName(), "namespace", statusOperation.GetNamespace())
+			return scale.CruiseControlStatus{}, errors.WrapIfWithDetails(err, "could not update the state of Status CruiseControlOperation", "name", operation.GetName(), "namespace", operation.GetNamespace())
 		}
 		err = r.Status().Update(ctx, operation)
 		if err != nil {
-			return scale.CruiseControlStatus{}, errors.WrapIfWithDetails(err, "could not update the state of Status CruiseControlOperation", "name", statusOperation.GetName(), "namespace", statusOperation.GetNamespace())
+			return scale.CruiseControlStatus{}, errors.WrapIfWithDetails(err, "could not update the state of Status CruiseControlOperation", "name", operation.GetName(), "namespace", operation.GetNamespace())
 		}
 
 		return scale.CruiseControlStatus{}, errors.New("could not get Cruise Control status, the operation is still in progress")

--- a/controllers/cruisecontroloperation_controller_test.go
+++ b/controllers/cruisecontroloperation_controller_test.go
@@ -16,14 +16,22 @@
 package controllers
 
 import (
+	"context"
 	"testing"
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/banzaicloud/koperator/api/v1alpha1"
 	"github.com/banzaicloud/koperator/api/v1beta1"
+	mocks "github.com/banzaicloud/koperator/controllers/tests/mocks"
+	"github.com/banzaicloud/koperator/pkg/scale"
 )
 
 func createCCRetryExecutionOperation(createTime time.Time, id string, operation v1alpha1.CruiseControlTaskOperation) *v1alpha1.CruiseControlOperation {
@@ -105,5 +113,49 @@ func TestSortOperations(t *testing.T) {
 		sortedCCOperations := sortOperations(testCase.ccOperations)
 		sortedRetryOutput := sortedCCOperations[ccOperationRetryExecution]
 		assert.Equal(t, sortedRetryOutput, testCase.expectedOutput, "test", testCase.testName)
+	}
+}
+
+// TestGetStatusDoesNotPanicWhenStatusNil exercises the res.Status==nil branch of
+// getStatus. On that path statusOperation is always nil (it is only assigned in the
+// early-returning statusOperation!=nil branch), so the error-wraps must reference the
+// freshly-created operation, not statusOperation. With the bug present this panics with
+// a nil-pointer dereference; with the fix it returns a wrapped error.
+//
+// The scaler returns Status==nil with an empty TaskResult, so updateResult fails parsing
+// the (empty) start time and we deterministically reach the buggy error-wrap. createCCOperation
+// must succeed first, hence the registered status subresource on a plain fake client.
+func TestGetStatusDoesNotPanicWhenStatusNil(t *testing.T) {
+	ctrlMock := gomock.NewController(t)
+	defer ctrlMock.Finish()
+
+	mockScaler := mocks.NewMockCruiseControlScaler(ctrlMock)
+	mockScaler.EXPECT().Status(gomock.Any()).
+		Return(scale.StatusTaskResult{Status: nil, TaskResult: &scale.Result{}}, nil)
+
+	scheme := runtime.NewScheme()
+	if err := v1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := v1beta1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).
+		WithStatusSubresource(&v1alpha1.CruiseControlOperation{}).
+		Build()
+
+	r := &CruiseControlOperationReconciler{Client: fakeClient, Scheme: scheme, scaler: mockScaler}
+
+	kafkaCluster := &v1beta1.KafkaCluster{
+		ObjectMeta: v1.ObjectMeta{Name: "kafka", Namespace: "default"},
+	}
+	ref := client.ObjectKey{Name: "kafka", Namespace: "default"}
+
+	// With the bug this panics; with the fix it returns a wrapped error.
+	_, err := r.getStatus(context.Background(), logr.Discard(), kafkaCluster,
+		ref, v1alpha1.CruiseControlOperationList{})
+	if err == nil {
+		t.Fatal("expected an error, got nil")
 	}
 }

--- a/tests/e2e/const.go
+++ b/tests/e2e/const.go
@@ -56,6 +56,7 @@ const (
 	kafkaClusterResourceReadinessTimeout   = 300 * time.Second // Increased for kind environments
 	defaultDeletionTimeout                 = 60 * time.Second  // Increased for kind environments
 	defaultPodReadinessWaitTime            = 180 * time.Second // Increased for kind environments
+	waitResourceConditionRetryInterval     = 2 * time.Second   // Retry interval when kubectl wait races with rolling updates
 	defaultTopicCreationWaitTime           = 60 * time.Second  // Increased for kind environments
 	defaultUserCreationWaitTime            = 60 * time.Second  // Increased for kind environments
 	kafkaClusterCreateTimeout              = 1800 * time.Second

--- a/tests/e2e/k8s.go
+++ b/tests/e2e/k8s.go
@@ -638,22 +638,68 @@ func waitK8sResourceCondition(kubectlOptions k8s.KubectlOptions, resourceKind, w
 		ginkgo.By(logMsg)
 	}
 
-	args := []string{
-		"wait",
-		resourceKind,
-		fmt.Sprintf("--for=%s", waitFor),
-		fmt.Sprintf("--timeout=%s", timeout),
+	// `kubectl wait` resolves the objects matching the selector once, up front, and then
+	// blocks on each of them individually. When those objects are being rolled (for example
+	// broker pods recreated during a disk removal), one can be deleted before `kubectl wait`
+	// evaluates its condition, so the command fails immediately with a transient
+	// "not found" / "no matching resources found" error instead of waiting for the
+	// replacement. Retry on those transient errors within the overall timeout budget, which
+	// makes kubectl re-resolve the selector against the current set of objects.
+	deadline := time.Now().Add(timeout)
+	var lastErr error
+	for {
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			return lastErr
+		}
+		// Round to whole seconds (1s floor) so the kubectl --timeout value reads cleanly in
+		// logs (e.g. 5m0s, not 4m59.999999449s). kubectl treats --timeout=0 specially, so
+		// never go below 1s.
+		attemptTimeout := remaining.Round(time.Second)
+		if attemptTimeout < time.Second {
+			attemptTimeout = time.Second
+		}
+
+		args := []string{
+			"wait",
+			resourceKind,
+			fmt.Sprintf("--for=%s", waitFor),
+			fmt.Sprintf("--timeout=%s", attemptTimeout),
+		}
+		_, args = kubectlArgExtender(args, "", selector, names, kubectlOptions.Namespace, extraArgs)
+
+		_, lastErr = k8s.RunKubectlAndGetOutputE(
+			ginkgo.GinkgoT(),
+			&kubectlOptions,
+			args...,
+		)
+		if lastErr == nil {
+			return nil
+		}
+
+		// Genuine failures (e.g. the condition not being met before the timeout) are
+		// returned immediately; only the transient rolling-update races are retried.
+		if !isTransientResourceWaitError(lastErr) {
+			return lastErr
+		}
+
+		time.Sleep(waitResourceConditionRetryInterval)
 	}
+}
 
-	_, args = kubectlArgExtender(args, "", selector, names, kubectlOptions.Namespace, extraArgs)
-
-	_, err := k8s.RunKubectlAndGetOutputE(
-		ginkgo.GinkgoT(),
-		&kubectlOptions,
-		args...,
-	)
-
-	return err
+// isTransientResourceWaitError reports whether a `kubectl wait` failure was caused by the
+// matched objects changing while waiting (deleted/recreated during a rolling update) rather
+// than by the wait condition genuinely not being met. Such errors are safe to retry because
+// re-running `kubectl wait` re-resolves the selector against the current set of objects.
+func isTransientResourceWaitError(err error) bool {
+	if err == nil {
+		return false
+	}
+	// "NotFound": an object that matched the selector was deleted before `kubectl wait`
+	// evaluated its condition (e.g. a pod recreated during a rolling update).
+	// "no matching resources found": the selector momentarily matched no objects.
+	return isKubectlNotFoundError(err) ||
+		strings.Contains(err.Error(), "no matching resources found")
 }
 
 // kubectlArgExtender extends the kubectl arguments and log message based on the parameters

--- a/tests/e2e/k8s_wait_test.go
+++ b/tests/e2e/k8s_wait_test.go
@@ -1,0 +1,66 @@
+// Copyright © 2023 Cisco Systems, Inc. and/or its affiliates
+// Copyright 2026 Adobe. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build e2e
+
+package e2e
+
+import (
+	"testing"
+
+	"emperror.dev/errors"
+)
+
+func TestIsTransientResourceWaitError(t *testing.T) {
+	testCases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil error is not transient",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "object deleted while waiting (rolling update) is transient",
+			err:  errors.New(`error while running command: exit status 1; Error from server (NotFound): pods "kafka-2-h4grv" not found`),
+			want: true,
+		},
+		{
+			name: "selector momentarily matched no objects is transient",
+			err:  errors.New("error: no matching resources found"),
+			want: true,
+		},
+		{
+			name: "condition not met before timeout is NOT transient",
+			err:  errors.New("error: timed out waiting for the condition on pods/kafka-0"),
+			want: false,
+		},
+		{
+			name: "unrelated failure is NOT transient",
+			err:  errors.New("error while running command: exit status 1; The connection to the server was refused"),
+			want: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isTransientResourceWaitError(tc.err); got != tc.want {
+				t.Errorf("isTransientResourceWaitError(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}

--- a/tests/e2e/test_multidisk_removal.go
+++ b/tests/e2e/test_multidisk_removal.go
@@ -34,7 +34,7 @@ import (
 
 const (
 	multidiskRemovalTimeout      = 1800 * time.Second // this test can take long: rebalance must finish before removal starts
-	multidiskRemovalPollInterval = 15 * time.Second
+	multidiskRemovalPollInterval = 5 * time.Second
 	brokerConfigTemplateFormat   = "%s-config-%d"
 )
 


### PR DESCRIPTION
Stabilizes and speeds up the flaky **multi-disk removal** e2e test, makes e2e failures debuggable, and fixes a related CruiseControl controller nil-panic. Four focused commits:

### 1. De-flake `waitK8sResourceCondition` (correctness)
`kubectl wait <kind> --selector` resolves the matched objects once, then blocks on each. During a rolling restart a matched broker pod can be deleted before the wait evaluates it → instant `Error from server (NotFound)` (not a timeout, so a bigger timeout doesn't help). Now retries on transient "object vanished" errors (`NotFound` / `no matching resources found`) within the overall timeout budget, re-resolving the selector each attempt; genuine condition-timeouts still return immediately. Per-attempt `--timeout` rounded to whole seconds for clean logs. Adds a classifier unit test.

### 2. Speed up Cruise Control warmup (~11 min → ~6 min)
The multi-disk wait was dominated by CC metrics warmup before it could rebalance replicas off the removed disks (tiny test data → pure latency). Tuned the CC config in the 4-disk and 2-disk manifests (kept identical so the removal patch doesn't restart CC): sampling `120000→15000`, partition/broker windows `300000→30000`, `num.broker.metrics.windows 20→5`, reporter interval `15000`, and `metadata.max.age.ms=10000` — satisfying all of CruiseControl's `sanityCheckSamplingPeriod` constraints (metadata≤sampling, window/sampling≤127, reporter≤sampling, sampling≤anomaly interval) for the 15s sampling. Test poll interval `15s→5s`. **Measured: multidisk "Waiting for disk removal" 11m18s → ~6m00s; full suite 89/89 green.** Values are commented as e2e-only, not production defaults.

### 3. Failure diagnostics (CI)
`if: failure()` step dumps nodes, all pods, and per-namespace pods/events/`describe` plus current and `--previous` container logs for the dependency namespaces (cert-manager, projectcontour, zookeeper, prometheus, kafka), and cluster-wide Warning events — always `exit 0` so it never masks the real failure. (This is how the CC crash-loop and the nil-panic below were diagnosed.)

### 4. fix(controllers): CC `getStatus` nil-panic
`CruiseControlOperationReconciler.getStatus` dereferenced a nil `statusOperation` on the `res.Status==nil` path when a follow-up `updateResult`/`Status().Update` failed — i.e. exactly when Cruise Control is unavailable. References the freshly-created `operation` instead. Adds a regression test (panics without the fix).

> Note: commit 4 is a production controller fix, independent of the e2e work — happy to split it into its own PR if preferred.

Verified locally (gofmt/vet/golangci-lint clean, unit tests pass) and the full e2e suite was green (run 26773009722, 89/89) on the pre-squash content (byte-identical to this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)