### PR TITLE
fix: recreate kind cluster if nodes never become Ready

### DIFF
--- a/.github/actions/kind-create/action.yaml
+++ b/.github/actions/kind-create/action.yaml
@@ -32,6 +32,36 @@ runs:
       node_image: kindest/node:${{ inputs.kind_k8s_version }}
       config: ${{ inputs.kind_config }}
 
+  - name: Verify all nodes are healthy, recreating the cluster otherwise
+    # The control plane occasionally never reports Ready on the runner (flaky
+    # infra), which otherwise goes unnoticed here and only surfaces 30-45
+    # minutes later as an opaque e2e test timeout. Recreate the cluster a
+    # couple of times before giving up.
+    run: |
+      max_attempts=3
+      attempt=1
+      until kubectl wait --for=condition=Ready nodes --all --timeout=120s; do
+        echo "::warning::kind cluster nodes not all Ready (attempt ${attempt}/${max_attempts})"
+        kubectl get nodes -o wide || true
+
+        if [ "${attempt}" -ge "${max_attempts}" ]; then
+          echo "::error::kind cluster nodes never became Ready after ${max_attempts} attempts"
+          kubectl describe nodes || true
+          exit 1
+        fi
+
+        attempt=$((attempt + 1))
+        echo "Recreating kind cluster '${{ inputs.kind_cluster_name }}' (attempt ${attempt}/${max_attempts})..."
+        kind delete cluster --name "${{ inputs.kind_cluster_name }}"
+        kind create cluster \
+          --name "${{ inputs.kind_cluster_name }}" \
+          --image "kindest/node:${{ inputs.kind_k8s_version }}" \
+          --config "${{ inputs.kind_config }}" \
+          --wait 120s
+      done
+      echo "All kind cluster nodes are Ready."
+    shell: bash
+
   - name: Check kind cluster and extract kubeconfig
     id: check-kind-cluster
     run: |


### PR DESCRIPTION
The e2e-test job's Kind control-plane node occasionally never reports Ready, but nothing was gated on that - the job just kept going, and only failed 30-45 minutes later with an opaque Kafka-readiness-probe timeout (evidence: [run 29146329882](https://github.com/adobe/koperator/actions/runs/29146329882), and an unrelated PR failing at the same moment with widespread node-not-ready symptoms across coredns/kube-scheduler/contour/zookeeper).

Adds an explicit health gate right after cluster creation in `.github/actions/kind-create`: wait up to 120s for all nodes to report `Ready`, and if they don't, delete and recreate the cluster (up to 2 retries) before giving up with `kubectl describe nodes` diagnostics. Turns a silent 45-minute hang into either a fast self-heal or a fast, clearly-diagnosed failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)