### PR TITLE
Sync gh-pages docs version on canonical release + fix stale/missing OCI version refs

### DIFF
--- a/.github/workflows/operator-release.yml
+++ b/.github/workflows/operator-release.yml
@@ -184,3 +184,34 @@ jobs:
           labels: |
             release
             automated
+
+  sync-gh-pages-version:
+    # Keeps gh-pages' docs version in sync with releases. Pushes directly
+    # (gh-pages has no branch protection) using secrets.PAT, which also
+    # triggers gh-pages to build and deploy the site.
+    runs-on: ubuntu-latest
+    needs: [prepare, release-helm]
+    if: needs.prepare.outputs.is_canonical == 'true'
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout gh-pages
+        uses: actions/checkout@v7
+        with:
+          ref: gh-pages
+          token: ${{ secrets.PAT }}
+      - name: Update docs version
+        run: |
+          TAG="${{ needs.prepare.outputs.tag }}"
+          CONFIG="config/_default/config.toml"
+          sed -i "s/^  latest_version = \"[^\"]*\"/  latest_version = \"${TAG}\"/" "$CONFIG"
+          sed -i "s/^  version = \"[^\"]*\"/  version = \"${TAG}\"/" "$CONFIG"
+          if git diff --quiet -- "$CONFIG"; then
+            echo "Docs version already up to date; nothing to push."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add "$CONFIG"
+          git commit -m "Update docs version to ${TAG}"
+          git push origin gh-pages

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ spec:
     replicas: 1
     image:
         repository: ghcr.io/adobe/zookeeper-operator/zookeeper
-        tag: 3.8.4-0.2.15-adobe-20250923
+        tag: 3.8.4-0.2.15-adobe-20260423
     persistence:
         reclaimPolicy: Delete
 EOF
@@ -124,11 +124,9 @@ kubectl apply -f https://raw.githubusercontent.com/adobe/koperator/refs/heads/ma
 
 > 📦 **View available versions**: [ghcr.io/adobe/helm-charts/kafka-operator](https://github.com/adobe/koperator/pkgs/container/helm-charts%2Fkafka-operator/versions)
 
-```sh
-# Install the latest release
-helm install kafka-operator oci://ghcr.io/adobe/helm-charts/kafka-operator --namespace=kafka --create-namespace --skip-crds
+OCI registries have no floating "latest" tag, so `--version` is required (replace with your desired version, see available versions above):
 
-# Or install a specific version (replace with desired version)
+```sh
 helm install kafka-operator oci://ghcr.io/adobe/helm-charts/kafka-operator --version 0.28.0-adobe-20260622 --namespace=kafka --create-namespace --skip-crds
 ```
 

--- a/charts/kafka-operator/README.md
+++ b/charts/kafka-operator/README.md
@@ -25,12 +25,9 @@ previous step - without it, Helm's own CRD install can conflict with the `kubect
 
 > 📦 **View available versions**: [ghcr.io/adobe/helm-charts/kafka-operator](https://github.com/adobe/koperator/pkgs/container/helm-charts%2Fkafka-operator/versions)
 
-```bash
-# Install the latest release
-helm install kafka-operator oci://ghcr.io/adobe/helm-charts/kafka-operator \
-  --namespace=kafka --create-namespace --skip-crds
+OCI registries have no floating "latest" tag, so `--version` is required (see available versions above):
 
-# Or install a specific version
+```bash
 helm install kafka-operator oci://ghcr.io/adobe/helm-charts/kafka-operator \
   --version 0.28.0-adobe-20260622 --namespace=kafka --create-namespace --skip-crds
 ```
@@ -38,20 +35,16 @@ helm install kafka-operator oci://ghcr.io/adobe/helm-charts/kafka-operator \
 To install the operator using an already installed cert-manager:
 ```bash
 helm install kafka-operator oci://ghcr.io/adobe/helm-charts/kafka-operator \
+  --version 0.28.0-adobe-20260622 \
   --set certManager.namespace=<your cert manager namespace> --namespace=kafka --create-namespace --skip-crds
 ```
 
 ## Upgrading the chart
 
 To upgrade the chart since the helm 3 limitation you have to set a value as well to keep your CRDs.
-If this value is not set your CRDs might be deleted.
+If this value is not set your CRDs might be deleted. `--version` is required, same as for install.
 
 ```bash
-# Upgrade to latest version
-helm upgrade kafka-operator oci://ghcr.io/adobe/helm-charts/kafka-operator \
-  --namespace=kafka
-
-# Upgrade to specific version
 helm upgrade kafka-operator oci://ghcr.io/adobe/helm-charts/kafka-operator \
   --version 0.28.0-adobe-20260622 --namespace=kafka
 ```

--- a/charts/kafka-operator/README.md.gotmpl
+++ b/charts/kafka-operator/README.md.gotmpl
@@ -25,12 +25,9 @@ previous step - without it, Helm's own CRD install can conflict with the `kubect
 
 > 📦 **View available versions**: [ghcr.io/adobe/helm-charts/kafka-operator](https://github.com/adobe/koperator/pkgs/container/helm-charts%2Fkafka-operator/versions)
 
-```bash
-# Install the latest release
-helm install kafka-operator oci://ghcr.io/adobe/helm-charts/kafka-operator \
-  --namespace=kafka --create-namespace --skip-crds
+OCI registries have no floating "latest" tag, so `--version` is required (see available versions above):
 
-# Or install a specific version
+```bash
 helm install kafka-operator oci://ghcr.io/adobe/helm-charts/kafka-operator \
   --version 0.28.0-adobe-20260622 --namespace=kafka --create-namespace --skip-crds
 ```
@@ -38,20 +35,16 @@ helm install kafka-operator oci://ghcr.io/adobe/helm-charts/kafka-operator \
 To install the operator using an already installed cert-manager:
 ```bash
 helm install kafka-operator oci://ghcr.io/adobe/helm-charts/kafka-operator \
+  --version 0.28.0-adobe-20260622 \
   --set certManager.namespace=<your cert manager namespace> --namespace=kafka --create-namespace --skip-crds
 ```
 
 ## Upgrading the chart
 
 To upgrade the chart since the helm 3 limitation you have to set a value as well to keep your CRDs.
-If this value is not set your CRDs might be deleted.
+If this value is not set your CRDs might be deleted. `--version` is required, same as for install.
 
 ```bash
-# Upgrade to latest version
-helm upgrade kafka-operator oci://ghcr.io/adobe/helm-charts/kafka-operator \
-  --namespace=kafka
-
-# Upgrade to specific version
 helm upgrade kafka-operator oci://ghcr.io/adobe/helm-charts/kafka-operator \
   --version 0.28.0-adobe-20260622 --namespace=kafka
 ```

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "forkProcessing": "enabled",
+  "baseBranchPatterns": ["master", "gh-pages"],
   "extends": [
     ":dependencyDashboard",
     ":ignoreUnstable",
@@ -19,7 +20,8 @@
       "customType": "regex",
       "managerFilePatterns": [
         "/(^|/)Makefile$/",
-        "/(^|/)Dockerfile$/"
+        "/(^|/)Dockerfile$/",
+        "/(^|/)\\.github/workflows/regenerate-crd-docs\\.yaml$/"
       ],
       "matchStrings": [
         "(?<depName>[A-Z][A-Z0-9_]*)_VERSION\\s*=\\s*(?<currentValue>[^\\s]+)\\s*#\\s*renovate:\\s*datasource=(?<datasource>[^\\s]+)\\s*depName=(?<packageName>[^\\s]+)(?:\\s*extractVersion=(?<extractVersion>[^\\s]+))?"
@@ -68,8 +70,9 @@
       "matchManagers": [
         "gomod"
       ],
+      "matchBaseBranches": ["master"],
       "enabled": false,
-      "description": "Disable Go module updates - handled by automated workflow: .github/workflows/update-go-deps.yml"
+      "description": "Disable Go module updates on master - handled by automated workflow: .github/workflows/update-go-deps.yml. gh-pages' go.mod is Hugo Modules (theme deps like docsy), not app code, so it stays enabled there."
     },
     {
       "matchCategories": [


### PR DESCRIPTION
## Summary
- Adds a `sync-gh-pages-version` job to `operator-release.yml`: for canonical dated release tags, pushes the bumped `version`/`latest_version` fields directly to `gh-pages`'s `config/_default/config.toml` (unprotected branch, no PR needed), using `secrets.PAT` so the push isn't suppressed and correctly triggers the existing `publish-docs.yaml` site rebuild. The gh-pages docs version was previously ~10 releases / several months stale with no automation keeping it in sync.
- Fixes install/upgrade examples across `README.md` and `charts/kafka-operator/README.md`(`.gotmpl`) that omitted `--version` for `oci://ghcr.io/adobe/helm-charts/kafka-operator` — OCI registries have no floating "latest" tag, so these examples failed as written.
- Bumps the stale ZooKeeper operator/image tag reference in `README.md` from `0.2.15-adobe-20250923` to `0.2.15-adobe-20260423` (verified against GitHub Packages for `adobe/zookeeper-operator`: `zookeeper-operator`, `zookeeper-operator/zookeeper`, `helm-charts/zookeeper-operator`).

Companion fixes were already pushed directly to `gh-pages` (same `--version` gap, de-hardcoded remaining Koperator version refs to use the `latest_version` Hugo param, and the same ZooKeeper version bump).

## Test plan
- [x] `actionlint` on the modified workflow — no new findings (all existing findings are pre-existing, in untouched lines)
- [x] YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] Dry-ran the `config.toml` sed substitutions against the real file fetched from `gh-pages` — only the two intended fields change, comment preserved
- [x] Regenerated `charts/kafka-operator/README.md` via `helm-docs` to confirm the template renders correctly, then hand-applied only the intended lines (avoided bundling unrelated values-table drift from stale `values.yaml`/README sync)
- [ ] End-to-end: only verifiable by cutting an actual canonical release tag (not done here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)