### PR TITLE
fix: strip leading v from JMX exporter image tag

### DIFF
--- a/.github/workflows/publish-kafka-docker.yml
+++ b/.github/workflows/publish-kafka-docker.yml
@@ -124,6 +124,9 @@ jobs:
         id: jmx_exporter_version
         run: |
           JMX_VERSION=$(grep "ARG JMX_EXPORTER_VERSION=" docker/jmx_exporter/Dockerfile | cut -d'=' -f2 | cut -d' ' -f1)
+          # Strip a leading "v" so the published image tag is always version-only,
+          # regardless of whether the upstream release tag (and thus the Dockerfile ARG) has one.
+          JMX_VERSION="${JMX_VERSION#v}"
           echo "jmx_version=$JMX_VERSION" >> $GITHUB_OUTPUT
       - name: Check if JMX exporter image already exists
         id: image_exists


### PR DESCRIPTION
## Summary
- The `build-and-push-jmx-agent-image` job in `.github/workflows/publish-kafka-docker.yml` reads the JMX exporter version straight out of the Dockerfile's `JMX_EXPORTER_VERSION` ARG and uses it verbatim as the published `ghcr.io/.../jmx-javaagent` image tag.
- That ARG mirrors the upstream `prometheus/jmx_exporter` GitHub release tag (currently `vX.Y.Z`), kept in sync by the `# renovate: datasource=github-releases depName=prometheus/jmx_exporter` rule in `docker/jmx_exporter/Dockerfile`.
- This strips a leading `v` right after extraction, so the published image tag is always version-only (e.g. `1.6.0`) regardless of whether the upstream release tag carries the `v` prefix. Both the "image already exists" check and the `docker/metadata-action` tag consume this same output, so fixing it once covers both.
- No change needed in the Dockerfile itself — it uses the raw ARG consistently for the tarball download URL, extraction path, and jar filename, so it's prefix-agnostic by construction.

## Test plan
- [x] Validated YAML syntax (`yaml.safe_load`)
- [x] Ran shellcheck via `actionlint`-style check on the modified step — no new issues introduced (only pre-existing unrelated `SC2086` info-level findings elsewhere in the file)
- [ ] Confirm on the next `kafka-*` tag push that the published `ghcr.io/adobe/koperator/jmx-javaagent` tag has no `v` prefix