### PR TITLE
feat: expose publishNotReadyAddresses for broker services (#244)

### DIFF
--- a/api/v1beta1/kafkacluster_types.go
+++ b/api/v1beta1/kafkacluster_types.go
@@ -148,6 +148,16 @@ type KafkaClusterSpec struct {
 	// +optional
 	KRaftMode              bool `json:"kRaft"`
 	HeadlessServiceEnabled bool `json:"headlessServiceEnabled"`
+	// PublishNotReadyAddresses controls whether the non-headless broker Services
+	// (kafka-{id} and kafka-all-broker) include the pod IP in their endpoints even
+	// when the pod fails its readiness probe.
+	// Enable this when using a custom readiness sidecar that checks Under-Replicated
+	// Partitions (URP) combined with a PodDisruptionBudget, so that brokers continue
+	// serving existing partition traffic while the PDB holds eviction.
+	// Headless services always publish not-ready addresses regardless of this field.
+	// +kubebuilder:default=false
+	// +optional
+	PublishNotReadyAddresses bool `json:"publishNotReadyAddresses,omitempty"`
 	// localDebugEnabled is used to decide whether to create a separate loadbalancer services for the
 	// Kafka and Cruise Control Pods. These services will expose the internal listener ports of the Kafka
 	// cluster with LoadBalancer type, which can be used for running Koperator on a local machine against

--- a/charts/kafka-operator/crds/kafkaclusters.yaml
+++ b/charts/kafka-operator/crds/kafkaclusters.yaml
@@ -22965,6 +22965,17 @@ spec:
                 type: boolean
               propagateLabels:
                 type: boolean
+              publishNotReadyAddresses:
+                default: false
+                description: |-
+                  PublishNotReadyAddresses controls whether the non-headless broker Services
+                  (kafka-{id} and kafka-all-broker) include the pod IP in their endpoints even
+                  when the pod fails its readiness probe.
+                  Enable this when using a custom readiness sidecar that checks Under-Replicated
+                  Partitions (URP) combined with a PodDisruptionBudget, so that brokers continue
+                  serving existing partition traffic while the PDB holds eviction.
+                  Headless services always publish not-ready addresses regardless of this field.
+                type: boolean
               rackAwareness:
                 description: RackAwareness defines the required fields to enable kafka's
                   rack aware feature

--- a/config/base/crds/kafka.banzaicloud.io_kafkaclusters.yaml
+++ b/config/base/crds/kafka.banzaicloud.io_kafkaclusters.yaml
@@ -22965,6 +22965,17 @@ spec:
                 type: boolean
               propagateLabels:
                 type: boolean
+              publishNotReadyAddresses:
+                default: false
+                description: |-
+                  PublishNotReadyAddresses controls whether the non-headless broker Services
+                  (kafka-{id} and kafka-all-broker) include the pod IP in their endpoints even
+                  when the pod fails its readiness probe.
+                  Enable this when using a custom readiness sidecar that checks Under-Replicated
+                  Partitions (URP) combined with a PodDisruptionBudget, so that brokers continue
+                  serving existing partition traffic while the PDB holds eviction.
+                  Headless services always publish not-ready addresses regardless of this field.
+                type: boolean
               rackAwareness:
                 description: RackAwareness defines the required fields to enable kafka's
                   rack aware feature

--- a/pkg/resources/kafka/allBrokerService.go
+++ b/pkg/resources/kafka/allBrokerService.go
@@ -46,10 +46,11 @@ func (r *Reconciler) allBrokerService() runtime.Object {
 			r.KafkaCluster.Spec.ListenersConfig.GetServiceAnnotations(),
 			r.KafkaCluster),
 		Spec: corev1.ServiceSpec{
-			Type:            corev1.ServiceTypeClusterIP,
-			SessionAffinity: corev1.ServiceAffinityNone,
-			Selector:        apiutil.LabelsForKafka(r.KafkaCluster.GetName()),
-			Ports:           usedPorts,
+			Type:                     corev1.ServiceTypeClusterIP,
+			SessionAffinity:          corev1.ServiceAffinityNone,
+			Selector:                 apiutil.LabelsForKafka(r.KafkaCluster.GetName()),
+			Ports:                    usedPorts,
+			PublishNotReadyAddresses: r.KafkaCluster.Spec.PublishNotReadyAddresses,
 		},
 	}
 

--- a/pkg/resources/kafka/service.go
+++ b/pkg/resources/kafka/service.go
@@ -55,10 +55,11 @@ func (r *Reconciler) service(id int32, _ *v1beta1.BrokerConfig) runtime.Object {
 			r.KafkaCluster.Spec.ListenersConfig.GetServiceAnnotations(),
 			r.KafkaCluster),
 		Spec: corev1.ServiceSpec{
-			Type:            corev1.ServiceTypeClusterIP,
-			SessionAffinity: corev1.ServiceAffinityNone,
-			Selector:        apiutil.MergeLabels(apiutil.LabelsForKafka(r.KafkaCluster.Name), map[string]string{v1beta1.BrokerIdLabelKey: fmt.Sprintf("%d", id)}),
-			Ports:           usedPorts,
+			Type:                     corev1.ServiceTypeClusterIP,
+			SessionAffinity:          corev1.ServiceAffinityNone,
+			Selector:                 apiutil.MergeLabels(apiutil.LabelsForKafka(r.KafkaCluster.Name), map[string]string{v1beta1.BrokerIdLabelKey: fmt.Sprintf("%d", id)}),
+			Ports:                    usedPorts,
+			PublishNotReadyAddresses: r.KafkaCluster.Spec.PublishNotReadyAddresses,
 		},
 	}
 	if r.KafkaCluster.Spec.LocalDebugEnabled {

--- a/pkg/resources/kafka/service_test.go
+++ b/pkg/resources/kafka/service_test.go
@@ -32,182 +32,164 @@ import (
 )
 
 func TestService(t *testing.T) {
+	basePorts := []corev1.ServicePort{
+		{
+			Name:       "tcp-internal",
+			Protocol:   "TCP",
+			Port:       29092,
+			TargetPort: intstr.FromInt(29092),
+			NodePort:   0,
+		},
+		{
+			Name:       "tcp-plaintext",
+			Protocol:   "TCP",
+			Port:       29094,
+			TargetPort: intstr.FromInt(29094),
+			NodePort:   0,
+		},
+		{
+			Name:       "metrics",
+			Protocol:   "TCP",
+			Port:       9020,
+			TargetPort: intstr.FromInt(9020),
+			NodePort:   0,
+		},
+	}
+
+	baseListeners := v1beta1.ListenersConfig{
+		InternalListeners: []v1beta1.InternalListenerConfig{
+			{
+				CommonListenerSpec: v1beta1.CommonListenerSpec{
+					Name:                            "internal",
+					ContainerPort:                   29092,
+					Type:                            "plaintext",
+					UsedForInnerBrokerCommunication: true,
+				},
+			},
+		},
+		ExternalListeners: []v1beta1.ExternalListenerConfig{
+			{
+				CommonListenerSpec: v1beta1.CommonListenerSpec{
+					Name:                            "plaintext",
+					ContainerPort:                   29094,
+					Type:                            "plaintext",
+					UsedForInnerBrokerCommunication: false,
+				},
+				AccessMethod: corev1.ServiceTypeLoadBalancer,
+			},
+		},
+	}
+
+	baseOwnerRef := []metav1.OwnerReference{
+		{
+			APIVersion:         "",
+			Kind:               "",
+			Name:               "kafka",
+			UID:                "",
+			Controller:         util.BoolPointer(true),
+			BlockOwnerDeletion: util.BoolPointer(true),
+		},
+	}
+
 	testCases := []struct {
 		testName        string
 		r               *Reconciler
 		expectedService *corev1.Service
 	}{
 		{
-			testName: "Basic Internal And External Service",
+			testName: "ClusterIP service with publishNotReadyAddresses disabled (default)",
 			r: &Reconciler{
 				Reconciler: resources.Reconciler{
 					KafkaCluster: &v1beta1.KafkaCluster{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "kafka",
-							Namespace: "kafka",
-						},
+						ObjectMeta: metav1.ObjectMeta{Name: "kafka", Namespace: "kafka"},
 						Spec: v1beta1.KafkaClusterSpec{
-							LocalDebugEnabled: false,
-							KRaftMode:         false,
-							ListenersConfig: v1beta1.ListenersConfig{
-								InternalListeners: []v1beta1.InternalListenerConfig{
-									{
-										CommonListenerSpec: v1beta1.CommonListenerSpec{
-											Name:                            "internal",
-											ContainerPort:                   29092,
-											Type:                            "plaintext",
-											UsedForInnerBrokerCommunication: true,
-										},
-									},
-								},
-								ExternalListeners: []v1beta1.ExternalListenerConfig{
-									{
-										CommonListenerSpec: v1beta1.CommonListenerSpec{
-											Name:                            "plaintext",
-											ContainerPort:                   29094,
-											Type:                            "plaintext",
-											UsedForInnerBrokerCommunication: false,
-										},
-										AccessMethod: corev1.ServiceTypeLoadBalancer,
-									},
-								},
-							},
+							LocalDebugEnabled:        false,
+							KRaftMode:                false,
+							PublishNotReadyAddresses: false,
+							ListenersConfig:          baseListeners,
 						},
 					},
 				},
 			},
 			expectedService: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        "kafka-1",
-					Namespace:   "kafka",
-					Labels:      map[string]string{"app": "kafka", "brokerId": "1", "kafka_cr": "kafka"},
-					Annotations: map[string]string{},
-					OwnerReferences: []metav1.OwnerReference{
-						{
-							APIVersion:         "",
-							Kind:               "",
-							Name:               "kafka",
-							UID:                "",
-							Controller:         util.BoolPointer(true),
-							BlockOwnerDeletion: util.BoolPointer(true),
-						},
-					},
+					Name:            "kafka-1",
+					Namespace:       "kafka",
+					Labels:          map[string]string{"app": "kafka", "brokerId": "1", "kafka_cr": "kafka"},
+					Annotations:     map[string]string{},
+					OwnerReferences: baseOwnerRef,
 				},
 				Spec: corev1.ServiceSpec{
-					Type:            corev1.ServiceTypeClusterIP,
-					SessionAffinity: corev1.ServiceAffinityNone,
-					Selector:        apiutil.MergeLabels(apiutil.LabelsForKafka("kafka"), map[string]string{v1beta1.BrokerIdLabelKey: "1"}),
-					Ports: []corev1.ServicePort{
-						{
-							Name:       "tcp-internal",
-							Protocol:   "TCP",
-							Port:       29092,
-							TargetPort: intstr.FromInt(29092),
-							NodePort:   0,
-						},
-						{
-							Name:       "tcp-plaintext",
-							Protocol:   "TCP",
-							Port:       29094,
-							TargetPort: intstr.FromInt(29094),
-							NodePort:   0,
-						},
-						{
-							Name:       "metrics",
-							Protocol:   "TCP",
-							Port:       9020,
-							TargetPort: intstr.FromInt(9020),
-							NodePort:   0,
-						},
-					},
+					Type:                     corev1.ServiceTypeClusterIP,
+					SessionAffinity:          corev1.ServiceAffinityNone,
+					Selector:                 apiutil.MergeLabels(apiutil.LabelsForKafka("kafka"), map[string]string{v1beta1.BrokerIdLabelKey: "1"}),
+					Ports:                    basePorts,
 					ClusterIP:                "",
 					PublishNotReadyAddresses: false,
 				},
 			},
 		},
 		{
-			testName: "Basic Internal And External Service",
+			testName: "ClusterIP service with publishNotReadyAddresses enabled (URP sidecar mode)",
 			r: &Reconciler{
 				Reconciler: resources.Reconciler{
 					KafkaCluster: &v1beta1.KafkaCluster{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "kafka",
-							Namespace: "kafka",
-						},
+						ObjectMeta: metav1.ObjectMeta{Name: "kafka", Namespace: "kafka"},
 						Spec: v1beta1.KafkaClusterSpec{
-							LocalDebugEnabled: true,
-							KRaftMode:         false,
-							ListenersConfig: v1beta1.ListenersConfig{
-								InternalListeners: []v1beta1.InternalListenerConfig{
-									{
-										CommonListenerSpec: v1beta1.CommonListenerSpec{
-											Name:                            "internal",
-											ContainerPort:                   29092,
-											Type:                            "plaintext",
-											UsedForInnerBrokerCommunication: true,
-										},
-									},
-								},
-								ExternalListeners: []v1beta1.ExternalListenerConfig{
-									{
-										CommonListenerSpec: v1beta1.CommonListenerSpec{
-											Name:                            "plaintext",
-											ContainerPort:                   29094,
-											Type:                            "plaintext",
-											UsedForInnerBrokerCommunication: false,
-										},
-										AccessMethod: corev1.ServiceTypeLoadBalancer,
-									},
-								},
-							},
+							LocalDebugEnabled:        false,
+							KRaftMode:                false,
+							PublishNotReadyAddresses: true,
+							ListenersConfig:          baseListeners,
 						},
 					},
 				},
 			},
 			expectedService: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        "kafka-1",
-					Namespace:   "kafka",
-					Labels:      map[string]string{"app": "kafka", "brokerId": "1", "kafka_cr": "kafka"},
-					Annotations: map[string]string{},
-					OwnerReferences: []metav1.OwnerReference{
-						{
-							APIVersion:         "",
-							Kind:               "",
-							Name:               "kafka",
-							UID:                "",
-							Controller:         util.BoolPointer(true),
-							BlockOwnerDeletion: util.BoolPointer(true),
+					Name:            "kafka-1",
+					Namespace:       "kafka",
+					Labels:          map[string]string{"app": "kafka", "brokerId": "1", "kafka_cr": "kafka"},
+					Annotations:     map[string]string{},
+					OwnerReferences: baseOwnerRef,
+				},
+				Spec: corev1.ServiceSpec{
+					Type:                     corev1.ServiceTypeClusterIP,
+					SessionAffinity:          corev1.ServiceAffinityNone,
+					Selector:                 apiutil.MergeLabels(apiutil.LabelsForKafka("kafka"), map[string]string{v1beta1.BrokerIdLabelKey: "1"}),
+					Ports:                    basePorts,
+					ClusterIP:                "",
+					PublishNotReadyAddresses: true,
+				},
+			},
+		},
+		{
+			testName: "LoadBalancer service when localDebugEnabled",
+			r: &Reconciler{
+				Reconciler: resources.Reconciler{
+					KafkaCluster: &v1beta1.KafkaCluster{
+						ObjectMeta: metav1.ObjectMeta{Name: "kafka", Namespace: "kafka"},
+						Spec: v1beta1.KafkaClusterSpec{
+							LocalDebugEnabled:        true,
+							KRaftMode:                false,
+							PublishNotReadyAddresses: false,
+							ListenersConfig:          baseListeners,
 						},
 					},
 				},
+			},
+			expectedService: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "kafka-1",
+					Namespace:       "kafka",
+					Labels:          map[string]string{"app": "kafka", "brokerId": "1", "kafka_cr": "kafka"},
+					Annotations:     map[string]string{},
+					OwnerReferences: baseOwnerRef,
+				},
 				Spec: corev1.ServiceSpec{
-					Type:            corev1.ServiceTypeLoadBalancer,
-					SessionAffinity: corev1.ServiceAffinityNone,
-					Selector:        apiutil.MergeLabels(apiutil.LabelsForKafka("kafka"), map[string]string{v1beta1.BrokerIdLabelKey: "1"}),
-					Ports: []corev1.ServicePort{
-						{
-							Name:       "tcp-internal",
-							Protocol:   "TCP",
-							Port:       29092,
-							TargetPort: intstr.FromInt(29092),
-							NodePort:   0,
-						},
-						{
-							Name:       "tcp-plaintext",
-							Protocol:   "TCP",
-							Port:       29094,
-							TargetPort: intstr.FromInt(29094),
-							NodePort:   0,
-						},
-						{
-							Name:       "metrics",
-							Protocol:   "TCP",
-							Port:       9020,
-							TargetPort: intstr.FromInt(9020),
-							NodePort:   0,
-						},
-					},
+					Type:                     corev1.ServiceTypeLoadBalancer,
+					SessionAffinity:          corev1.ServiceAffinityNone,
+					Selector:                 apiutil.MergeLabels(apiutil.LabelsForKafka("kafka"), map[string]string{v1beta1.BrokerIdLabelKey: "1"}),
+					Ports:                    basePorts,
 					ClusterIP:                "",
 					PublishNotReadyAddresses: false,
 				},

--- a/run-local.sh
+++ b/run-local.sh
@@ -172,7 +172,7 @@ else
 fi
 
 ## Initialize Zookeeper and Kafka Cluster
-kubectl apply -f config/samples/simplezookeeper.yaml -n zookeeper
+kubectl apply -f config/samples/simpleZookeeper.yaml -n zookeeper
 
 if ! $LOCAL; then
   kubectl wait --for=condition=Ready pod -l app.kubernetes.io/name=kafka-operator -n kafka --timeout=120s


### PR DESCRIPTION
## Description

Adds a `publishNotReadyAddresses` field to the `KafkaCluster` CRD spec and propagates it to the
non-headless broker Services created by the operator: the per-broker Services (`kafka-{id}`) and
`kafka-all-broker`.

Resolves adobe/koperator#244
 
**Problem:** During Kubernetes node upgrades/evictions, brokers can be evicted without regard to
replica sync status. The recommended mitigation is a sidecar container with a readiness probe that
checks Under-Replicated Partitions (URP), combined with a PodDisruptionBudget, so the next eviction
is held until replicas are back in sync. However, when that probe fails, Kubernetes also removes the
pod from the endpoints of the non-headless broker Services — while the Kafka controller may still be
directing clients to that broker via metadata. The mismatch surfaces as client-side
`Connection Refused` / `UnknownHostException` errors.
 
**Solution:** With `spec.publishNotReadyAddresses: true`, the broker Services keep the pod IP in
their endpoints even while the readiness probe fails, so the URP probe can safely block the PDB
without dropping active traffic routing (mirroring the behavior headless Services already have via
[`publishNotReadyAddresses`](https://kubernetes.io/docs/reference/kubernetes-api/service-resources/service-v1/#ServiceSpec)).
 
**Changes:**
- `api/v1beta1/kafkacluster_types.go` — new optional `publishNotReadyAddresses` field (defaults to
  `false`, preserving existing behavior; non-breaking)
- `pkg/resources/kafka/service.go`, `pkg/resources/kafka/allBrokerService.go` — set the flag on the
  generated Services from the spec
- Regenerated CRD manifests (`config/base/crds/`, `charts/kafka-operator/crds/`) via `make manifests`
- `pkg/resources/kafka/service_test.go` — added coverage for the enabled/disabled paths
- `run-local.sh` — fixed `simpleZookeeper.yaml` filename casing (broke local setup on
  case-sensitive filesystems)
 
**Verified end-to-end** on a local kind cluster: field persists through the API server (no schema
pruning), operator sets it on all broker Services, and during a simulated node upgrade
(cordon + eviction API) with a URP sidecar + PDB, NotReady broker endpoints remained published — a
producer running `acks=all` / `min.insync.replicas=2` saw zero connection errors while the PDB
blocked a second eviction.

## Type of Change
- [x] New Feature

## Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
