### PR TITLE
docs: rename master -> main in doc URLs (2/2: gh-pages)

### DIFF
--- a/.github/crd-docs-generator/crd.template
+++ b/.github/crd-docs-generator/crd.template
@@ -202,6 +202,6 @@ This CRD is being replaced by <a href="../{{ .FullName }}/">{{ .ShortName }}</a>
 {{ else }}
 <div class="crd-noversions">
 <p>We currently cannot show any schema information on this <abbr title="custom resource definition">CRD</abbr>. Sorry for the inconvenience!</p>
-<p>Please refer to the <a href="https://pkg.go.dev/github.com/adobe/koperator/api/">Godoc</a> or <a href="https://github.com/adobe/koperator/tree/master/api">source</a> for details.</p>
+<p>Please refer to the <a href="https://pkg.go.dev/github.com/adobe/koperator/api/">Godoc</a> or <a href="https://github.com/adobe/koperator/tree/main/api">source</a> for details.</p>
 </div>
 {{ end }}

--- a/content/docs/benchmarks/_index.md
+++ b/content/docs/benchmarks/_index.md
@@ -74,10 +74,10 @@ How to setup the environment for the Kafka Performance Test.
 1. Install the Koperator CustomResourceDefinition resources (adjust the version number to the Koperator release you want to install) and the corresponding version of Koperator, the Operator for managing Apache Kafka on Kubernetes.
 
     ```bash
-    kubectl apply -f https://raw.githubusercontent.com/adobe/koperator/refs/heads/master/config/base/crds/kafka.banzaicloud.io_cruisecontroloperations.yaml
-    kubectl apply -f https://raw.githubusercontent.com/adobe/koperator/refs/heads/master/config/base/crds/kafka.banzaicloud.io_kafkaclusters.yaml
-    kubectl apply -f https://raw.githubusercontent.com/adobe/koperator/refs/heads/master/config/base/crds/kafka.banzaicloud.io_kafkatopics.yaml
-    kubectl apply -f https://raw.githubusercontent.com/adobe/koperator/refs/heads/master/config/base/crds/kafka.banzaicloud.io_kafkausers.yaml
+    kubectl apply -f https://raw.githubusercontent.com/adobe/koperator/refs/heads/main/config/base/crds/kafka.banzaicloud.io_cruisecontroloperations.yaml
+    kubectl apply -f https://raw.githubusercontent.com/adobe/koperator/refs/heads/main/config/base/crds/kafka.banzaicloud.io_kafkaclusters.yaml
+    kubectl apply -f https://raw.githubusercontent.com/adobe/koperator/refs/heads/main/config/base/crds/kafka.banzaicloud.io_kafkatopics.yaml
+    kubectl apply -f https://raw.githubusercontent.com/adobe/koperator/refs/heads/main/config/base/crds/kafka.banzaicloud.io_kafkausers.yaml
     ```
 
     OCI registries have no floating "latest" tag, so `--version` is required:
@@ -90,7 +90,7 @@ How to setup the environment for the Kafka Performance Test.
     --version {{< param "latest_version" >}}
     ```
 
-1. Create a 3-broker Kafka Cluster using [this YAML file](https://raw.githubusercontent.com/adobe/koperator/master/docs/benchmarks/infrastructure/kafka.yaml).
+1. Create a 3-broker Kafka Cluster using [this YAML file](https://raw.githubusercontent.com/adobe/koperator/main/docs/benchmarks/infrastructure/kafka.yaml).
 
     This will install 3 brokers with fast SSD. If you would like the brokers in different zones, modify the following configurations to match your environment and use them in the broker configurations:
 
@@ -159,7 +159,7 @@ Monitoring environment is automatically installed. To monitor the infrastructure
 
 ## Run the tests
 
-1. Run performance test against the cluster, by building [this Docker image](https://raw.githubusercontent.com/adobe/koperator/master/docs/benchmarks/loadgens/Dockerfile).
+1. Run performance test against the cluster, by building [this Docker image](https://raw.githubusercontent.com/adobe/koperator/main/docs/benchmarks/loadgens/Dockerfile).
 
     ```bash
     docker build -t <yourname>/perfload:0.1.0 /loadgens

--- a/content/docs/configurations/crd/_index.md
+++ b/content/docs/configurations/crd/_index.md
@@ -5,4 +5,4 @@ weight: 990
 
 The following sections contain the reference documentation of the various custom resource definitions (CRDs) that are specific to Koperator.
 
-For sample YAML files, see the [samples directory in the GitHub project](https://github.com/adobe/koperator/tree/master/config/samples).
+For sample YAML files, see the [samples directory in the GitHub project](https://github.com/adobe/koperator/tree/main/config/samples).

--- a/content/docs/configurations/examples/_index.md
+++ b/content/docs/configurations/examples/_index.md
@@ -11,46 +11,46 @@ You can use these examples as a base for your own Kafka cluster.
 
 This is our most descriptive KafkaCluster CR. You can find a lot of valuable explanation about the settings.
 
-- [Detailed CR with descriptions](https://github.com/adobe/koperator/blob/master/config/samples/banzaicloud_v1beta1_kafkacluster.yaml)
+- [Detailed CR with descriptions](https://github.com/adobe/koperator/blob/main/config/samples/banzaicloud_v1beta1_kafkacluster.yaml)
 
 ## Kafka cluster with monitoring
 
 This is a very simple KafkaCluster CR with Prometheus monitoring enabled.
 
-- [Simple KafkaCluster with monitoring](https://github.com/adobe/koperator/blob/master/config/samples/simplekafkacluster.yaml)
+- [Simple KafkaCluster with monitoring](https://github.com/adobe/koperator/blob/main/config/samples/simplekafkacluster.yaml)
 
 ## Kafka cluster with ACL, SSL, and rack awareness
 
 You can read more details about rack awareness [here]({{< relref "../../rackawareness/index.md" >}}).
 
-- [Use SSL and rack awareness](https://github.com/adobe/koperator/blob/master/config/samples/kafkacluster_with_ssl_groups.yaml)
+- [Use SSL and rack awareness](https://github.com/adobe/koperator/blob/main/config/samples/kafkacluster_with_ssl_groups.yaml)
 
 ## Kafka cluster with broker configuration
 
-- [Use broker configuration groups](https://github.com/adobe/koperator/blob/master/config/samples/kafkacluster_without_ssl_groups.yaml)
-- [Use independent broker configurations](https://github.com/adobe/koperator/blob/master/config/samples/kafkacluster_without_ssl.yaml)
+- [Use broker configuration groups](https://github.com/adobe/koperator/blob/main/config/samples/kafkacluster_without_ssl_groups.yaml)
+- [Use independent broker configurations](https://github.com/adobe/koperator/blob/main/config/samples/kafkacluster_without_ssl.yaml)
 
 ## Kafka cluster with custom SSL certificates for external listeners
 
 You can specify custom SSL certificates for listeners.  
 For details about SSL configuration, see {{% xref "../../ssl.md" %}}.
 
-- [Use custom SSL certificate for an external listener](https://github.com/adobe/koperator/blob/master/config/samples/kafkacluster_with_external_ssl_customcert.yaml)
-- [Use custom SSL certificate for controller and inter-broker communication](https://github.com/adobe/koperator/blob/master/config/samples/kafkacluster_with_ssl_groups_customcert.yaml). In this case you also need to provide the client SSL certificate for Koperator.  
-- [Hybrid solution](https://github.com/adobe/koperator/blob/master/config/samples/kafkacluster_with_ssl_hybrid_customcert.yaml): some listeners have custom SSL certificates and some use certificates Koperator has generated automatically using cert-manager.
+- [Use custom SSL certificate for an external listener](https://github.com/adobe/koperator/blob/main/config/samples/kafkacluster_with_external_ssl_customcert.yaml)
+- [Use custom SSL certificate for controller and inter-broker communication](https://github.com/adobe/koperator/blob/main/config/samples/kafkacluster_with_ssl_groups_customcert.yaml). In this case you also need to provide the client SSL certificate for Koperator.  
+- [Hybrid solution](https://github.com/adobe/koperator/blob/main/config/samples/kafkacluster_with_ssl_hybrid_customcert.yaml): some listeners have custom SSL certificates and some use certificates Koperator has generated automatically using cert-manager.
 
 ## Kafka cluster with SASL
 
 You can use SASL authentication on the listeners.
 For details, see {{% xref "../../external-listener/index.md" %}}.
 
-- [Use SASL authentication on the listeners](https://github.com/adobe/koperator/blob/master/config/samples/simplekafkacluster_with_sasl.yaml)
+- [Use SASL authentication on the listeners](https://github.com/adobe/koperator/blob/main/config/samples/simplekafkacluster_with_sasl.yaml)
 
 ## Kafka cluster with load balancers and brokers in the same availability zone
 
 You can create a broker-ingress mapping to eliminate traffic across availability zones between load balancers and brokers by configuring load balancers for brokers in same availability zone.
 
-- [Load balancers and brokers in same availability zone](https://github.com/adobe/koperator/blob/master/config/samples/simplekafkacluster-with-brokerbindings.yaml)
+- [Load balancers and brokers in same availability zone](https://github.com/adobe/koperator/blob/main/config/samples/simplekafkacluster-with-brokerbindings.yaml)
 
 ## Kafka cluster with custom advertised address for external listeners and brokers
 
@@ -59,24 +59,24 @@ This is useful when you're advertising the brokers on an IP address different fr
 You can also set custom advertised address for external listeners.  
 For details, see {{% xref "../../external-listener/index.md" %}}.
 
-- [Custom advertised address for external listeners](https://github.com/adobe/koperator/blob/master/config/samples/simplekafkacluster-with-nodeport-external.yaml)
+- [Custom advertised address for external listeners](https://github.com/adobe/koperator/blob/main/config/samples/simplekafkacluster-with-nodeport-external.yaml)
 
 ## Kafka cluster with Kubernetes scheduler affinity settings
 
 You can set node [affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/) for your brokers.
 
-- [Custom affinity settings](https://github.com/adobe/koperator/blob/master/config/samples/simplekafkacluster_affinity.yaml)
+- [Custom affinity settings](https://github.com/adobe/koperator/blob/main/config/samples/simplekafkacluster_affinity.yaml)
 
 ## Kafka cluster with custom storage class
 
 You can configure your brokers to use custom [storage classes](https://kubernetes.io/docs/concepts/storage/storage-classes/).
 
-- [Custom storage class](https://github.com/adobe/koperator/blob/master/config/samples/simplekafkacluster_ebs_csi.yaml)
+- [Custom storage class](https://github.com/adobe/koperator/blob/main/config/samples/simplekafkacluster_ebs_csi.yaml)
 
 ## Kafka cluster with KRaft mode (ZooKeeper-free)
 
 You can deploy Kafka clusters using KRaft mode, which eliminates the need for ZooKeeper by using Kafka's built-in consensus mechanism. This is the future of Kafka and is recommended for new deployments.
 
-- [Simple KafkaCluster with KRaft mode](https://github.com/adobe/koperator/blob/master/config/samples/kraft/simplekafkacluster_kraft.yaml)
+- [Simple KafkaCluster with KRaft mode](https://github.com/adobe/koperator/blob/main/config/samples/kraft/simplekafkacluster_kraft.yaml)
 
 For detailed information about KRaft configuration and deployment, see {{% xref "../../kraft.md" %}}.

--- a/content/docs/cruisecontroloperation.md
+++ b/content/docs/cruisecontroloperation.md
@@ -163,7 +163,7 @@ status:
 - The `state` shows the progress of the request.  
 - The `summary` is Cruise Control's optimization proposal. It shows the scope of the changes that Cruise Control will apply through the operation.  
 - The `retryCount` field shows the number of retries when a task has failed and `cruiseControlOperation.spec.errorPolicy` is set to `retry`. In this case, the `status.failedTask` field shows the history of the failed tasks (including their error messages).  
-For further information on the fields, see the [source code](https://github.com/adobe/koperator/blob/master/api/v1alpha1/cruisecontroloperation_types.go).
+For further information on the fields, see the [source code](https://github.com/adobe/koperator/blob/main/api/v1alpha1/cruisecontroloperation_types.go).
 
 ## Control the created CruiseControlOperation {#control-cruisecontroloperation}
 

--- a/content/docs/delete-kafka-operator.md
+++ b/content/docs/delete-kafka-operator.md
@@ -75,10 +75,10 @@ In case you want to delete the Koperator from your cluster, note that because of
 
 1. Delete Koperator Custom Resource Definitions (CRDs).
     ```
-    kubectl delete -f https://raw.githubusercontent.com/adobe/koperator/refs/heads/master/config/base/crds/kafka.banzaicloud.io_cruisecontroloperations.yaml
-    kubectl delete -f https://raw.githubusercontent.com/adobe/koperator/refs/heads/master/config/base/crds/kafka.banzaicloud.io_kafkaclusters.yaml
-    kubectl delete -f https://raw.githubusercontent.com/adobe/koperator/refs/heads/master/config/base/crds/kafka.banzaicloud.io_kafkatopics.yaml
-    kubectl delete -f https://raw.githubusercontent.com/adobe/koperator/refs/heads/master/config/base/crds/kafka.banzaicloud.io_kafkausers.yaml
+    kubectl delete -f https://raw.githubusercontent.com/adobe/koperator/refs/heads/main/config/base/crds/kafka.banzaicloud.io_cruisecontroloperations.yaml
+    kubectl delete -f https://raw.githubusercontent.com/adobe/koperator/refs/heads/main/config/base/crds/kafka.banzaicloud.io_kafkaclusters.yaml
+    kubectl delete -f https://raw.githubusercontent.com/adobe/koperator/refs/heads/main/config/base/crds/kafka.banzaicloud.io_kafkatopics.yaml
+    kubectl delete -f https://raw.githubusercontent.com/adobe/koperator/refs/heads/main/config/base/crds/kafka.banzaicloud.io_kafkausers.yaml
     ```
 
 ## Uninstall Prometheus operator

--- a/content/docs/e2e-tutorial/koperator-install.md
+++ b/content/docs/e2e-tutorial/koperator-install.md
@@ -41,16 +41,16 @@ The Koperator requires several Custom Resource Definitions to manage Kafka clust
 
 ```bash
 # Install KafkaCluster CRD
-kubectl apply --server-side -f https://raw.githubusercontent.com/adobe/koperator/refs/heads/master/config/base/crds/kafka.banzaicloud.io_kafkaclusters.yaml
+kubectl apply --server-side -f https://raw.githubusercontent.com/adobe/koperator/refs/heads/main/config/base/crds/kafka.banzaicloud.io_kafkaclusters.yaml
 
 # Install KafkaTopic CRD
-kubectl apply --server-side -f https://raw.githubusercontent.com/adobe/koperator/refs/heads/master/config/base/crds/kafka.banzaicloud.io_kafkatopics.yaml
+kubectl apply --server-side -f https://raw.githubusercontent.com/adobe/koperator/refs/heads/main/config/base/crds/kafka.banzaicloud.io_kafkatopics.yaml
 
 # Install KafkaUser CRD
-kubectl apply --server-side -f https://raw.githubusercontent.com/adobe/koperator/refs/heads/master/config/base/crds/kafka.banzaicloud.io_kafkausers.yaml
+kubectl apply --server-side -f https://raw.githubusercontent.com/adobe/koperator/refs/heads/main/config/base/crds/kafka.banzaicloud.io_kafkausers.yaml
 
 # Install CruiseControlOperation CRD
-kubectl apply --server-side -f https://raw.githubusercontent.com/adobe/koperator/refs/heads/master/config/base/crds/kafka.banzaicloud.io_cruisecontroloperations.yaml
+kubectl apply --server-side -f https://raw.githubusercontent.com/adobe/koperator/refs/heads/main/config/base/crds/kafka.banzaicloud.io_cruisecontroloperations.yaml
 ```
 
 ### Verify CRD Installation
@@ -239,7 +239,7 @@ If CRDs are not properly installed:
 ```bash
 # Reinstall CRDs
 kubectl delete crd kafkaclusters.kafka.banzaicloud.io
-kubectl apply --server-side -f https://raw.githubusercontent.com/adobe/koperator/refs/heads/master/config/base/crds/kafka.banzaicloud.io_kafkaclusters.yaml
+kubectl apply --server-side -f https://raw.githubusercontent.com/adobe/koperator/refs/heads/main/config/base/crds/kafka.banzaicloud.io_kafkaclusters.yaml
 
 # Check CRD status
 kubectl get crd kafkaclusters.kafka.banzaicloud.io -o yaml

--- a/content/docs/external-listener/index.md
+++ b/content/docs/external-listener/index.md
@@ -127,7 +127,7 @@ To configure an external listener that uses the LoadBalancer access method, comp
                       tlsSecretName: heptio-contour/cluster-ssl
       ```
 
-      For a complete example, see the [Contour sample](https://github.com/adobe/koperator/blob/master/config/samples/simplekafkacluster_with_contour.yaml).
+      For a complete example, see the [Contour sample](https://github.com/adobe/koperator/blob/main/config/samples/simplekafkacluster_with_contour.yaml).
 
 1. Configure additional parameters for the ingress controller as needed for your environment, for example, number of replicas, resource requirements and resource limits. You can configure such parameters using the *envoyConfig* and *contourIngressConfig* fields, respectively.
 1. (Optional) For external access through a static URL instead of the load balancer's public IP, specify the URL in the `hostnameOverride` field of the external listener that resolves to the public IP of the load balancer. The broker address will be advertised as, `advertised.listeners=EXTERNAL1://kafka-1.dev.my.domain:<broker port number>`.

--- a/content/docs/install-kafka-operator.md
+++ b/content/docs/install-kafka-operator.md
@@ -491,10 +491,10 @@ Koperator can be deployed using its [Helm chart](https://github.com/adobe/kopera
 1. Install the Koperator CustomResourceDefinition resources (adjust the version number to the Koperator release you want to install). This is performed in a separate step to allow you to uninstall and reinstall Koperator without deleting your installed custom resources.
 
     ```bash
-    kubectl apply -f https://raw.githubusercontent.com/adobe/koperator/refs/heads/master/config/base/crds/kafka.banzaicloud.io_cruisecontroloperations.yaml
-    kubectl apply -f https://raw.githubusercontent.com/adobe/koperator/refs/heads/master/config/base/crds/kafka.banzaicloud.io_kafkaclusters.yaml
-    kubectl apply -f https://raw.githubusercontent.com/adobe/koperator/refs/heads/master/config/base/crds/kafka.banzaicloud.io_kafkatopics.yaml
-    kubectl apply -f https://raw.githubusercontent.com/adobe/koperator/refs/heads/master/config/base/crds/kafka.banzaicloud.io_kafkausers.yaml
+    kubectl apply -f https://raw.githubusercontent.com/adobe/koperator/refs/heads/main/config/base/crds/kafka.banzaicloud.io_cruisecontroloperations.yaml
+    kubectl apply -f https://raw.githubusercontent.com/adobe/koperator/refs/heads/main/config/base/crds/kafka.banzaicloud.io_kafkaclusters.yaml
+    kubectl apply -f https://raw.githubusercontent.com/adobe/koperator/refs/heads/main/config/base/crds/kafka.banzaicloud.io_kafkatopics.yaml
+    kubectl apply -f https://raw.githubusercontent.com/adobe/koperator/refs/heads/main/config/base/crds/kafka.banzaicloud.io_kafkausers.yaml
     ```
 
     Expected output:
@@ -621,7 +621,7 @@ Koperator can be deployed using its [Helm chart](https://github.com/adobe/kopera
         ```bash
         kubectl create \
         -n kafka \
-        -f https://raw.githubusercontent.com/adobe/koperator/master/config/samples/kraft/simplekafkacluster_kraft.yaml
+        -f https://raw.githubusercontent.com/adobe/koperator/main/config/samples/kraft/simplekafkacluster_kraft.yaml
         ```
 
     Expected output:

--- a/content/docs/kraft.md
+++ b/content/docs/kraft.md
@@ -271,4 +271,4 @@ kubectl logs kafka-controller-3-xxx -f
 
 - [Apache Kafka KRaft Documentation](https://kafka.apache.org/documentation/#kraft)
 - [KIP-500: Replace ZooKeeper with a Self-Managed Metadata Quorum](https://cwiki.apache.org/confluence/display/KAFKA/KIP-500%3A+Replace+ZooKeeper+with+a+Self-Managed+Metadata+Quorum)
-- [Koperator KRaft Sample Configuration](https://github.com/adobe/koperator/blob/master/config/samples/kraft/simplekafkacluster_kraft.yaml)
+- [Koperator KRaft Sample Configuration](https://github.com/adobe/koperator/blob/main/config/samples/kraft/simplekafkacluster_kraft.yaml)

--- a/content/docs/license.md
+++ b/content/docs/license.md
@@ -29,7 +29,7 @@ limitations under the License.
 
 ## Third-Party Components
 
-This project includes third-party components that are subject to their own license terms. See the [NOTICE](https://github.com/adobe/koperator/blob/master/NOTICE) file in the source repository for details.
+This project includes third-party components that are subject to their own license terms. See the [NOTICE](https://github.com/adobe/koperator/blob/main/NOTICE) file in the source repository for details.
 
 ## Contributing
 

--- a/content/docs/monitoring/_index.md
+++ b/content/docs/monitoring/_index.md
@@ -58,7 +58,7 @@ Prometheus must be configured to recognize these annotations. The following exam
       target_label: __address__
 ```
 
-If you are using the provided [CR](https://github.com/adobe/koperator/blob/master/config/samples/banzaicloud_v1beta1_kafkacluster.yaml), the operator installs the official [jmx exporter](https://github.com/prometheus/jmx_exporter) for Prometheus.
+If you are using the provided [CR](https://github.com/adobe/koperator/blob/main/config/samples/banzaicloud_v1beta1_kafkacluster.yaml), the operator installs the official [jmx exporter](https://github.com/prometheus/jmx_exporter) for Prometheus.
 
 To change this behavior, modify the following lines at the end of the CR.
 

--- a/content/docs/ssl.md
+++ b/content/docs/ssl.md
@@ -31,7 +31,7 @@ If `sslSecrets.create` is `false`, the operator will look for the secret at `ssl
 
 ### Listeners not used for internal broker and controller communication
 
-In [this **KafkaCluster** custom resource](https://github.com/adobe/koperator/blob/master/config/samples/kafkacluster_with_ssl_hybrid_customcert.yaml), SSL is enabled for all listeners, and certificates are automatically generated for "inner" and "controller" listeners. The "external" and "internal" listeners will use the user-provided certificates. The **serverSSLCertSecret** key is a reference to the Kubernetes secret that contains the server certificate for the listener to be used for SSL communication.
+In [this **KafkaCluster** custom resource](https://github.com/adobe/koperator/blob/main/config/samples/kafkacluster_with_ssl_hybrid_customcert.yaml), SSL is enabled for all listeners, and certificates are automatically generated for "inner" and "controller" listeners. The "external" and "internal" listeners will use the user-provided certificates. The **serverSSLCertSecret** key is a reference to the Kubernetes secret that contains the server certificate for the listener to be used for SSL communication.
 
 In the server secret, the following keys must be set:
 
@@ -45,7 +45,7 @@ The certificates in the listener configuration must be in JKS format.
 
 ### Listeners used for internal broker or controller communication
 
-In [this **KafkaCluster** custom resource](https://github.com/adobe/koperator/blob/master/config/samples/kafkacluster_with_ssl_groups_customcert.yaml), SSL is enabled for all listeners, and user-provided server certificates. In that case, when a custom certificate is used for a listener which is used for internal broker or controller communication, you must also specify the client certificate. The client certificate will be used by Koperator, Cruise Control, Cruise Control Metrics Reporter to communicate on SSL. The **clientSSLCertSecret** key is a reference to the Kubernetes secret where the custom client SSL certificate can be provided. The client certificate must be signed by the same CA authority as the server certificate for the corresponding listener. The **clientSSLCertSecret** has to be in the **KafkaCluster** custom resource spec field.
+In [this **KafkaCluster** custom resource](https://github.com/adobe/koperator/blob/main/config/samples/kafkacluster_with_ssl_groups_customcert.yaml), SSL is enabled for all listeners, and user-provided server certificates. In that case, when a custom certificate is used for a listener which is used for internal broker or controller communication, you must also specify the client certificate. The client certificate will be used by Koperator, Cruise Control, Cruise Control Metrics Reporter to communicate on SSL. The **clientSSLCertSecret** key is a reference to the Kubernetes secret where the custom client SSL certificate can be provided. The client certificate must be signed by the same CA authority as the server certificate for the corresponding listener. The **clientSSLCertSecret** has to be in the **KafkaCluster** custom resource spec field.
 The client secret must contain the keystore and truststore JKS files and the password for them in base64 encoded format.
 
 In the server secret the following keys must be set:

--- a/content/docs/upgrade-kafka-operator.md
+++ b/content/docs/upgrade-kafka-operator.md
@@ -13,10 +13,10 @@ When upgrading your Koperator deployment to a new version, complete the followin
 1. Replace the KafkaCluster CRDs with the new ones on your cluster by running the following commands:
 
     ```bash
-    kubectl apply -f https://raw.githubusercontent.com/adobe/koperator/refs/heads/master/config/base/crds/kafka.banzaicloud.io_cruisecontroloperations.yaml
-    kubectl apply -f https://raw.githubusercontent.com/adobe/koperator/refs/heads/master/config/base/crds/kafka.banzaicloud.io_kafkaclusters.yaml
-    kubectl apply -f https://raw.githubusercontent.com/adobe/koperator/refs/heads/master/config/base/crds/kafka.banzaicloud.io_kafkatopics.yaml
-    kubectl apply -f https://raw.githubusercontent.com/adobe/koperator/refs/heads/master/config/base/crds/kafka.banzaicloud.io_kafkausers.yaml
+    kubectl apply -f https://raw.githubusercontent.com/adobe/koperator/refs/heads/main/config/base/crds/kafka.banzaicloud.io_cruisecontroloperations.yaml
+    kubectl apply -f https://raw.githubusercontent.com/adobe/koperator/refs/heads/main/config/base/crds/kafka.banzaicloud.io_kafkaclusters.yaml
+    kubectl apply -f https://raw.githubusercontent.com/adobe/koperator/refs/heads/main/config/base/crds/kafka.banzaicloud.io_kafkatopics.yaml
+    kubectl apply -f https://raw.githubusercontent.com/adobe/koperator/refs/heads/main/config/base/crds/kafka.banzaicloud.io_kafkausers.yaml
     ```
 
 1. Update your Koperator deployment by running (OCI registries have no floating "latest" tag, so `--version` is required):


### PR DESCRIPTION
Companion to #282 (code-branch rename). Part 2 of 2.

Updates all `adobe/koperator` **`master` → `main`** branch URLs in the published docs so install/upgrade/delete commands and source links keep resolving after the default-branch rename (47 URLs across 14 files: raw CRD-apply commands, `blob`/`tree` source links, benchmark asset links, and the crd-docs-generator template).

External `/master` links (confluentinc, prometheus/jmx_exporter) are left unchanged. The `gh-pages` branch itself is **not** renamed — only the code default branch is.

Merge after the `master → main` rename is done (order doesn't strictly matter for these, since they're doc links, but keeping it after avoids transient confusion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
