### PR TITLE
fix: make Renovate actually track the Kafka docker image version

### DIFF
--- a/docker/kafka/Dockerfile
+++ b/docker/kafka/Dockerfile
@@ -1,37 +1,43 @@
 ARG scala_version=2.13
-ARG kafka_version=3.9.2 # renovate: datasource=github-tags depName=apache/kafka
+# Renovate is pinned to the 3.x line (see the apache/kafka packageRule in renovate.json).
+# Kafka 4.x removes ZooKeeper support entirely (KRaft-only) and needs an operator-side
+# migration; when this repo is ready for that, drop the allowedVersions constraint too.
+# Also bump java_version to 25 (next LTS after 21) as part of that migration.
+ARG KAFKA_VERSION=3.9.2 # renovate: datasource=github-tags depName=apache/kafka
 ARG java_version=21
 
 FROM alpine:latest@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b AS kafka_dist
 
 ARG scala_version
-ARG kafka_version
-ARG kafka_distro_base_url=https://downloads.apache.org/kafka
+ARG KAFKA_VERSION
+# archive.apache.org retains every historical release permanently; downloads.apache.org
+# only mirrors the newest active releases and 404s once a pinned version ages out.
+ARG kafka_distro_base_url=https://archive.apache.org/dist/kafka
 
-ENV kafka_distro=kafka_$scala_version-$kafka_version.tgz
+ENV kafka_distro=kafka_$scala_version-$KAFKA_VERSION.tgz
 ENV kafka_distro_asc=$kafka_distro.asc
 
 WORKDIR /var/tmp
 
 # Download, verify, extract and clean up Kafka in single layer
 RUN apk add --no-cache gnupg wget && \
-    wget -q $kafka_distro_base_url/$kafka_version/$kafka_distro && \
-    wget -q $kafka_distro_base_url/$kafka_version/$kafka_distro_asc && \
+    wget -q $kafka_distro_base_url/$KAFKA_VERSION/$kafka_distro && \
+    wget -q $kafka_distro_base_url/$KAFKA_VERSION/$kafka_distro_asc && \
     wget -q $kafka_distro_base_url/KEYS && \
     gpg --import KEYS && \
     gpg --verify $kafka_distro_asc $kafka_distro && \
     tar -xzf $kafka_distro && \
-    rm -rf kafka_$scala_version-$kafka_version/bin/windows \
-           kafka_$scala_version-$kafka_version/site-docs \
+    rm -rf kafka_$scala_version-$KAFKA_VERSION/bin/windows \
+           kafka_$scala_version-$KAFKA_VERSION/site-docs \
            $kafka_distro $kafka_distro_asc KEYS && \
-    find kafka_$scala_version-$kafka_version -name "*.bat" -delete
+    find kafka_$scala_version-$KAFKA_VERSION -name "*.bat" -delete
 
 
 # backported from https://github.com/docker-library/openjdk/blob/master/18/jdk/slim-bullseye/Dockerfile
 FROM debian:bullseye-slim@sha256:f18adf4e1d04b1d8ba48025b8e35003f4c748ddd3dd8e875fe4e7d9a9c0dec84
 
 ARG scala_version
-ARG kafka_version
+ARG KAFKA_VERSION
 ARG java_version
 ARG VERSION
 ARG BUILT_AT
@@ -119,7 +125,7 @@ RUN set -eux; \
 	javac --version; \
 	java --version
 
-ENV KAFKA_VERSION=$kafka_version \
+ENV KAFKA_VERSION=$KAFKA_VERSION \
     SCALA_VERSION=$scala_version \
     KAFKA_HOME=/opt/kafka
 
@@ -132,7 +138,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
     mkdir -p ${KAFKA_HOME}/libs/extensions
 
-COPY --from=kafka_dist /var/tmp/kafka_$scala_version-$kafka_version ${KAFKA_HOME}
+COPY --from=kafka_dist /var/tmp/kafka_$scala_version-$KAFKA_VERSION ${KAFKA_HOME}
 COPY opt/kafka/config/log4j.properties ${KAFKA_HOME}/config/log4j.properties
 
 # Optimize Kafka installation: remove unnecessary files and set permissions

--- a/renovate.json
+++ b/renovate.json
@@ -98,6 +98,13 @@
       ]
     },
     {
+      "matchPackageNames": [
+        "apache/kafka"
+      ],
+      "allowedVersions": "<4.0.0",
+      "description": "Kafka 4.x drops ZooKeeper support (KRaft-only) and needs an operator-side migration. Keep Renovate on the 3.x line until docker/kafka/Dockerfile is ready for that jump, then remove this rule."
+    },
+    {
       "groupName": "kafka docker images (major)",
       "groupSlug": "kafka-docker-major",
       "matchFileNames": [


### PR DESCRIPTION
## Summary

Renovate has never once tracked `apache/kafka` as a dependency here — every historical Kafka bump (3.1.2 → 3.9.2) has been a manually-branched PR, never a `renovate/*` one, and the live [Dependency Dashboard](https://github.com/adobe/koperator/issues/156) confirms `docker/kafka/Dockerfile`'s Kafka ARG has never shown up under detected dependencies.

**Root cause**: the `customManagers` regex in `renovate.json` for `ARG_VERSION=...` comments requires an all-caps variable name immediately before `_VERSION=`:
```
(?<depName>[A-Z][A-Z0-9_]*)_VERSION\s*=\s*...
```
`docker/kafka/Dockerfile` declared `ARG kafka_version=3.9.2` (lowercase), so the regex never matched and the dependency was silently dropped — no error, no warning, just absence from tracking.

## Changes

- Rename `kafka_version` → `KAFKA_VERSION` throughout `docker/kafka/Dockerfile` so the customManager regex matches and Renovate starts tracking `apache/kafka` again.
- Add a `renovate.json` packageRule pinning `apache/kafka` to `allowedVersions: "<4.0.0"`. Kafka 4.x drops ZooKeeper support entirely (KRaft-only) and needs an operator-side migration, so we don't want an unreviewed major-version PR landing the moment tracking starts working.
- Add Dockerfile comments pointing future maintainers at the `allowedVersions` pin and noting `java_version` should be bumped to 25 (next LTS after 21) as part of that eventual 4.x migration.
- **Separate, pre-existing bug found while verifying the fix with a real `docker build`**: `kafka_distro_base_url` defaulted to `downloads.apache.org`, which only mirrors the newest active Kafka releases (currently 4.1.2/4.2.1/4.3.1). The pinned 3.9.2 has already aged off it (confirmed `404`), so any cache-cold build of this Dockerfile was already broken today, independent of any future patch release. Switched the default to `archive.apache.org`, which retains every release permanently.

## Test plan
- [x] `renovate-config-validator` passes against the updated `renovate.json`
- [x] `docker build --check` (BuildKit lint) — no warnings
- [x] `docker build --target kafka_dist` with `--build-arg kafka_distro_base_url=https://archive.apache.org/dist/kafka` — succeeds, GPG signature verifies
- [x] `docker build --no-cache --target kafka_dist` using the new default (no override) — succeeds end-to-end
- [ ] Confirm Renovate picks up `apache/kafka` under Detected Dependencies on the next Dependency Dashboard refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)