### PR TITLE
fix: unblock two more dependencies silently dropped by Renovate customManagers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,9 +23,9 @@ LICENSEI_VERSION = 0.9.0 # renovate: datasource=github-releases depName=goph/lic
 CONTROLLER_GEN_VERSION = v0.21.0 # renovate: datasource=github-releases depName=kubernetes-sigs/controller-tools
 ENVTEST_K8S_VERSION = 1.36.2 # renovate: datasource=github-releases depName=kubernetes-sigs/controller-tools extractVersion=^envtest-v(?<version>.+)$
 SETUP_ENVTEST_VERSION := latest
-ADDLICENSE_VERSION := 1.2.0 # renovate: datasource=github-releases depName=google/addlicense
-GOTEMPLATE_VERSION := 3.12.0 # renovate: datasource=github-releases depName=cznic/gotemplate
-MOCKGEN_VERSION := 0.6.0 # renovate: datasource=github-releases depName=uber-go/mock
+ADDLICENSE_VERSION = 1.2.0 # renovate: datasource=github-releases depName=google/addlicense
+GOTEMPLATE_VERSION = 3.12.0 # renovate: datasource=github-releases depName=cznic/gotemplate
+MOCKGEN_VERSION = 0.6.0 # renovate: datasource=github-releases depName=uber-go/mock
 
 GOPROXY=https://proxy.golang.org
 

--- a/renovate.json
+++ b/renovate.json
@@ -36,11 +36,11 @@
         "/tests/e2e/versions\\.go$/"
       ],
       "matchStrings": [
-        "\\s*(?<depName>\\w+)\\s*=\\s*\"(?<currentValue>[^\"]+)\"\\s*//\\s*renovate:\\s*datasource=(?<datasource>[^\\s]+)\\s*depName=(?<packageName>[^\\s]+)\\s*registryUrl=(?<registryUrl>\\S+)"
+        "\\s*(?<depName>\\w+)\\s*=\\s*\"(?<currentValue>[^\"]+)\"\\s*//\\s*renovate:\\s*datasource=(?<datasource>[^\\s]+)\\s*depName=(?<packageName>[^\\s]+)(?:\\s*registryUrl=(?<registryUrl>\\S+))?"
       ],
       "datasourceTemplate": "{{datasource}}",
       "depNameTemplate": "{{packageName}}",
-      "registryUrlTemplate": "{{registryUrl}}"
+      "registryUrlTemplate": "{{#if registryUrl}}{{{registryUrl}}}{{/if}}"
     },
     {
       "customType": "regex",


### PR DESCRIPTION
## Summary

Follow-up to #284. That PR found Renovate never tracked `apache/kafka` because a customManager regex required an all-caps variable name. While auditing every other `# renovate:` / `// renovate:` annotation in the repo against its manager regex (not just for case mismatches), two more silently-dropped dependencies turned up — same failure mode (regex doesn't match, dependency vanishes with no error), different specific mismatch. Confirmed both by testing the actual regexes against the actual file content, and cross-referenced against the live [Dependency Dashboard](https://github.com/adobe/koperator/issues/156), which is missing exactly these entries today.

## Changes

- **Makefile**: `ADDLICENSE_VERSION`, `GOTEMPLATE_VERSION`, `MOCKGEN_VERSION` were declared with `:=` while the customManager regex only matches a plain `=`. `google/addlicense`, `cznic/gotemplate` and `uber-go/mock` were never tracked as a result. Switched to `=`, matching the sibling entries in the same file that already work (`GOLANGCI_VERSION`, `LICENSEI_VERSION`, `CONTROLLER_GEN_VERSION`, `ENVTEST_K8S_VERSION`). Harmless — these are static version literals, so `=` vs `:=` (recursive vs simple Make expansion) makes no behavioral difference.
- **tests/e2e/versions.go**: `ZookeeperOperatorVersion` uses `datasource=docker`, which has no concept of a Helm repo `registryUrl`, but the customManager regex required `registryUrl=` unconditionally (every other entry in the file is a Helm chart and does supply one). Made `registryUrl` optional in the regex and template, mirroring the optional-group pattern already used for `extractVersion` in the Dockerfile/Makefile manager.

## Test plan
- [x] `renovate-config-validator` passes against the updated `renovate.json`
- [x] Standalone Node regex test confirms all previously-silent entries (`google/addlicense`, `cznic/gotemplate`, `uber-go/mock`, `ghcr.io/adobe/helm-charts/zookeeper-operator`) now extract correctly, alongside the entries that already worked
- [ ] Confirm all four show up under Detected Dependencies on the next Dependency Dashboard refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)