### PR TITLE
fix: wrong depName for gotemplate + spurious empty registryUrl warning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ CONTROLLER_GEN_VERSION = v0.21.0 # renovate: datasource=github-releases depName=
 ENVTEST_K8S_VERSION = 1.36.2 # renovate: datasource=github-releases depName=kubernetes-sigs/controller-tools extractVersion=^envtest-v(?<version>.+)$
 SETUP_ENVTEST_VERSION := latest
 ADDLICENSE_VERSION = 1.2.0 # renovate: datasource=github-releases depName=google/addlicense
-GOTEMPLATE_VERSION = 3.12.0 # renovate: datasource=github-releases depName=cznic/gotemplate
+GOTEMPLATE_VERSION = 3.12.0 # renovate: datasource=github-releases depName=coveooss/gotemplate
 MOCKGEN_VERSION = 0.6.0 # renovate: datasource=github-releases depName=uber-go/mock
 
 GOPROXY=https://proxy.golang.org

--- a/renovate.json
+++ b/renovate.json
@@ -36,11 +36,23 @@
         "/tests/e2e/versions\\.go$/"
       ],
       "matchStrings": [
-        "\\s*(?<depName>\\w+)\\s*=\\s*\"(?<currentValue>[^\"]+)\"\\s*//\\s*renovate:\\s*datasource=(?<datasource>[^\\s]+)\\s*depName=(?<packageName>[^\\s]+)(?:\\s*registryUrl=(?<registryUrl>\\S+))?"
+        "\\s*(?<depName>\\w+)\\s*=\\s*\"(?<currentValue>[^\"]+)\"\\s*//\\s*renovate:\\s*datasource=(?<datasource>[^\\s]+)\\s*depName=(?<packageName>[^\\s]+)\\s*registryUrl=(?<registryUrl>\\S+)"
       ],
       "datasourceTemplate": "{{datasource}}",
       "depNameTemplate": "{{packageName}}",
-      "registryUrlTemplate": "{{#if registryUrl}}{{{registryUrl}}}{{/if}}"
+      "registryUrlTemplate": "{{registryUrl}}"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/tests/e2e/versions\\.go$/"
+      ],
+      "description": "Same file as above, but for datasource=docker entries, which have no notion of a Helm repo registryUrl and so never carry one. Kept as a separate manager (RE2 has no lookaround, so the split is done by requiring the literal 'docker' datasource rather than a negative match on registryUrl) so registryUrlTemplate is never evaluated for these - a templated empty string is still a defined (invalid) registryUrl to Renovate, not the same as omitting it.",
+      "matchStrings": [
+        "\\s*(?<depName>\\w+)\\s*=\\s*\"(?<currentValue>[^\"]+)\"\\s*//\\s*renovate:\\s*datasource=(?<datasource>docker)\\s*depName=(?<packageName>[^\\s]+)"
+      ],
+      "datasourceTemplate": "{{datasource}}",
+      "depNameTemplate": "{{packageName}}"
     },
     {
       "customType": "regex",


### PR DESCRIPTION
## Summary

Follow-up to #285. Both bugs fixed here only surfaced *after* #285 merged and Renovate re-evaluated `master` — visible in the Mend job log (https://developer.mend.io/github/adobe/koperator) and reflected in PR #279 / the Dependency Dashboard (#156):

```
WARN: Package lookup failures (branch="renovate/master-all-minor-patch")
{ "warnings": ["Failed to look up github-releases package cznic/gotemplate: no-result"], "files": ["Makefile"] }

WARN: Invalid regex manager registryUrl
{ "baseBranch": "master", "value": "" }
```

## Changes

1. **Wrong depName**: `Makefile`'s `GOTEMPLATE_VERSION` annotation said `depName=cznic/gotemplate`, but the Makefile actually does `go install github.com/coveooss/gotemplate/v3@v$(GOTEMPLATE_VERSION)` a few lines down. `cznic/gotemplate` doesn't exist on GitHub (confirmed 404), so the lookup could never succeed — likely a copy-paste slip from whoever originally annotated it. Fixed to `depName=coveooss/gotemplate`, which exists and has a `v3.12.0` release matching the currently pinned version.

2. **Spurious empty-string registryUrl warning**: #285's fix for `ZookeeperOperatorVersion` (datasource=docker) made `registryUrl` optional in the regex, but `registryUrlTemplate` still rendered to `""` for it, since docker deps have no Helm-repo registryUrl. A templated empty string is still a *defined* (invalid) registryUrl to Renovate, not the same as omitting it — hence the warning. Split the customManager into two: the original, unchanged, for Helm entries that always carry a `registryUrl`, plus a new one scoped to the literal `datasource=docker` (RE2 has no lookaround, so this is how the split avoids overlap without negative-lookahead tricks) that never defines `registryUrlTemplate` at all. Renovate then auto-derives the registry from the image name itself.

## Test plan

Per feedback on the previous PR, verified with a real `renovate` run instead of just the config validator:

- [x] `renovate-config-validator` passes
- [x] `renovate --platform=local --dry-run=full` (LOG_LEVEL=debug) run end-to-end against this branch, with real datasource lookups. Confirmed in the output:
  - `coveooss/gotemplate` resolves cleanly, `warnings: []`
  - `ghcr.io/adobe/helm-charts/zookeeper-operator` extracted with registryUrl auto-derived as `https://ghcr.io`, `warnings: []`
  - `apache/kafka` (from #284) still tracked, `updates: []` — 3.9.2 is in fact the latest 3.x release, nothing newer within the `allowedVersions "<4.0.0"` pin (confirmed against GitHub tags directly)
  - zero occurrences of `"invalid regex"`, `"lookup fail"`, or `"no-result"` anywhere in the full run log

🤖 Generated with [Claude Code](https://claude.com/claude-code)