### PR TITLE
test(e2e): fix flaky multi-disk & broker removal health checks

### DIFF
--- a/config/samples/banzaicloud_v1beta1_kafkacluster.yaml
+++ b/config/samples/banzaicloud_v1beta1_kafkacluster.yaml
@@ -565,7 +565,7 @@ spec:
       # The list of supported hard goals
       hard.goals=com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuCapacityGoal
       # The minimum percentage of well monitored partitions out of all the partitions
-      min.monitored.partition.percentage=0.95
+      min.valid.partition.ratio=0.95
       # The balance threshold for CPU
       cpu.balance.threshold=1.1
       # The balance threshold for disk

--- a/config/samples/kafkacluster_with_external_ssl.yaml
+++ b/config/samples/kafkacluster_with_external_ssl.yaml
@@ -138,7 +138,7 @@ spec:
       # The list of supported hard goals
       hard.goals=com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuCapacityGoal
       # The minimum percentage of well monitored partitions out of all the partitions
-      min.monitored.partition.percentage=0.95
+      min.valid.partition.ratio=0.95
       # The balance threshold for CPU
       cpu.balance.threshold=1.1
       # The balance threshold for disk

--- a/config/samples/kafkacluster_with_external_ssl_customcert.yaml
+++ b/config/samples/kafkacluster_with_external_ssl_customcert.yaml
@@ -135,7 +135,7 @@ spec:
       # The list of supported hard goals
       hard.goals=com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuCapacityGoal
       # The minimum percentage of well monitored partitions out of all the partitions
-      min.monitored.partition.percentage=0.95
+      min.valid.partition.ratio=0.95
       # The balance threshold for CPU
       cpu.balance.threshold=1.1
       # The balance threshold for disk

--- a/config/samples/kafkacluster_with_ssl_groups.yaml
+++ b/config/samples/kafkacluster_with_ssl_groups.yaml
@@ -128,7 +128,7 @@ spec:
       # The list of supported hard goals
       hard.goals=com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuCapacityGoal
       # The minimum percentage of well monitored partitions out of all the partitions
-      min.monitored.partition.percentage=0.95
+      min.valid.partition.ratio=0.95
       # The balance threshold for CPU
       cpu.balance.threshold=1.1
       # The balance threshold for disk

--- a/config/samples/kafkacluster_with_ssl_groups_customcert.yaml
+++ b/config/samples/kafkacluster_with_ssl_groups_customcert.yaml
@@ -127,7 +127,7 @@ spec:
       # The list of supported hard goals
       hard.goals=com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuCapacityGoal
       # The minimum percentage of well monitored partitions out of all the partitions
-      min.monitored.partition.percentage=0.95
+      min.valid.partition.ratio=0.95
       # The balance threshold for CPU
       cpu.balance.threshold=1.1
       # The balance threshold for disk

--- a/config/samples/kafkacluster_with_ssl_hybrid_customcert.yaml
+++ b/config/samples/kafkacluster_with_ssl_hybrid_customcert.yaml
@@ -137,7 +137,7 @@ spec:
       # The list of supported hard goals
       hard.goals=com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuCapacityGoal
       # The minimum percentage of well monitored partitions out of all the partitions
-      min.monitored.partition.percentage=0.95
+      min.valid.partition.ratio=0.95
       # The balance threshold for CPU
       cpu.balance.threshold=1.1
       # The balance threshold for disk

--- a/config/samples/kafkacluster_without_ssl.yaml
+++ b/config/samples/kafkacluster_without_ssl.yaml
@@ -133,7 +133,7 @@ spec:
       # The list of supported hard goals
       hard.goals=com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuCapacityGoal
       # The minimum percentage of well monitored partitions out of all the partitions
-      min.monitored.partition.percentage=0.95
+      min.valid.partition.ratio=0.95
       # The balance threshold for CPU
       cpu.balance.threshold=1.1
       # The balance threshold for disk

--- a/config/samples/kafkacluster_without_ssl_groups.yaml
+++ b/config/samples/kafkacluster_without_ssl_groups.yaml
@@ -119,7 +119,7 @@ spec:
       # The list of supported hard goals
       hard.goals=com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuCapacityGoal
       # The minimum percentage of well monitored partitions out of all the partitions
-      min.monitored.partition.percentage=0.95
+      min.valid.partition.ratio=0.95
       # The balance threshold for CPU
       cpu.balance.threshold=1.1
       # The balance threshold for disk

--- a/config/samples/kraft/simplekafkacluster_kraft.yaml
+++ b/config/samples/kraft/simplekafkacluster_kraft.yaml
@@ -135,6 +135,11 @@ spec:
       broker.metric.sample.store.topic=__KafkaCruiseControlModelTrainingSamples
       # The replication factor of Kafka metric sample store topic
       sample.store.topic.replication.factor=2
+      # e2e: shrink CC's sample-store topics from their 32-partitions-each default so broker/disk removal
+      # reshuffles only a few partitions (not 64) and the CC execution completes quickly; not production defaults.
+      # NOTE: CC only ever increases these partition counts (never shrinks), so this only takes effect on a fresh cluster.
+      partition.sample.store.topic.partition.count=3
+      broker.sample.store.topic.partition.count=3
       # The config for the number of Kafka sample store consumer threads
       num.sample.loading.threads=8
       # The partition assignor class for the metric samplers

--- a/config/samples/kraft/simplekafkacluster_kraft.yaml
+++ b/config/samples/kraft/simplekafkacluster_kraft.yaml
@@ -173,9 +173,8 @@ spec:
       # The list of supported hard goals
       hard.goals=com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuCapacityGoal
       # The minimum percentage of well monitored partitions out of all the partitions
-      # e2e: min.valid.partition.ratio is the REAL CC key — min.monitored.partition.percentage was renamed to it in
-      # CC PR #781 (2019); the old name is silently ignored so CC keeps its 0.995 default. Lowered so CC's load
-      # model becomes valid quickly on a tiny cluster with few partitions/windows; not production defaults
+      # e2e: lowered from CC's 0.995 default so the load model becomes valid quickly on a tiny cluster
+      # with few partitions/windows; not production defaults
       min.valid.partition.ratio=0.5
       # The balance threshold for CPU
       cpu.balance.threshold=1.1

--- a/config/samples/kraft/simplekafkacluster_kraft.yaml
+++ b/config/samples/kraft/simplekafkacluster_kraft.yaml
@@ -17,6 +17,8 @@ spec:
     cruise.control.metrics.topic.auto.create=true
     cruise.control.metrics.topic.num.partitions=1
     cruise.control.metrics.topic.replication.factor=2
+    # e2e: publish CruiseControl metrics every 15s (default 60s) so CC warms up quickly; not production defaults
+    cruise.control.metrics.reporter.metrics.reporting.interval.ms=15000
   brokerConfigGroups:
     default:
       storageConfigs:
@@ -85,7 +87,8 @@ spec:
     cruiseControlTaskSpec:
       RetryDurationMinutes: 5
     topicConfig:
-      partitions: 12
+      # e2e: fewer partitions on the __CruiseControlMetrics topic => faster CC monitoring coverage
+      partitions: 3
       replicationFactor: 3
 #    resourceRequirements:
 #      requests:
@@ -102,7 +105,8 @@ spec:
       # Configuration for the metadata client.
       # =======================================
       # The maximum interval in milliseconds between two metadata refreshes.
-      #metadata.max.age.ms=300000
+      # e2e: must be <= metric.sampling.interval.ms (CC sanityCheckSamplingPeriod); low for the fast 15s sampling
+      metadata.max.age.ms=10000
       # Client id for the Cruise Control. It is used for the metadata client.
       #client.id=kafka-cruise-control
       # The size of TCP send buffer bytes for the metadata client.
@@ -136,18 +140,25 @@ spec:
       # The partition assignor class for the metric samplers
       metric.sampler.partition.assignor.class=com.linkedin.kafka.cruisecontrol.monitor.sampling.DefaultMetricSamplerPartitionAssignor
       # The metric sampling interval in milliseconds
-      metric.sampling.interval.ms=120000
+      # e2e: sample every 15s (default 120s) so CC accrues valid windows fast; not production defaults
+      metric.sampling.interval.ms=15000
+      # e2e: CC reads the reporter interval for a sanity check and requires it <= the sampling interval
+      cruise.control.metrics.reporter.metrics.reporting.interval.ms=15000
+      # e2e: must be >= metric.sampling.interval.ms (CC sanityCheckSamplingPeriod)
       metric.anomaly.detection.interval.ms=180000
       # The partition metrics window size in milliseconds
-      partition.metrics.window.ms=300000
+      # e2e: shrink window to the 15s sampling interval so CC accrues a valid window fast; not production defaults
+      partition.metrics.window.ms=15000
       # The number of partition metric windows to keep in memory
       num.partition.metrics.windows=1
       # The minimum partition metric samples required for a partition in each window
       min.samples.per.partition.metrics.window=1
       # The broker metrics window size in milliseconds
-      broker.metrics.window.ms=300000
+      # e2e: shrink window to the 15s sampling interval to speed up CC warmup; not production defaults
+      broker.metrics.window.ms=15000
       # The number of broker metric windows to keep in memory
-      num.broker.metrics.windows=20
+      # e2e: only 2 broker windows needed for warmup on a tiny static cluster (was 20); not production defaults
+      num.broker.metrics.windows=2
       # The minimum broker metric samples required for a partition in each window
       min.samples.per.broker.metrics.window=1
       # The configuration for the BrokerCapacityConfigFileResolver (supports JBOD and non-JBOD broker capacities)
@@ -162,7 +173,10 @@ spec:
       # The list of supported hard goals
       hard.goals=com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuCapacityGoal
       # The minimum percentage of well monitored partitions out of all the partitions
-      min.monitored.partition.percentage=0.95
+      # e2e: min.valid.partition.ratio is the REAL CC key — min.monitored.partition.percentage was renamed to it in
+      # CC PR #781 (2019); the old name is silently ignored so CC keeps its 0.995 default. Lowered so CC's load
+      # model becomes valid quickly on a tiny cluster with few partitions/windows; not production defaults
+      min.valid.partition.ratio=0.5
       # The balance threshold for CPU
       cpu.balance.threshold=1.1
       # The balance threshold for disk
@@ -206,7 +220,8 @@ spec:
       # The max number of partitions to move in/out on a given broker at a given time.
       num.concurrent.partition.movements.per.broker=10
       # The interval between two execution progress checks.
-      execution.progress.check.interval.ms=10000
+      # e2e: 5s is the floor (must be >= min.execution.progress.check.interval.ms, default 5000); was 10s
+      execution.progress.check.interval.ms=5000
       # Configurations for anomaly detector
       # =======================================
       # The goal violation notifier class

--- a/config/samples/simplekafkacluster-with-brokerbindings.yaml
+++ b/config/samples/simplekafkacluster-with-brokerbindings.yaml
@@ -145,7 +145,7 @@ spec:
       # The list of supported hard goals
       hard.goals=com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuCapacityGoal
       # The minimum percentage of well monitored partitions out of all the partitions
-      min.monitored.partition.percentage=0.95
+      min.valid.partition.ratio=0.95
       # The balance threshold for CPU
       cpu.balance.threshold=1.1
       # The balance threshold for disk

--- a/config/samples/simplekafkacluster-with-nodeport-external.yaml
+++ b/config/samples/simplekafkacluster-with-nodeport-external.yaml
@@ -152,7 +152,7 @@ spec:
       # The list of supported hard goals
       hard.goals=com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuCapacityGoal
       # The minimum percentage of well monitored partitions out of all the partitions
-      min.monitored.partition.percentage=0.95
+      min.valid.partition.ratio=0.95
       # The balance threshold for CPU
       cpu.balance.threshold=1.1
       # The balance threshold for disk

--- a/config/samples/simplekafkacluster.yaml
+++ b/config/samples/simplekafkacluster.yaml
@@ -161,9 +161,8 @@ spec:
       # The list of supported hard goals
       hard.goals=com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuCapacityGoal
       # The minimum percentage of well monitored partitions out of all the partitions
-      # e2e: min.valid.partition.ratio is the REAL CC key — min.monitored.partition.percentage was renamed to it in
-      # CC PR #781 (2019); the old name is silently ignored so CC keeps its 0.995 default. Lowered so CC's load
-      # model becomes valid quickly on a tiny cluster with few partitions/windows; not production defaults
+      # e2e: lowered from CC's 0.995 default so the load model becomes valid quickly on a tiny cluster
+      # with few partitions/windows; not production defaults
       min.valid.partition.ratio=0.5
       # The balance threshold for CPU
       cpu.balance.threshold=1.1

--- a/config/samples/simplekafkacluster.yaml
+++ b/config/samples/simplekafkacluster.yaml
@@ -123,6 +123,11 @@ spec:
       broker.metric.sample.store.topic=__KafkaCruiseControlModelTrainingSamples
       # The replication factor of Kafka metric sample store topic
       sample.store.topic.replication.factor=2
+      # e2e: shrink CC's sample-store topics from their 32-partitions-each default so broker/disk removal
+      # reshuffles only a few partitions (not 64) and the CC execution completes quickly; not production defaults.
+      # NOTE: CC only ever increases these partition counts (never shrinks), so this only takes effect on a fresh cluster.
+      partition.sample.store.topic.partition.count=3
+      broker.sample.store.topic.partition.count=3
       # The config for the number of Kafka sample store consumer threads
       num.sample.loading.threads=8
       # The partition assignor class for the metric samplers

--- a/config/samples/simplekafkacluster.yaml
+++ b/config/samples/simplekafkacluster.yaml
@@ -20,6 +20,8 @@ spec:
     cruise.control.metrics.topic.auto.create=true
     cruise.control.metrics.topic.num.partitions=1
     cruise.control.metrics.topic.replication.factor=2
+    # e2e: publish CruiseControl metrics every 15s (default 60s) so CC warms up quickly; not production defaults
+    cruise.control.metrics.reporter.metrics.reporting.interval.ms=15000
   brokerConfigGroups:
     default:
       # podSecurityContext:
@@ -73,7 +75,8 @@ spec:
     cruiseControlTaskSpec:
       RetryDurationMinutes: 5
     topicConfig:
-      partitions: 12
+      # e2e: fewer partitions on the __CruiseControlMetrics topic => faster CC monitoring coverage
+      partitions: 3
       replicationFactor: 3
 #    resourceRequirements:
 #      requests:
@@ -90,7 +93,8 @@ spec:
       # Configuration for the metadata client.
       # =======================================
       # The maximum interval in milliseconds between two metadata refreshes.
-      #metadata.max.age.ms=300000
+      # e2e: must be <= metric.sampling.interval.ms (CC sanityCheckSamplingPeriod); low for the fast 15s sampling
+      metadata.max.age.ms=10000
       # Client id for the Cruise Control. It is used for the metadata client.
       #client.id=kafka-cruise-control
       # The size of TCP send buffer bytes for the metadata client.
@@ -124,18 +128,25 @@ spec:
       # The partition assignor class for the metric samplers
       metric.sampler.partition.assignor.class=com.linkedin.kafka.cruisecontrol.monitor.sampling.DefaultMetricSamplerPartitionAssignor
       # The metric sampling interval in milliseconds
-      metric.sampling.interval.ms=120000
+      # e2e: sample every 15s (default 120s) so CC accrues valid windows fast; not production defaults
+      metric.sampling.interval.ms=15000
+      # e2e: CC reads the reporter interval for a sanity check and requires it <= the sampling interval
+      cruise.control.metrics.reporter.metrics.reporting.interval.ms=15000
+      # e2e: must be >= metric.sampling.interval.ms (CC sanityCheckSamplingPeriod)
       metric.anomaly.detection.interval.ms=180000
       # The partition metrics window size in milliseconds
-      partition.metrics.window.ms=300000
+      # e2e: shrink window to the 15s sampling interval so CC accrues a valid window fast; not production defaults
+      partition.metrics.window.ms=15000
       # The number of partition metric windows to keep in memory
       num.partition.metrics.windows=1
       # The minimum partition metric samples required for a partition in each window
       min.samples.per.partition.metrics.window=1
       # The broker metrics window size in milliseconds
-      broker.metrics.window.ms=300000
+      # e2e: shrink window to the 15s sampling interval to speed up CC warmup; not production defaults
+      broker.metrics.window.ms=15000
       # The number of broker metric windows to keep in memory
-      num.broker.metrics.windows=20
+      # e2e: only 2 broker windows needed for warmup on a tiny static cluster (was 20); not production defaults
+      num.broker.metrics.windows=2
       # The minimum broker metric samples required for a partition in each window
       min.samples.per.broker.metrics.window=1
       # The configuration for the BrokerCapacityConfigFileResolver (supports JBOD and non-JBOD broker capacities)
@@ -150,7 +161,10 @@ spec:
       # The list of supported hard goals
       hard.goals=com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuCapacityGoal
       # The minimum percentage of well monitored partitions out of all the partitions
-      min.monitored.partition.percentage=0.95
+      # e2e: min.valid.partition.ratio is the REAL CC key — min.monitored.partition.percentage was renamed to it in
+      # CC PR #781 (2019); the old name is silently ignored so CC keeps its 0.995 default. Lowered so CC's load
+      # model becomes valid quickly on a tiny cluster with few partitions/windows; not production defaults
+      min.valid.partition.ratio=0.5
       # The balance threshold for CPU
       cpu.balance.threshold=1.1
       # The balance threshold for disk
@@ -194,7 +208,8 @@ spec:
       # The max number of partitions to move in/out on a given broker at a given time.
       num.concurrent.partition.movements.per.broker=10
       # The interval between two execution progress checks.
-      execution.progress.check.interval.ms=10000
+      # e2e: 5s is the floor (must be >= min.execution.progress.check.interval.ms, default 5000); was 10s
+      execution.progress.check.interval.ms=5000
       # Configurations for anomaly detector
       # =======================================
       # The goal violation notifier class

--- a/config/samples/simplekafkacluster_2disk.yaml
+++ b/config/samples/simplekafkacluster_2disk.yaml
@@ -81,7 +81,8 @@ spec:
     cruiseControlTaskSpec:
       RetryDurationMinutes: 5
     topicConfig:
-      partitions: 12
+      # e2e: fewer partitions => faster CC monitoring coverage and less data movement during disk removal
+      partitions: 3
       replicationFactor: 3
 #    resourceRequirements:
 #      requests:
@@ -143,15 +144,18 @@ spec:
       cruise.control.metrics.reporter.metrics.reporting.interval.ms=15000
       metric.anomaly.detection.interval.ms=180000
       # The partition metrics window size in milliseconds
-      partition.metrics.window.ms=30000
+      # e2e: shrink window to the 15s sampling interval so CC accrues a valid window fast; not production defaults
+      partition.metrics.window.ms=15000
       # The number of partition metric windows to keep in memory
       num.partition.metrics.windows=1
       # The minimum partition metric samples required for a partition in each window
       min.samples.per.partition.metrics.window=1
       # The broker metrics window size in milliseconds
-      broker.metrics.window.ms=30000
+      # e2e: shrink window to the 15s sampling interval to speed up CC warmup; not production defaults
+      broker.metrics.window.ms=15000
       # The number of broker metric windows to keep in memory
-      num.broker.metrics.windows=5
+      # e2e: only 2 broker windows needed for warmup on a tiny static cluster (was 5); not production defaults
+      num.broker.metrics.windows=2
       # The minimum broker metric samples required for a partition in each window
       min.samples.per.broker.metrics.window=1
       # The configuration for the BrokerCapacityConfigFileResolver (supports JBOD and non-JBOD broker capacities)
@@ -166,7 +170,10 @@ spec:
       # The list of supported hard goals
       hard.goals=com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuCapacityGoal
       # The minimum percentage of well monitored partitions out of all the partitions
-      min.monitored.partition.percentage=0.95
+      # e2e: min.valid.partition.ratio is the REAL CC key — min.monitored.partition.percentage was renamed to it in
+      # CC PR #781 (2019); the old name is silently ignored so CC keeps its 0.995 default. Lowered so CC's load
+      # model becomes valid quickly on a tiny cluster with few partitions/windows; not production defaults
+      min.valid.partition.ratio=0.5
       # The balance threshold for CPU
       cpu.balance.threshold=1.1
       # The balance threshold for disk
@@ -210,7 +217,8 @@ spec:
       # The max number of partitions to move in/out on a given broker at a given time.
       num.concurrent.partition.movements.per.broker=10
       # The interval between two execution progress checks.
-      execution.progress.check.interval.ms=10000
+      # e2e: poll execution progress every 5s (was 10s) so disk removal/rebalance completion is detected sooner; not production defaults
+      execution.progress.check.interval.ms=5000
       # Configurations for anomaly detector
       # =======================================
       # The goal violation notifier class

--- a/config/samples/simplekafkacluster_2disk.yaml
+++ b/config/samples/simplekafkacluster_2disk.yaml
@@ -170,9 +170,8 @@ spec:
       # The list of supported hard goals
       hard.goals=com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuCapacityGoal
       # The minimum percentage of well monitored partitions out of all the partitions
-      # e2e: min.valid.partition.ratio is the REAL CC key — min.monitored.partition.percentage was renamed to it in
-      # CC PR #781 (2019); the old name is silently ignored so CC keeps its 0.995 default. Lowered so CC's load
-      # model becomes valid quickly on a tiny cluster with few partitions/windows; not production defaults
+      # e2e: lowered from CC's 0.995 default so the load model becomes valid quickly on a tiny cluster
+      # with few partitions/windows; not production defaults
       min.valid.partition.ratio=0.5
       # The balance threshold for CPU
       cpu.balance.threshold=1.1

--- a/config/samples/simplekafkacluster_2disk.yaml
+++ b/config/samples/simplekafkacluster_2disk.yaml
@@ -130,6 +130,11 @@ spec:
       broker.metric.sample.store.topic=__KafkaCruiseControlModelTrainingSamples
       # The replication factor of Kafka metric sample store topic
       sample.store.topic.replication.factor=2
+      # e2e: shrink CC's sample-store topics from their 32-partitions-each default so broker/disk removal
+      # reshuffles only a few partitions (not 64) and the CC execution completes quickly; not production defaults.
+      # NOTE: CC only ever increases these partition counts (never shrinks), so this only takes effect on a fresh cluster.
+      partition.sample.store.topic.partition.count=3
+      broker.sample.store.topic.partition.count=3
       # The config for the number of Kafka sample store consumer threads
       num.sample.loading.threads=8
       # The partition assignor class for the metric samplers

--- a/config/samples/simplekafkacluster_4disk.yaml
+++ b/config/samples/simplekafkacluster_4disk.yaml
@@ -144,6 +144,11 @@ spec:
       broker.metric.sample.store.topic=__KafkaCruiseControlModelTrainingSamples
       # The replication factor of Kafka metric sample store topic
       sample.store.topic.replication.factor=2
+      # e2e: shrink CC's sample-store topics from their 32-partitions-each default so broker/disk removal
+      # reshuffles only a few partitions (not 64) and the CC execution completes quickly; not production defaults.
+      # NOTE: CC only ever increases these partition counts (never shrinks), so this only takes effect on a fresh cluster.
+      partition.sample.store.topic.partition.count=3
+      broker.sample.store.topic.partition.count=3
       # The config for the number of Kafka sample store consumer threads
       num.sample.loading.threads=8
       # The partition assignor class for the metric samplers

--- a/config/samples/simplekafkacluster_4disk.yaml
+++ b/config/samples/simplekafkacluster_4disk.yaml
@@ -184,9 +184,8 @@ spec:
       # The list of supported hard goals
       hard.goals=com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuCapacityGoal
       # The minimum percentage of well monitored partitions out of all the partitions
-      # e2e: min.valid.partition.ratio is the REAL CC key — min.monitored.partition.percentage was renamed to it in
-      # CC PR #781 (2019); the old name is silently ignored so CC keeps its 0.995 default. Lowered so CC's load
-      # model becomes valid quickly on a tiny cluster with few partitions/windows; not production defaults
+      # e2e: lowered from CC's 0.995 default so the load model becomes valid quickly on a tiny cluster
+      # with few partitions/windows; not production defaults
       min.valid.partition.ratio=0.5
       # The balance threshold for CPU
       cpu.balance.threshold=1.1

--- a/config/samples/simplekafkacluster_4disk.yaml
+++ b/config/samples/simplekafkacluster_4disk.yaml
@@ -95,7 +95,8 @@ spec:
     cruiseControlTaskSpec:
       RetryDurationMinutes: 5
     topicConfig:
-      partitions: 12
+      # e2e: fewer partitions => faster CC monitoring coverage and less data movement during disk removal
+      partitions: 3
       replicationFactor: 3
 #    resourceRequirements:
 #      requests:
@@ -157,15 +158,18 @@ spec:
       cruise.control.metrics.reporter.metrics.reporting.interval.ms=15000
       metric.anomaly.detection.interval.ms=180000
       # The partition metrics window size in milliseconds
-      partition.metrics.window.ms=30000
+      # e2e: shrink window to the 15s sampling interval so CC accrues a valid window fast; not production defaults
+      partition.metrics.window.ms=15000
       # The number of partition metric windows to keep in memory
       num.partition.metrics.windows=1
       # The minimum partition metric samples required for a partition in each window
       min.samples.per.partition.metrics.window=1
       # The broker metrics window size in milliseconds
-      broker.metrics.window.ms=30000
+      # e2e: shrink window to the 15s sampling interval to speed up CC warmup; not production defaults
+      broker.metrics.window.ms=15000
       # The number of broker metric windows to keep in memory
-      num.broker.metrics.windows=5
+      # e2e: only 2 broker windows needed for warmup on a tiny static cluster (was 5); not production defaults
+      num.broker.metrics.windows=2
       # The minimum broker metric samples required for a partition in each window
       min.samples.per.broker.metrics.window=1
       # The configuration for the BrokerCapacityConfigFileResolver (supports JBOD and non-JBOD broker capacities)
@@ -180,7 +184,10 @@ spec:
       # The list of supported hard goals
       hard.goals=com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuCapacityGoal
       # The minimum percentage of well monitored partitions out of all the partitions
-      min.monitored.partition.percentage=0.95
+      # e2e: min.valid.partition.ratio is the REAL CC key — min.monitored.partition.percentage was renamed to it in
+      # CC PR #781 (2019); the old name is silently ignored so CC keeps its 0.995 default. Lowered so CC's load
+      # model becomes valid quickly on a tiny cluster with few partitions/windows; not production defaults
+      min.valid.partition.ratio=0.5
       # The balance threshold for CPU
       cpu.balance.threshold=1.1
       # The balance threshold for disk
@@ -224,7 +231,8 @@ spec:
       # The max number of partitions to move in/out on a given broker at a given time.
       num.concurrent.partition.movements.per.broker=10
       # The interval between two execution progress checks.
-      execution.progress.check.interval.ms=10000
+      # e2e: poll execution progress every 5s (was 10s) so disk removal/rebalance completion is detected sooner; not production defaults
+      execution.progress.check.interval.ms=5000
       # Configurations for anomaly detector
       # =======================================
       # The goal violation notifier class

--- a/config/samples/simplekafkacluster_5broker.yaml
+++ b/config/samples/simplekafkacluster_5broker.yaml
@@ -164,9 +164,8 @@ spec:
       # The list of supported hard goals
       hard.goals=com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuCapacityGoal
       # The minimum percentage of well monitored partitions out of all the partitions
-      # e2e: min.valid.partition.ratio is the REAL CC key — min.monitored.partition.percentage was renamed to it in
-      # CC PR #781 (2019); the old name is silently ignored so CC keeps its 0.995 default. Lowered so CC's load
-      # model becomes valid quickly on a tiny cluster with few partitions/windows; not production defaults
+      # e2e: lowered from CC's 0.995 default so the load model becomes valid quickly on a tiny cluster
+      # with few partitions/windows; not production defaults
       min.valid.partition.ratio=0.5
       # The balance threshold for CPU
       cpu.balance.threshold=1.1

--- a/config/samples/simplekafkacluster_5broker.yaml
+++ b/config/samples/simplekafkacluster_5broker.yaml
@@ -126,6 +126,11 @@ spec:
       broker.metric.sample.store.topic=__KafkaCruiseControlModelTrainingSamples
       # The replication factor of Kafka metric sample store topic
       sample.store.topic.replication.factor=2
+      # e2e: shrink CC's sample-store topics from their 32-partitions-each default so broker/disk removal
+      # reshuffles only a few partitions (not 64) and the CC execution completes quickly; not production defaults.
+      # NOTE: CC only ever increases these partition counts (never shrinks), so this only takes effect on a fresh cluster.
+      partition.sample.store.topic.partition.count=3
+      broker.sample.store.topic.partition.count=3
       # The config for the number of Kafka sample store consumer threads
       num.sample.loading.threads=8
       # The partition assignor class for the metric samplers

--- a/config/samples/simplekafkacluster_5broker.yaml
+++ b/config/samples/simplekafkacluster_5broker.yaml
@@ -19,6 +19,8 @@ spec:
     cruise.control.metrics.topic.auto.create=true
     cruise.control.metrics.topic.num.partitions=1
     cruise.control.metrics.topic.replication.factor=2
+    # e2e: publish CruiseControl metrics every 15s (default 60s) so CC warms up quickly; not production defaults
+    cruise.control.metrics.reporter.metrics.reporting.interval.ms=15000
   brokerConfigGroups:
     default:
       # podSecurityContext:
@@ -76,7 +78,8 @@ spec:
     cruiseControlTaskSpec:
       RetryDurationMinutes: 5
     topicConfig:
-      partitions: 12
+      # e2e: fewer partitions on the __CruiseControlMetrics topic => faster CC monitoring coverage
+      partitions: 3
       replicationFactor: 3
 #    resourceRequirements:
 #      requests:
@@ -93,7 +96,8 @@ spec:
       # Configuration for the metadata client.
       # =======================================
       # The maximum interval in milliseconds between two metadata refreshes.
-      #metadata.max.age.ms=300000
+      # e2e: must be <= metric.sampling.interval.ms (CC sanityCheckSamplingPeriod); low for the fast 15s sampling
+      metadata.max.age.ms=10000
       # Client id for the Cruise Control. It is used for the metadata client.
       #client.id=kafka-cruise-control
       # The size of TCP send buffer bytes for the metadata client.
@@ -127,18 +131,25 @@ spec:
       # The partition assignor class for the metric samplers
       metric.sampler.partition.assignor.class=com.linkedin.kafka.cruisecontrol.monitor.sampling.DefaultMetricSamplerPartitionAssignor
       # The metric sampling interval in milliseconds
-      metric.sampling.interval.ms=120000
+      # e2e: sample every 15s (default 120s) so CC accrues valid windows fast; not production defaults
+      metric.sampling.interval.ms=15000
+      # e2e: CC reads the reporter interval for a sanity check and requires it <= the sampling interval
+      cruise.control.metrics.reporter.metrics.reporting.interval.ms=15000
+      # e2e: must be >= metric.sampling.interval.ms (CC sanityCheckSamplingPeriod)
       metric.anomaly.detection.interval.ms=180000
       # The partition metrics window size in milliseconds
-      partition.metrics.window.ms=300000
+      # e2e: shrink window to the 15s sampling interval so CC accrues a valid window fast; not production defaults
+      partition.metrics.window.ms=15000
       # The number of partition metric windows to keep in memory
       num.partition.metrics.windows=1
       # The minimum partition metric samples required for a partition in each window
       min.samples.per.partition.metrics.window=1
       # The broker metrics window size in milliseconds
-      broker.metrics.window.ms=300000
+      # e2e: shrink window to the 15s sampling interval to speed up CC warmup; not production defaults
+      broker.metrics.window.ms=15000
       # The number of broker metric windows to keep in memory
-      num.broker.metrics.windows=20
+      # e2e: only 2 broker windows needed for warmup on a tiny static cluster (was 20); not production defaults
+      num.broker.metrics.windows=2
       # The minimum broker metric samples required for a partition in each window
       min.samples.per.broker.metrics.window=1
       # The configuration for the BrokerCapacityConfigFileResolver (supports JBOD and non-JBOD broker capacities)
@@ -153,7 +164,10 @@ spec:
       # The list of supported hard goals
       hard.goals=com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuCapacityGoal
       # The minimum percentage of well monitored partitions out of all the partitions
-      min.monitored.partition.percentage=0.95
+      # e2e: min.valid.partition.ratio is the REAL CC key — min.monitored.partition.percentage was renamed to it in
+      # CC PR #781 (2019); the old name is silently ignored so CC keeps its 0.995 default. Lowered so CC's load
+      # model becomes valid quickly on a tiny cluster with few partitions/windows; not production defaults
+      min.valid.partition.ratio=0.5
       # The balance threshold for CPU
       cpu.balance.threshold=1.1
       # The balance threshold for disk
@@ -197,7 +211,8 @@ spec:
       # The max number of partitions to move in/out on a given broker at a given time.
       num.concurrent.partition.movements.per.broker=10
       # The interval between two execution progress checks.
-      execution.progress.check.interval.ms=10000
+      # e2e: 5s is the floor (must be >= min.execution.progress.check.interval.ms, default 5000); was 10s
+      execution.progress.check.interval.ms=5000
       # Configurations for anomaly detector
       # =======================================
       # The goal violation notifier class

--- a/config/samples/simplekafkacluster_affinity.yaml
+++ b/config/samples/simplekafkacluster_affinity.yaml
@@ -144,7 +144,7 @@ spec:
       # The list of supported hard goals
       hard.goals=com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuCapacityGoal
       # The minimum percentage of well monitored partitions out of all the partitions
-      min.monitored.partition.percentage=0.95
+      min.valid.partition.ratio=0.95
       # The balance threshold for CPU
       cpu.balance.threshold=1.1
       # The balance threshold for disk

--- a/config/samples/simplekafkacluster_ebs_csi.yaml
+++ b/config/samples/simplekafkacluster_ebs_csi.yaml
@@ -126,7 +126,7 @@ spec:
       # The list of supported hard goals
       hard.goals=com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuCapacityGoal
       # The minimum percentage of well monitored partitions out of all the partitions
-      min.monitored.partition.percentage=0.95
+      min.valid.partition.ratio=0.95
       # The balance threshold for CPU
       cpu.balance.threshold=1.1
       # The balance threshold for disk

--- a/config/samples/simplekafkacluster_ssl.yaml
+++ b/config/samples/simplekafkacluster_ssl.yaml
@@ -17,6 +17,8 @@ spec:
     cruise.control.metrics.topic.auto.create=true
     cruise.control.metrics.topic.num.partitions=1
     cruise.control.metrics.topic.replication.factor=2
+    # e2e: publish CruiseControl metrics every 15s (default 60s) so CC warms up quickly; not production defaults
+    cruise.control.metrics.reporter.metrics.reporting.interval.ms=15000
   brokerConfigGroups:
     default:
       # podSecurityContext:
@@ -69,7 +71,8 @@ spec:
     cruiseControlTaskSpec:
       RetryDurationMinutes: 5
     topicConfig:
-      partitions: 12
+      # e2e: fewer partitions on the __CruiseControlMetrics topic => faster CC monitoring coverage
+      partitions: 3
       replicationFactor: 3
     config: |
       # Copyright 2017 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
@@ -78,7 +81,8 @@ spec:
       # Configuration for the metadata client.
       # =======================================
       # The maximum interval in milliseconds between two metadata refreshes.
-      #metadata.max.age.ms=300000
+      # e2e: must be <= metric.sampling.interval.ms (CC sanityCheckSamplingPeriod); low for the fast 15s sampling
+      metadata.max.age.ms=10000
       # Client id for the Cruise Control. It is used for the metadata client.
       #client.id=kafka-cruise-control
       # The size of TCP send buffer bytes for the metadata client.
@@ -112,18 +116,25 @@ spec:
       # The partition assignor class for the metric samplers
       metric.sampler.partition.assignor.class=com.linkedin.kafka.cruisecontrol.monitor.sampling.DefaultMetricSamplerPartitionAssignor
       # The metric sampling interval in milliseconds
-      metric.sampling.interval.ms=120000
+      # e2e: sample every 15s (default 120s) so CC accrues valid windows fast; not production defaults
+      metric.sampling.interval.ms=15000
+      # e2e: CC reads the reporter interval for a sanity check and requires it <= the sampling interval
+      cruise.control.metrics.reporter.metrics.reporting.interval.ms=15000
+      # e2e: must be >= metric.sampling.interval.ms (CC sanityCheckSamplingPeriod)
       metric.anomaly.detection.interval.ms=180000
       # The partition metrics window size in milliseconds
-      partition.metrics.window.ms=300000
+      # e2e: shrink window to the 15s sampling interval so CC accrues a valid window fast; not production defaults
+      partition.metrics.window.ms=15000
       # The number of partition metric windows to keep in memory
       num.partition.metrics.windows=1
       # The minimum partition metric samples required for a partition in each window
       min.samples.per.partition.metrics.window=1
       # The broker metrics window size in milliseconds
-      broker.metrics.window.ms=300000
+      # e2e: shrink window to the 15s sampling interval to speed up CC warmup; not production defaults
+      broker.metrics.window.ms=15000
       # The number of broker metric windows to keep in memory
-      num.broker.metrics.windows=20
+      # e2e: only 2 broker windows needed for warmup on a tiny static cluster (was 20); not production defaults
+      num.broker.metrics.windows=2
       # The minimum broker metric samples required for a partition in each window
       min.samples.per.broker.metrics.window=1
       # The configuration for the BrokerCapacityConfigFileResolver (supports JBOD and non-JBOD broker capacities)
@@ -138,7 +149,10 @@ spec:
       # The list of supported hard goals
       hard.goals=com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuCapacityGoal
       # The minimum percentage of well monitored partitions out of all the partitions
-      min.monitored.partition.percentage=0.95
+      # e2e: min.valid.partition.ratio is the REAL CC key — min.monitored.partition.percentage was renamed to it in
+      # CC PR #781 (2019); the old name is silently ignored so CC keeps its 0.995 default. Lowered so CC's load
+      # model becomes valid quickly on a tiny cluster with few partitions/windows; not production defaults
+      min.valid.partition.ratio=0.5
       # The balance threshold for CPU
       cpu.balance.threshold=1.1
       # The balance threshold for disk
@@ -182,7 +196,8 @@ spec:
       # The max number of partitions to move in/out on a given broker at a given time.
       num.concurrent.partition.movements.per.broker=10
       # The interval between two execution progress checks.
-      execution.progress.check.interval.ms=10000
+      # e2e: 5s is the floor (must be >= min.execution.progress.check.interval.ms, default 5000); was 10s
+      execution.progress.check.interval.ms=5000
       # Configurations for anomaly detector
       # =======================================
       # The goal violation notifier class

--- a/config/samples/simplekafkacluster_ssl.yaml
+++ b/config/samples/simplekafkacluster_ssl.yaml
@@ -111,6 +111,11 @@ spec:
       broker.metric.sample.store.topic=__KafkaCruiseControlModelTrainingSamples
       # The replication factor of Kafka metric sample store topic
       sample.store.topic.replication.factor=2
+      # e2e: shrink CC's sample-store topics from their 32-partitions-each default so broker/disk removal
+      # reshuffles only a few partitions (not 64) and the CC execution completes quickly; not production defaults.
+      # NOTE: CC only ever increases these partition counts (never shrinks), so this only takes effect on a fresh cluster.
+      partition.sample.store.topic.partition.count=3
+      broker.sample.store.topic.partition.count=3
       # The config for the number of Kafka sample store consumer threads
       num.sample.loading.threads=8
       # The partition assignor class for the metric samplers

--- a/config/samples/simplekafkacluster_ssl.yaml
+++ b/config/samples/simplekafkacluster_ssl.yaml
@@ -149,9 +149,8 @@ spec:
       # The list of supported hard goals
       hard.goals=com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuCapacityGoal
       # The minimum percentage of well monitored partitions out of all the partitions
-      # e2e: min.valid.partition.ratio is the REAL CC key — min.monitored.partition.percentage was renamed to it in
-      # CC PR #781 (2019); the old name is silently ignored so CC keeps its 0.995 default. Lowered so CC's load
-      # model becomes valid quickly on a tiny cluster with few partitions/windows; not production defaults
+      # e2e: lowered from CC's 0.995 default so the load model becomes valid quickly on a tiny cluster
+      # with few partitions/windows; not production defaults
       min.valid.partition.ratio=0.5
       # The balance threshold for CPU
       cpu.balance.threshold=1.1

--- a/config/samples/simplekafkacluster_with_contour.yaml
+++ b/config/samples/simplekafkacluster_with_contour.yaml
@@ -169,7 +169,7 @@ spec:
       # The list of supported hard goals
       hard.goals=com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuCapacityGoal
       # The minimum percentage of well monitored partitions out of all the partitions
-      min.monitored.partition.percentage=0.95
+      min.valid.partition.ratio=0.95
       # The balance threshold for CPU
       cpu.balance.threshold=1.1
       # The balance threshold for disk

--- a/config/samples/simplekafkacluster_with_k8s_provided_nodeport.yaml
+++ b/config/samples/simplekafkacluster_with_k8s_provided_nodeport.yaml
@@ -133,7 +133,7 @@ spec:
       # The list of supported hard goals
       hard.goals=com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuCapacityGoal
       # The minimum percentage of well monitored partitions out of all the partitions
-      min.monitored.partition.percentage=0.95
+      min.valid.partition.ratio=0.95
       # The balance threshold for CPU
       cpu.balance.threshold=1.1
       # The balance threshold for disk

--- a/config/samples/simplekafkacluster_with_sasl.yaml
+++ b/config/samples/simplekafkacluster_with_sasl.yaml
@@ -144,7 +144,7 @@ spec:
       # The list of supported hard goals
       hard.goals=com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuCapacityGoal
       # The minimum percentage of well monitored partitions out of all the partitions
-      min.monitored.partition.percentage=0.95
+      min.valid.partition.ratio=0.95
       # The balance threshold for CPU
       cpu.balance.threshold=1.1
       # The balance threshold for disk

--- a/docs/benchmarks/infrastructure/kafka.yaml
+++ b/docs/benchmarks/infrastructure/kafka.yaml
@@ -124,7 +124,7 @@ spec:
       # The list of supported hard goals
       hard.goals=com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuCapacityGoal
       # The minimum percentage of well monitored partitions out of all the partitions
-      min.monitored.partition.percentage=0.95
+      min.valid.partition.ratio=0.95
       # The balance threshold for CPU
       cpu.balance.threshold=1.1
       # The balance threshold for disk

--- a/docs/benchmarks/infrastructure/kafka_202001_3brokers.yaml
+++ b/docs/benchmarks/infrastructure/kafka_202001_3brokers.yaml
@@ -207,7 +207,7 @@ spec:
       # The list of supported hard goals
       hard.goals=com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundCapacityGoal,com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuCapacityGoal
       # The minimum percentage of well monitored partitions out of all the partitions
-      min.monitored.partition.percentage=0.95
+      min.valid.partition.ratio=0.95
       # The balance threshold for CPU
       cpu.balance.threshold=1.1
       # The balance threshold for disk

--- a/tests/e2e/const.go
+++ b/tests/e2e/const.go
@@ -57,6 +57,7 @@ const (
 	defaultDeletionTimeout                 = 60 * time.Second  // Increased for kind environments
 	defaultPodReadinessWaitTime            = 180 * time.Second // Increased for kind environments
 	waitResourceConditionRetryInterval     = 2 * time.Second   // Retry interval when kubectl wait races with rolling updates
+	waitResourceConditionMaxAttemptTimeout = 30 * time.Second  // Per-attempt kubectl wait --timeout cap so a single attempt cannot consume the whole budget; the loop re-resolves the selector and retries until the overall deadline
 	defaultTopicCreationWaitTime           = 60 * time.Second  // Increased for kind environments
 	defaultUserCreationWaitTime            = 60 * time.Second  // Increased for kind environments
 	kafkaClusterCreateTimeout              = 1800 * time.Second

--- a/tests/e2e/k8s.go
+++ b/tests/e2e/k8s.go
@@ -658,11 +658,17 @@ func waitK8sResourceCondition(kubectlOptions k8s.KubectlOptions, resourceKind, w
 
 	// `kubectl wait` resolves the objects matching the selector once, up front, and then
 	// blocks on each of them individually. When those objects are being rolled (for example
-	// broker pods recreated during a disk removal), one can be deleted before `kubectl wait`
-	// evaluates its condition, so the command fails immediately with a transient
-	// "not found" / "no matching resources found" error instead of waiting for the
-	// replacement. Retry on those transient errors within the overall timeout budget, which
-	// makes kubectl re-resolve the selector against the current set of objects.
+	// broker pods recreated during a disk removal), a matched pod can be deleted mid-wait.
+	// Depending on the failure mode kubectl then either errors out with a transient
+	// "not found" / "no matching resources found" error, or (for `--for=condition=...`,
+	// where deletion is not terminal) keeps blocking on the now-doomed pod until its
+	// `--timeout` elapses and reports "timed out waiting for the condition on <res>/<name>".
+	//
+	// To survive both, each attempt uses a capped `--timeout` (so a single doomed pod cannot
+	// consume the whole budget) and the loop retries transient races AND per-attempt timeouts
+	// until the overall deadline, re-resolving the selector against the current object set on
+	// every attempt. A genuinely unmet condition still fails: once the overall budget is
+	// exhausted the last timeout error is returned, so real regressions are not masked.
 	deadline := time.Now().Add(timeout)
 	var lastErr error
 	for {
@@ -670,13 +676,10 @@ func waitK8sResourceCondition(kubectlOptions k8s.KubectlOptions, resourceKind, w
 		if remaining <= 0 {
 			return lastErr
 		}
-		// Round to whole seconds (1s floor) so the kubectl --timeout value reads cleanly in
-		// logs (e.g. 5m0s, not 4m59.999999449s). kubectl treats --timeout=0 specially, so
-		// never go below 1s.
-		attemptTimeout := remaining.Round(time.Second)
-		if attemptTimeout < time.Second {
-			attemptTimeout = time.Second
-		}
+		// Cap each attempt so one hung wait cannot eat the entire budget, then round to whole
+		// seconds (1s floor) so the kubectl --timeout value reads cleanly in logs (e.g. 30s,
+		// not 29.999999449s). kubectl treats --timeout=0 specially, so never go below 1s.
+		attemptTimeout := max(min(remaining, waitResourceConditionMaxAttemptTimeout).Round(time.Second), time.Second)
 
 		args := []string{
 			"wait",
@@ -696,9 +699,10 @@ func waitK8sResourceCondition(kubectlOptions k8s.KubectlOptions, resourceKind, w
 			return nil
 		}
 
-		// Genuine failures (e.g. the condition not being met before the timeout) are
-		// returned immediately; only the transient rolling-update races are retried.
-		if !isTransientResourceWaitError(lastErr) {
+		// Retry transient rolling-update races and per-attempt timeouts within the overall
+		// deadline; both are resolved by re-running kubectl wait against the current object
+		// set. Any other (genuine) failure is returned immediately.
+		if !isTransientResourceWaitError(lastErr) && !isConditionWaitTimeoutError(lastErr) {
 			return lastErr
 		}
 
@@ -719,6 +723,18 @@ func isTransientResourceWaitError(err error) bool {
 	// "no matching resources found": the selector momentarily matched no objects.
 	return isKubectlNotFoundError(err) ||
 		strings.Contains(err.Error(), "no matching resources found")
+}
+
+// isConditionWaitTimeoutError reports whether a `kubectl wait` failure is the per-attempt
+// timeout ("timed out waiting for the condition ..."). With a capped per-attempt timeout this
+// is expected while the condition has not yet been met (e.g. a broker still rolling), so the
+// caller retries within the overall budget, re-resolving the selector against the current
+// object set. It is deliberately kept separate from isTransientResourceWaitError, which
+// classifies the object-changed races: a bare timeout is only "safe to retry" because the
+// enclosing loop bounds total time with an overall deadline, not because the condition itself
+// is transient.
+func isConditionWaitTimeoutError(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "timed out waiting for the condition")
 }
 
 // kubectlArgExtender extends the kubectl arguments and log message based on the parameters

--- a/tests/e2e/k8s_wait_test.go
+++ b/tests/e2e/k8s_wait_test.go
@@ -64,3 +64,40 @@ func TestIsTransientResourceWaitError(t *testing.T) {
 		})
 	}
 }
+
+func TestIsConditionWaitTimeoutError(t *testing.T) {
+	testCases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil error is not a condition-wait timeout",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "per-attempt condition timeout is a condition-wait timeout",
+			err:  errors.New("error: timed out waiting for the condition on pods/kafka-2-tzplk"),
+			want: true,
+		},
+		{
+			name: "object-changed race is not a condition-wait timeout",
+			err:  errors.New(`error while running command: exit status 1; Error from server (NotFound): pods "kafka-2-h4grv" not found`),
+			want: false,
+		},
+		{
+			name: "unrelated failure is not a condition-wait timeout",
+			err:  errors.New("error while running command: exit status 1; The connection to the server was refused"),
+			want: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isConditionWaitTimeoutError(tc.err); got != tc.want {
+				t.Errorf("isConditionWaitTimeoutError(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}

--- a/tests/e2e/test_broker_removal.go
+++ b/tests/e2e/test_broker_removal.go
@@ -47,6 +47,21 @@ func testBatchedBrokerRemoval() bool {
 			kubectlOptions.Namespace = koperatorLocalHelmDescriptor.Namespace
 		})
 
+		ginkgo.It("Waiting for Cruise Control to be ready and idle before triggering removal", func() {
+			// A freshly installed cluster runs an initial CruiseControl rebalance to spread replicas
+			// across the new brokers. Triggering remove_broker while that rebalance is still in flight
+			// makes the two operations race and the removal can stall. Gate on a running cluster with no
+			// in-flight CC operation so removal starts from a quiescent Cruise Control.
+			ginkgo.By("Ensuring the KafkaCluster is running")
+			err := waitForKafkaClusterWithPodStatusCheck(kubectlOptions, kafkaClusterName, kafkaClusterResourceReadinessTimeout)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			ginkgo.By("Waiting until no Cruise Control operation is in flight (initial rebalance finished)")
+			gomega.Eventually(context.Background(), func() (bool, error) {
+				return hasNoInFlightCruiseControlOperation(kubectlOptions)
+			}, batchedBrokerRemovalTimeout, batchedBrokerRemovalPollInterval).Should(gomega.BeTrue())
+		})
+
 		ginkgo.It("Applying 3-broker manifest to trigger removal of brokers 3 and 4", func() {
 			ginkgo.By("Patching KafkaCluster to remove brokers 3 and 4")
 			applyK8sResourceManifest(kubectlOptions, "../../config/samples/simplekafkacluster.yaml")
@@ -102,6 +117,29 @@ func hasExactlyOneRemoveBrokerOperation(kubectlOptions k8s.KubectlOptions) (bool
 		}
 	}
 	return count == 1, nil
+}
+
+// hasNoInFlightCruiseControlOperation returns true when no CruiseControlOperation in the namespace
+// has a currently-running task (Active or InExecution). Completed / CompletedWithError tasks and
+// operations without a currentTask count as idle. It is used to gate mutation tests (broker/disk
+// removal) on a quiescent Cruise Control so a new operation does not race an in-flight one, such as
+// the rebalance CruiseControl runs right after a fresh cluster install.
+func hasNoInFlightCruiseControlOperation(kubectlOptions k8s.KubectlOptions) (bool, error) {
+	states, err := getK8sResources(kubectlOptions,
+		[]string{"cruisecontroloperation"},
+		"",
+		"",
+		"-o", "jsonpath={range .items[*]}{.status.currentTask.state}{'\\n'}{end}",
+	)
+	if err != nil {
+		return false, err
+	}
+	for _, state := range states {
+		if state == string(v1beta1.CruiseControlTaskActive) || state == string(v1beta1.CruiseControlTaskInExecution) {
+			return false, nil
+		}
+	}
+	return true, nil
 }
 
 // hasExactlyNBrokerPods returns true when exactly n broker pods exist in the namespace.

--- a/tests/e2e/test_broker_removal.go
+++ b/tests/e2e/test_broker_removal.go
@@ -73,8 +73,10 @@ func testBatchedBrokerRemoval() bool {
 		})
 
 		ginkgo.It("Asserting remaining Kafka brokers are healthy", func() {
-			err := waitK8sResourceCondition(kubectlOptions, "pod", "condition=Ready", defaultPodReadinessWaitTime,
-				v1beta1.KafkaCRLabelKey+"="+kafkaClusterName+","+kafkaLabelSelectorBrokers, "")
+			// Broker removal reconciles the cluster; gate on the operator's own ClusterRunning
+			// state and re-resolve the live pod set each poll rather than `kubectl wait`-ing on
+			// a snapshot of pod names that can change while the cluster settles.
+			err := waitForKafkaClusterWithPodStatusCheck(kubectlOptions, kafkaClusterName, kafkaClusterResourceReadinessTimeout)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		})
 	})

--- a/tests/e2e/test_multidisk_removal.go
+++ b/tests/e2e/test_multidisk_removal.go
@@ -28,7 +28,6 @@ import (
 	ginkgo "github.com/onsi/ginkgo/v2"
 	gomega "github.com/onsi/gomega"
 
-	"github.com/banzaicloud/koperator/api/v1beta1"
 	kafkautils "github.com/banzaicloud/koperator/pkg/util/kafka"
 )
 
@@ -75,8 +74,10 @@ func testMultiDiskRemoval() bool {
 		})
 
 		ginkgo.It("Asserting Kafka brokers remain healthy", func() {
-			err := waitK8sResourceCondition(kubectlOptions, "pod", "condition=Ready", defaultPodReadinessWaitTime,
-				v1beta1.KafkaCRLabelKey+"="+kafkaClusterName+",app=kafka", "")
+			// Disk removal rolls the broker pods, so their names change underneath us. Gate on
+			// the operator's own ClusterRunning state and re-resolve the live pod set each poll
+			// instead of `kubectl wait`-ing on a snapshot of pod names that get deleted mid-roll.
+			err := waitForKafkaClusterWithPodStatusCheck(kubectlOptions, kafkaClusterName, kafkaClusterResourceReadinessTimeout)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		})
 	})

--- a/tests/e2e/test_multidisk_removal.go
+++ b/tests/e2e/test_multidisk_removal.go
@@ -73,6 +73,17 @@ func testMultiDiskRemoval() bool {
 			gomega.Expect(exclude).To(gomega.BeTrue(), "broker log.dirs must not contain removed path %s", removedLogDirPath)
 		})
 
+		ginkgo.It("Waiting for the Cruise Control disk rebalance to complete", func() {
+			// The log.dirs ConfigMap update above only proves the operator dropped the removed path from
+			// broker config, not that Cruise Control finished draining data off those disks. Gate on a
+			// quiescent Cruise Control so the disk rebalance genuinely completes here rather than lingering
+			// in flight (which would otherwise leave an in-progress operation for the next scenario).
+			ginkgo.By("Waiting until no Cruise Control operation is in flight (disk rebalance finished)")
+			gomega.Eventually(context.Background(), func() (bool, error) {
+				return hasNoInFlightCruiseControlOperation(kubectlOptions)
+			}, multidiskRemovalTimeout, multidiskRemovalPollInterval).Should(gomega.BeTrue())
+		})
+
 		ginkgo.It("Asserting Kafka brokers remain healthy", func() {
 			// Disk removal rolls the broker pods, so their names change underneath us. Gate on
 			// the operator's own ClusterRunning state and re-resolve the live pod set each poll


### PR DESCRIPTION
## Problem

The e2e **broker removal** and **multi-disk removal** specs were flaky/failing:

1. **Health checks** used `kubectl wait --selector`, which pins pod names up front and times out when disk/broker removal rolls the pods underneath it — a false negative even though the cluster is healthy.
2. **Broker removal hung** (0 of 56 partition movements ever completed). Cruise Control's `remove_broker` was reshuffling its own sample-store topics (`__KafkaCruiseControl{PartitionMetric,ModelTraining}Samples`), which default to **32 partitions each** — the earlier e2e partition reduction only touched `__CruiseControlMetrics`. Removal also fired ~33s after `ClusterRunning`, racing CC's initial post-install rebalance. Brokers are only deleted at `GracefulDownscaleSucceeded`, which never arrived → 20m timeout.

## Fix

- **Roll-safe health checks**: both removal specs assert via `waitForKafkaClusterWithPodStatusCheck` (gates on operator `ClusterRunning`, re-resolves the live pod set each poll). Hardened `waitK8sResourceCondition` to cap per-attempt `--timeout` and retry within the overall deadline.
- **Speed up CC warmup**: smaller sampling/window intervals; fixed the stale `min.monitored.partition.percentage` → `min.valid.partition.ratio` key.
- **Shrink CC sample-store topics** to 3 partitions each in e2e manifests, turning the removal rebalance from 56 movements into a handful (CC only ever grows these, so relies on the fresh cluster each spec installs).
- **Gate removal specs on a ready + idle Cruise Control** (`hasNoInFlightCruiseControlOperation`) so a new operation doesn't race the initial rebalance, and the disk spec no longer passes while CC is still draining data.

## Verification

`go build` / `go vet -tags e2e` clean. Full e2e green: **99/99 specs passed** ([run 30364005903](https://github.com/adobe/koperator/actions/runs/30364005903)) — batched broker removal drops to 3 brokers and completes instead of timing out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)