### PR TITLE
Release 0.28.0-adobe-20260731

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![Koperator](https://img.shields.io/github/v/release/adobe/koperator?label=Koperator)
 ![Released](https://img.shields.io/github/release-date/adobe/koperator?label=Released)
 ![License](https://img.shields.io/github/license/adobe/koperator?label=License)
-![Go version (latest release)](https://img.shields.io/github/go-mod/go-version/adobe/koperator/0.28.0-adobe-20260622)
+![Go version (latest release)](https://img.shields.io/github/go-mod/go-version/adobe/koperator/0.28.0-adobe-20260731)
 
 </p>
 
@@ -127,17 +127,17 @@ kubectl apply -f https://raw.githubusercontent.com/adobe/koperator/refs/heads/ma
 OCI registries have no floating "latest" tag, so `--version` is required (replace with your desired version, see available versions above):
 
 ```sh
-helm install kafka-operator oci://ghcr.io/adobe/helm-charts/kafka-operator --version 0.28.0-adobe-20260622 --namespace=kafka --create-namespace --skip-crds
+helm install kafka-operator oci://ghcr.io/adobe/helm-charts/kafka-operator --version 0.28.0-adobe-20260731 --namespace=kafka --create-namespace --skip-crds
 ```
 
 #### Pull and inspect the chart before installation
 
 ```sh
 # Pull the chart locally
-helm pull oci://ghcr.io/adobe/helm-charts/kafka-operator --version 0.28.0-adobe-20260622
+helm pull oci://ghcr.io/adobe/helm-charts/kafka-operator --version 0.28.0-adobe-20260731
 
 # Extract and inspect
-tar -xzf kafka-operator-0.28.0-adobe-20260622.tgz
+tar -xzf kafka-operator-0.28.0-adobe-20260731.tgz
 helm template kafka-operator ./kafka-operator/
 
 # Install from local chart

--- a/charts/kafka-operator/Chart.yaml
+++ b/charts/kafka-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: kafka-operator
-version: "0.28.0-adobe-20260622"
+version: "0.28.0-adobe-20260731"
 description: kafka-operator manages Kafka deployments on Kubernetes
 sources:
   - https://github.com/adobe/koperator
-appVersion: "0.28.0-adobe-20260622"
+appVersion: "0.28.0-adobe-20260731"

--- a/charts/kafka-operator/README.md
+++ b/charts/kafka-operator/README.md
@@ -29,13 +29,13 @@ OCI registries have no floating "latest" tag, so `--version` is required (see av
 
 ```bash
 helm install kafka-operator oci://ghcr.io/adobe/helm-charts/kafka-operator \
-  --version 0.28.0-adobe-20260622 --namespace=kafka --create-namespace --skip-crds
+  --version 0.28.0-adobe-20260731 --namespace=kafka --create-namespace --skip-crds
 ```
 
 To install the operator using an already installed cert-manager:
 ```bash
 helm install kafka-operator oci://ghcr.io/adobe/helm-charts/kafka-operator \
-  --version 0.28.0-adobe-20260622 \
+  --version 0.28.0-adobe-20260731 \
   --set certManager.namespace=<your cert manager namespace> --namespace=kafka --create-namespace --skip-crds
 ```
 
@@ -46,7 +46,7 @@ If this value is not set your CRDs might be deleted. `--version` is required, sa
 
 ```bash
 helm upgrade kafka-operator oci://ghcr.io/adobe/helm-charts/kafka-operator \
-  --version 0.28.0-adobe-20260622 --namespace=kafka
+  --version 0.28.0-adobe-20260731 --namespace=kafka
 ```
 
 ## Uninstalling the Chart
@@ -66,7 +66,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | replicaCount | int | `1` | Operator replica count can be set |
 | operator.annotations | object | `{}` | Operator pod annotations can be set |
 | operator.image.repository | string | `"ghcr.io/adobe/koperator"` | Operator container image repository |
-| operator.image.tag | string | `"0.28.0-adobe-20260622"` | Operator container image tag |
+| operator.image.tag | string | `"0.28.0-adobe-20260731"` | Operator container image tag |
 | operator.image.pullPolicy | string | `"IfNotPresent"` | Operator container image pull policy |
 | operator.namespaces | string | `"kafka, cert-manager"` | List of namespaces where Operator watches for custom resources.<br><br>**Note** that the operator still requires to read the cluster-scoped `Node` labels to configure `rack awareness`. Make sure the operator ServiceAccount is granted `get` permissions on this `Node` resource when using limited RBACs. |
 | operator.verboseLogging | bool | `false` | Enable verbose logging |

--- a/charts/kafka-operator/README.md.gotmpl
+++ b/charts/kafka-operator/README.md.gotmpl
@@ -29,13 +29,13 @@ OCI registries have no floating "latest" tag, so `--version` is required (see av
 
 ```bash
 helm install kafka-operator oci://ghcr.io/adobe/helm-charts/kafka-operator \
-  --version 0.28.0-adobe-20260622 --namespace=kafka --create-namespace --skip-crds
+  --version 0.28.0-adobe-20260731 --namespace=kafka --create-namespace --skip-crds
 ```
 
 To install the operator using an already installed cert-manager:
 ```bash
 helm install kafka-operator oci://ghcr.io/adobe/helm-charts/kafka-operator \
-  --version 0.28.0-adobe-20260622 \
+  --version 0.28.0-adobe-20260731 \
   --set certManager.namespace=<your cert manager namespace> --namespace=kafka --create-namespace --skip-crds
 ```
 
@@ -46,7 +46,7 @@ If this value is not set your CRDs might be deleted. `--version` is required, sa
 
 ```bash
 helm upgrade kafka-operator oci://ghcr.io/adobe/helm-charts/kafka-operator \
-  --version 0.28.0-adobe-20260622 --namespace=kafka
+  --version 0.28.0-adobe-20260731 --namespace=kafka
 ```
 
 ## Uninstalling the Chart

--- a/charts/kafka-operator/values.yaml
+++ b/charts/kafka-operator/values.yaml
@@ -18,7 +18,7 @@ operator:
     # -- Operator container image repository
     repository: ghcr.io/adobe/koperator
     # -- Operator container image tag
-    tag: "0.28.0-adobe-20260622"
+    tag: "0.28.0-adobe-20260731"
     # -- Operator container image pull policy
     pullPolicy: IfNotPresent
   # In constrained environments where operator cannot


### PR DESCRIPTION
Automated version reference bump for release `0.28.0-adobe-20260731`.

---
*Generated by https://github.com/adobe/koperator/blob/master/.github/workflows/operator-release.yml*