### PR TITLE
Update renovate.json with adobe/cruise-control rule

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -117,6 +117,12 @@
       "description": "Kafka 4.x drops ZooKeeper support (KRaft-only) and needs an operator-side migration. Keep Renovate on the 3.x line until docker/kafka/Dockerfile is ready for that jump, then remove this rule."
     },
     {
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["adobe/cruise-control"],
+      "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-adbe-(?<build>\\d+)$",
+      "description": "adobe/cruise-control tags are <semver>-adbe-<yyyymmdd>. Default docker versioning treats the '-adbe-<date>' suffix as an immutable compatibility string, so newer daily builds are never offered. Capturing the date as a purely-numeric 'build' (handled like a patch update) makes e.g. 3.0.3-adbe-20250804 -> 3.0.3-adbe-20260722 resolve. The trailing '$' anchor deliberately excludes '-rc' builds."
+    },
+    {
       "groupName": "kafka docker images (major)",
       "groupSlug": "kafka-docker-major",
       "matchFileNames": [


### PR DESCRIPTION
Added new versioning rule for adobe/cruise-control to handle date suffixes.

## Description

Please provide a meaningful description of what this change will do, or is for. Bonus points for including links to
related issues, other PRs, or technical references.

Note that by _not_ including a description, you are asking reviewers to do extra work to understand the context of this
change, which may lead to your PR taking much longer to review, or result in it not being reviewed at all.

## Type of Change
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [ ] I have read the [contributing guidelines](../CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
