### PR TITLE
KRaft hardening: correctness fixes, admission validation, and controller rolling-restart quorum safety

### DIFF
--- a/api/assets/kafka/kraft-controller-healthcheck.sh
+++ b/api/assets/kafka/kraft-controller-healthcheck.sh
@@ -15,52 +15,65 @@
 # limitations under the License.
 
 
-# This script returns a successful exit code (0) if the controller is a follower or leader.  For any other state, it returns a failure exit code (1).
-# In addition, if the environment variable KRAFT_HEALTH_CHECK_SKIP is set to "true" (case insensitive), the script will exit successfully without performing any checks.
+# Health check for a KRaft controller, driven by the Prometheus JMX exporter's raft current-state gauge.
+# The jmx-exporter maps the "raft-metrics current-state=<state>" MBean attribute to a single gauge named
+# kafka_server_raft_metrics_current_state_<state> with value 1, so exactly one such gauge exists at a time
+# and its name is the controller's current raft state (leader, follower, candidate, unattached, ...).
 #
-# The behaviour when the raft state metric cannot be read (JMX endpoint not up yet, or the metric is
-# absent) depends on KRAFT_HEALTH_CHECK_MODE:
-#   - "liveness" (default): exit 0 (fail-open) so a slow-starting or briefly-unavailable JMX exporter
-#     does not cause the kubelet to restart an otherwise healthy controller.
-#   - "readiness": exit 1 (fail-closed) so the pod is only marked Ready once it is a confirmed
-#     leader/follower in the quorum. Koperator's rolling upgrade uses this readiness signal to avoid
-#     restarting the next controller before the previously restarted one has rejoined the quorum.
+# Behaviour is selected by KRAFT_HEALTH_CHECK_MODE:
+#   readiness        -> fail-closed: succeeds only when the controller is a leader or follower (a
+#                       functioning quorum member). Koperator's rolling upgrade waits on this readiness
+#                       signal so it never restarts the next controller before the previously restarted
+#                       one has rejoined the metadata quorum.
+#   liveness (default) -> fails only when the controller is reachable and reporting a state that is not
+#                       leader/follower; a not-yet-emitted state (startup/catch-up) or an unreachable
+#                       metrics endpoint is treated as healthy (fail-open) so a slow-starting or briefly
+#                       unavailable JMX exporter does not restart an otherwise healthy controller.
+# If KRAFT_HEALTH_CHECK_SKIP is set to "true" (case insensitive) all checks are skipped.
 
 skip_check=$(echo "$KRAFT_HEALTH_CHECK_SKIP" | tr '[:upper:]' '[:lower:]')
 mode=$(echo "${KRAFT_HEALTH_CHECK_MODE:-liveness}" | tr '[:upper:]' '[:lower:]')
 
 if [ "$skip_check" = "true" ]; then
-    echo "KRAFT_HEALTH_CHECK_SKIP is set to TRUE. Exiting health check."
+    echo "KRAFT_HEALTH_CHECK_SKIP is set to TRUE. Skipping health check."
     exit 0
 fi
 
-JMX_ENDPOINT="http://localhost:9020/metrics"
 METRIC_PREFIX="kafka_server_raft_metrics_current_state_"
 
-# Fetch the matching current-state metric with value of 1.0 from the JMX endpoint
-MATCHING_METRIC=$(curl -s "$JMX_ENDPOINT" | grep "^${METRIC_PREFIX}" | awk '$2 == 1.0 {print $1}')
+# Request only the raft current-state gauges via the Prometheus name[] query filter, so the exporter
+# returns a few lines instead of the whole /metrics exposition (which on a combined broker+controller
+# node is large). Only the node's current state is ever present, but we list all known raft states so we
+# can still tell "reporting a non-leader/follower state" apart from "no state emitted yet". If the
+# exporter version ignores name[] it returns the full exposition and the same greps below still work.
+STATES="unattached voted prospective candidate leader follower observer resigned"
+FILTER=""
+for state in ${STATES}; do
+    FILTER="${FILTER}&name[]=${METRIC_PREFIX}${state}"
+done
+URL="http://localhost:9020/metrics?${FILTER#&}"
 
-# If it's not empty, it means we found a metric with a value of 1.0.
-if [ -n "$MATCHING_METRIC" ]; then
-    # Determine the state of the controller using the last field name of the metric 
-    # Possible values are leader, candidate, voted, follower, unattached, observer
-    STATE=$(echo "$MATCHING_METRIC" | rev | cut -d'_' -f1 | rev)
-
-    # Check if the extracted state is 'leader' or 'follower'
-    if [ "$STATE" == "leader" ] || [ "$STATE" == "follower" ]; then
-        echo "The controller is in a healthy quorum state."
-        exit 0
-    else
-        # Any other state (e.g., 'candidate', 'unattached', 'observer') is not considered healthy
-        echo "Failure: The controller is in an unexpected state: $STATE. Expecting 'leader' or 'follower'."
-        exit 1
-    fi
-else
-    echo "JMX Exporter endpoint is not available or kafka_server_raft_metrics_current_state_ was not found."
-    if [ "$mode" = "readiness" ]; then
-        # Not yet reporting a healthy quorum state: not ready.
-        exit 1
-    fi
-    # Liveness: do not restart on a transient/absent metric.
+if ! METRICS=$(curl -s --max-time 4 "${URL}"); then
+    echo "JMX exporter metrics endpoint is not reachable."
+    # Unreachable: not a confirmed quorum member (not ready), but do not restart on a transient blip.
+    [ "${mode}" = "readiness" ] && exit 1
     exit 0
 fi
+
+# Healthy quorum member: the leader or follower current-state gauge is present.
+if echo "${METRICS}" | grep -Eq "^${METRIC_PREFIX}(leader|follower) 1(\.[0-9]+)?$"; then
+    echo "The controller is in a healthy quorum state (leader or follower)."
+    exit 0
+fi
+
+# Reachable and reporting some other raft state (e.g. candidate, unattached, observer).
+if echo "${METRICS}" | grep -q "^${METRIC_PREFIX}"; then
+    STATE=$(echo "${METRICS}" | grep "^${METRIC_PREFIX}" | head -n 1 | sed -E "s/^${METRIC_PREFIX}([a-z]+).*/\1/")
+    echo "Failure: the controller is in an unexpected state: ${STATE}. Expecting 'leader' or 'follower'."
+    exit 1
+fi
+
+# Reachable but no raft current-state gauge yet (startup / not caught up).
+echo "kafka_server_raft_metrics_current_state_ was not found (controller not caught up yet)."
+[ "${mode}" = "readiness" ] && exit 1
+exit 0

--- a/api/assets/kafka/kraft-controller-healthcheck.sh
+++ b/api/assets/kafka/kraft-controller-healthcheck.sh
@@ -17,8 +17,17 @@
 
 # This script returns a successful exit code (0) if the controller is a follower or leader.  For any other state, it returns a failure exit code (1).
 # In addition, if the environment variable KRAFT_HEALTH_CHECK_SKIP is set to "true" (case insensitive), the script will exit successfully without performing any checks.
+#
+# The behaviour when the raft state metric cannot be read (JMX endpoint not up yet, or the metric is
+# absent) depends on KRAFT_HEALTH_CHECK_MODE:
+#   - "liveness" (default): exit 0 (fail-open) so a slow-starting or briefly-unavailable JMX exporter
+#     does not cause the kubelet to restart an otherwise healthy controller.
+#   - "readiness": exit 1 (fail-closed) so the pod is only marked Ready once it is a confirmed
+#     leader/follower in the quorum. Koperator's rolling upgrade uses this readiness signal to avoid
+#     restarting the next controller before the previously restarted one has rejoined the quorum.
 
 skip_check=$(echo "$KRAFT_HEALTH_CHECK_SKIP" | tr '[:upper:]' '[:lower:]')
+mode=$(echo "${KRAFT_HEALTH_CHECK_MODE:-liveness}" | tr '[:upper:]' '[:lower:]')
 
 if [ "$skip_check" = "true" ]; then
     echo "KRAFT_HEALTH_CHECK_SKIP is set to TRUE. Exiting health check."
@@ -47,6 +56,11 @@ if [ -n "$MATCHING_METRIC" ]; then
         exit 1
     fi
 else
-    echo "JMX Exporter endpoint is not avaiable or kafka_server_raft_metrics_current_state_ was not found."
+    echo "JMX Exporter endpoint is not available or kafka_server_raft_metrics_current_state_ was not found."
+    if [ "$mode" = "readiness" ]; then
+        # Not yet reporting a healthy quorum state: not ready.
+        exit 1
+    fi
+    # Liveness: do not restart on a transient/absent metric.
     exit 0
 fi

--- a/controllers/cruisecontroltask_controller.go
+++ b/controllers/cruisecontroltask_controller.go
@@ -177,15 +177,30 @@ func (r *CruiseControlTaskReconciler) Reconcile(ctx context.Context, request ctr
 			brokerIDs = append(brokerIDs, task.BrokerID)
 		}
 
-		cruiseControlOpRef, err := r.removeBrokers(ctx, instance, operationTTLSecondsAfterFinished, brokerIDs)
-		if err != nil {
-			return requeueWithError(log, fmt.Sprintf("creating CruiseControlOperation for downscale has failed, brokerIDs: %s", brokerIDs), err)
+		if instance.Spec.KRaftMode {
+			// In KRaft mode, CC has no information about the controller-only nodes, so a remove_broker
+			// request for one would fail in CC. Controller-only nodes are downscaled by deleting their
+			// pod directly (see reconcileKafkaPodDelete) and never receive a GracefulDownscaleRequired
+			// state, so this filter is defense-in-depth to keep the three broker-id CC operations
+			// (add_broker, remove_broker, rebalance) symmetric.
+			brokerIDs, err = util.FilterControllerOnlyNodes(brokerIDs, instance.Spec)
+			if err != nil {
+				return requeueWithError(log, fmt.Sprintf("failed to filter out controller-only nodes from the Kafka cluster, "+
+					"clusterName: %s, clusterNamespace: %s", instance.GetName(), instance.GetNamespace()), err)
+			}
 		}
 
-		// map the CC broker removal operation with each broker status
-		for _, task := range tasksAndStates.GetActiveTasksByOp(banzaiv1alpha1.OperationRemoveBroker) {
-			task.SetCruiseControlOperationRef(cruiseControlOpRef)
-			task.SetStateScheduled()
+		if len(brokerIDs) != 0 {
+			cruiseControlOpRef, err := r.removeBrokers(ctx, instance, operationTTLSecondsAfterFinished, brokerIDs)
+			if err != nil {
+				return requeueWithError(log, fmt.Sprintf("creating CruiseControlOperation for downscale has failed, brokerIDs: %s", brokerIDs), err)
+			}
+
+			// map the CC broker removal operation with each broker status
+			for _, task := range tasksAndStates.GetActiveTasksByOp(banzaiv1alpha1.OperationRemoveBroker) {
+				task.SetCruiseControlOperationRef(cruiseControlOpRef)
+				task.SetStateScheduled()
+			}
 		}
 
 	case tasksAndStates.NumActiveTasksByOp(banzaiv1alpha1.OperationRemoveDisks) > 0:

--- a/pkg/resources/kafka/configmap.go
+++ b/pkg/resources/kafka/configmap.go
@@ -220,7 +220,7 @@ func configureBrokerKRaftMode(bConfig *v1beta1.BrokerConfig, brokerID int32, kaf
 	if bConfig.IsControllerOnlyNode() {
 		// "listeners" configuration can only contain controller configuration when the node is a controller-only node
 		for _, listener := range listenerConfig {
-			if listener[:len(controllerListenerName)] == strings.ToUpper(controllerListenerName) {
+			if isControllerListenerEntry(listener, controllerListenerName) {
 				if err := config.Set(kafkautils.KafkaConfigListeners, listener); err != nil {
 					log.Error(err, fmt.Sprintf(kafkautils.BrokerConfigErrorMsgTemplate, kafkautils.KafkaConfigListeners))
 				}
@@ -231,7 +231,7 @@ func configureBrokerKRaftMode(bConfig *v1beta1.BrokerConfig, brokerID int32, kaf
 		// "listeners" configuration cannot contain broker configuration when the node is a broker-only node
 		var nonControllerListener []string
 		for _, listener := range listenerConfig {
-			if listener[:len(controllerListenerName)] != strings.ToUpper(controllerListenerName) {
+			if !isControllerListenerEntry(listener, controllerListenerName) {
 				nonControllerListener = append(nonControllerListener, listener)
 			}
 		}
@@ -426,6 +426,20 @@ func generateControlPlaneListener(iListeners []v1beta1.InternalListenerConfig) s
 	}
 
 	return controlPlaneListener
+}
+
+// isControllerListenerEntry reports whether a "listeners" entry (formatted as "NAME://:PORT")
+// belongs to the controller listener identified by controllerListenerName.
+// It compares the listener NAME segment exactly rather than by string prefix, avoiding both
+// the panic risk of slicing a shorter listener string and false matches when one listener name
+// is a prefix of another (e.g. "CONTROLLER" vs "CONTROLLER-EXTERNAL"). Returns false when
+// controllerListenerName is empty so that an unset controller listener never matches.
+func isControllerListenerEntry(listenerEntry, controllerListenerName string) bool {
+	if controllerListenerName == "" {
+		return false
+	}
+	name, _, _ := strings.Cut(listenerEntry, "://")
+	return strings.EqualFold(name, controllerListenerName)
 }
 
 func generateListenerSpecificConfig(kcs *v1beta1.KafkaClusterSpec, serverPasses map[string]string, log logr.Logger) (*properties.Properties, map[int32]*properties.Properties, []string) {

--- a/pkg/resources/kafka/configmap_test.go
+++ b/pkg/resources/kafka/configmap_test.go
@@ -1590,7 +1590,7 @@ listener.name.external.ssl.truststore.location=/var/run/secrets/java.io/keystore
 listener.name.external.ssl.truststore.password=
 listener.name.external.ssl.truststore.type=JKS
 listener.security.protocol.map=EXTERNAL:SSL,CONTROLLER:SSL
-listeners=
+listeners=EXTERNAL://:9092,CONTROLLER://:9093
 log.dirs=/test-kafka-logs/kafka,/test-kafka-logs-0/kafka
 metric.reporters=com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsReporter
 node.id=0
@@ -1613,7 +1613,7 @@ listener.name.external.ssl.truststore.location=/var/run/secrets/java.io/keystore
 listener.name.external.ssl.truststore.password=
 listener.name.external.ssl.truststore.type=JKS
 listener.security.protocol.map=EXTERNAL:SSL,CONTROLLER:SSL
-listeners=EXTERNAL://:9092
+listeners=EXTERNAL://:9092,CONTROLLER://:9093
 log.dirs=/test-kafka-logs/kafka
 node.id=500
 process.roles=controller
@@ -1652,6 +1652,58 @@ process.roles=controller
 
 				require.Equal(t, test.expectedBrokerConfigs[i], generatedConfig)
 			}
+		})
+	}
+}
+
+func TestIsControllerListenerEntry(t *testing.T) {
+	tests := []struct {
+		testName               string
+		listenerEntry          string
+		controllerListenerName string
+		expected               bool
+	}{
+		{
+			testName:               "exact controller listener match",
+			listenerEntry:          "CONTROLLER://:9093",
+			controllerListenerName: "CONTROLLER",
+			expected:               true,
+		},
+		{
+			testName:               "case-insensitive match",
+			listenerEntry:          "CONTROLLER://:9093",
+			controllerListenerName: "controller",
+			expected:               true,
+		},
+		{
+			testName:               "prefix collision must not match (CONTROLLER vs CONTROLLER-EXTERNAL)",
+			listenerEntry:          "CONTROLLER-EXTERNAL://:9094",
+			controllerListenerName: "CONTROLLER",
+			expected:               false,
+		},
+		{
+			testName:               "non-controller listener does not match",
+			listenerEntry:          "INTERNAL://:9092",
+			controllerListenerName: "CONTROLLER",
+			expected:               false,
+		},
+		{
+			testName:               "empty controller listener name never matches",
+			listenerEntry:          "INTERNAL://:9092",
+			controllerListenerName: "",
+			expected:               false,
+		},
+		{
+			testName:               "controller name longer than the listener entry does not panic and does not match",
+			listenerEntry:          "IB://:9092",
+			controllerListenerName: "CONTROLLERLISTENERWITHAVERYLONGNAME",
+			expected:               false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+			require.Equal(t, test.expected, isControllerListenerEntry(test.listenerEntry, test.controllerListenerName))
 		})
 	}
 }

--- a/pkg/resources/kafka/kafka.go
+++ b/pkg/resources/kafka/kafka.go
@@ -1005,6 +1005,20 @@ func (r *Reconciler) handleRollingUpgrade(log logr.Logger, desiredPod, currentPo
 				return errorfactory.New(errorfactory.ReconcileRollingUpgrade{}, errors.New("pod count differs from brokers spec"), "rolling upgrade in progress")
 			}
 
+			// In KRaft mode, do not delete a controller pod while any other controller is still catching up
+			// in the metadata quorum. A controller pod's readiness reflects quorum membership (see its
+			// readiness probe), so waiting for all other controllers to be Ready keeps the operator from
+			// restarting the next controller before the previously restarted one has rejoined the quorum -
+			// which could otherwise cost the quorum its majority. The pod being reconciled is excluded so an
+			// unhealthy controller can still be replaced. Broker-only restarts cannot affect quorum majority
+			// and are gated by the data-plane health check below, so they are not blocked here.
+			if notReadyControllers := controllersBlockingRollingUpgrade(r.KafkaCluster.Spec.KRaftMode, podList.Items, currentPod); len(notReadyControllers) > 0 {
+				return errorfactory.New(errorfactory.ReconcileRollingUpgrade{},
+					errors.New("KRaft controller quorum is not stable yet"),
+					"waiting for KRaft controllers to rejoin the quorum before continuing rolling upgrade",
+					"notReadyControllerBrokerIDs", strings.Join(notReadyControllers, ","))
+			}
+
 			// Check if we support multiple broker restarts and restart only in same AZ, otherwise restart only 1 broker at once
 			terminatingOrPendingPods := getPodsInTerminatingOrPendingState(podList.Items)
 			if len(terminatingOrPendingPods) >= r.KafkaCluster.Spec.RollingUpgradeConfig.ConcurrentBrokerRestartCountPerRack {
@@ -1613,6 +1627,50 @@ func getPodsInTerminatingOrPendingState(items []corev1.Pod) []corev1.Pod {
 		}
 	}
 	return pods
+}
+
+// controllersBlockingRollingUpgrade returns the not-Ready controller broker IDs that must block the
+// rolling upgrade before currentPod is deleted, or nil when the upgrade may proceed. The quorum-readiness
+// gate applies only when the cluster is in KRaft mode AND currentPod is itself a controller node:
+// restarting a broker-only node cannot cost the metadata quorum its majority (brokers are not voters),
+// so broker restarts are gated by the data-plane health check instead, not by controller readiness.
+func controllersBlockingRollingUpgrade(kRaftMode bool, pods []corev1.Pod, currentPod *corev1.Pod) []string {
+	if !kRaftMode || currentPod.Labels[banzaiv1beta1.IsControllerNodeKey] != configValueTrue {
+		return nil
+	}
+	return notReadyControllerBrokerIDs(pods, currentPod)
+}
+
+// notReadyControllerBrokerIDs returns the broker IDs of KRaft controller pods (broker id label of pods
+// labeled isControllerNode=true) that are not Ready, excluding the pod currently being reconciled.
+// A controller pod's readiness reflects its metadata-quorum membership, so a non-empty result means the
+// quorum is still stabilizing and the rolling upgrade should pause before deleting another pod.
+func notReadyControllerBrokerIDs(pods []corev1.Pod, currentPod *corev1.Pod) []string {
+	var notReady []string
+	currentBrokerID := currentPod.Labels[banzaiv1beta1.BrokerIdLabelKey]
+	for i := range pods {
+		pod := &pods[i]
+		if pod.Labels[banzaiv1beta1.BrokerIdLabelKey] == currentBrokerID {
+			continue
+		}
+		if pod.Labels[banzaiv1beta1.IsControllerNodeKey] != configValueTrue {
+			continue
+		}
+		if !isPodReady(pod) {
+			notReady = append(notReady, pod.Labels[banzaiv1beta1.BrokerIdLabelKey])
+		}
+	}
+	return notReady
+}
+
+// isPodReady reports whether the pod's Ready condition is true.
+func isPodReady(pod *corev1.Pod) bool {
+	for _, cond := range pod.Status.Conditions {
+		if cond.Type == corev1.PodReady {
+			return cond.Status == corev1.ConditionTrue
+		}
+	}
+	return false
 }
 
 func (r *Reconciler) getBrokerAz(pod *corev1.Pod, kafkaBrokerAvailabilityZoneMap map[int32]string) (string, error) {

--- a/pkg/resources/kafka/kafka.go
+++ b/pkg/resources/kafka/kafka.go
@@ -602,8 +602,10 @@ func (r *Reconciler) reconcileKafkaPodDelete(ctx context.Context, log logr.Logge
 			}
 
 			processRoles, found := broker.GetLabels()[banzaiv1beta1.ProcessRolesKey]
-			// only applicable in KRaft: if this Kafka pod is not a controller-only node, there is no corresponding CC
-			// therefore we can just skip the broker state check and delete the pod safely
+			// Only applicable in KRaft: a controller-only node has no corresponding Cruise Control broker,
+			// so it has no graceful-downscale state to honor and can be deleted directly (this branch is skipped).
+			// For every other node (broker-only, combined, or non-KRaft) we wait for the graceful downscale
+			// to finish before deleting the pod.
 			if !found || processRoles != banzaiv1beta1.ControllerNodeProcessRole {
 				if brokerState, ok := r.KafkaCluster.Status.BrokersState[broker.Labels[banzaiv1beta1.BrokerIdLabelKey]]; ok &&
 					brokerState.GracefulActionState.CruiseControlState != banzaiv1beta1.GracefulDownscaleSucceeded &&

--- a/pkg/resources/kafka/kafka_test.go
+++ b/pkg/resources/kafka/kafka_test.go
@@ -1986,3 +1986,149 @@ func TestGetBrokerAzMap(t *testing.T) {
 		})
 	}
 }
+
+func TestNotReadyControllerBrokerIDs(t *testing.T) {
+	makePod := func(brokerID, isController string, ready bool) corev1.Pod {
+		readyStatus := corev1.ConditionFalse
+		if ready {
+			readyStatus = corev1.ConditionTrue
+		}
+		return corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					v1beta1.BrokerIdLabelKey:    brokerID,
+					v1beta1.IsControllerNodeKey: isController,
+				},
+			},
+			Status: corev1.PodStatus{
+				Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: readyStatus}},
+			},
+		}
+	}
+
+	tests := []struct {
+		testName      string
+		pods          []corev1.Pod
+		currentBroker string
+		expected      []string
+	}{
+		{
+			testName: "all controllers ready",
+			pods: []corev1.Pod{
+				makePod("0", "false", true),
+				makePod("1", "true", true),
+				makePod("2", "true", true),
+			},
+			currentBroker: "0",
+			expected:      nil,
+		},
+		{
+			testName: "one other controller not ready is reported",
+			pods: []corev1.Pod{
+				makePod("0", "false", true),
+				makePod("1", "true", false),
+				makePod("2", "true", true),
+			},
+			currentBroker: "0",
+			expected:      []string{"1"},
+		},
+		{
+			testName: "the controller being reconciled is excluded even when not ready",
+			pods: []corev1.Pod{
+				makePod("1", "true", false),
+				makePod("2", "true", true),
+			},
+			currentBroker: "1",
+			expected:      nil,
+		},
+		{
+			testName: "not-ready broker-only node is ignored",
+			pods: []corev1.Pod{
+				makePod("0", "false", false),
+				makePod("1", "true", true),
+			},
+			currentBroker: "1",
+			expected:      nil,
+		},
+		{
+			testName: "combined node counts as a controller",
+			pods: []corev1.Pod{
+				makePod("0", "true", false),
+				makePod("1", "true", true),
+			},
+			currentBroker: "1",
+			expected:      []string{"0"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+			currentPod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{v1beta1.BrokerIdLabelKey: test.currentBroker}}}
+			assert.Equal(t, test.expected, notReadyControllerBrokerIDs(test.pods, currentPod))
+		})
+	}
+}
+
+func TestControllersBlockingRollingUpgrade(t *testing.T) {
+	pod := func(brokerID, isController string, ready bool) corev1.Pod {
+		readyStatus := corev1.ConditionFalse
+		if ready {
+			readyStatus = corev1.ConditionTrue
+		}
+		return corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{
+				v1beta1.BrokerIdLabelKey:    brokerID,
+				v1beta1.IsControllerNodeKey: isController,
+			}},
+			Status: corev1.PodStatus{Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: readyStatus}}},
+		}
+	}
+	// broker 0: broker-only, broker 1: controller (not ready), broker 2: controller (ready)
+	pods := []corev1.Pod{pod("0", "false", true), pod("1", "true", false), pod("2", "true", true)}
+	currentPodFor := func(brokerID string) *corev1.Pod {
+		for i := range pods {
+			if pods[i].Labels[v1beta1.BrokerIdLabelKey] == brokerID {
+				return &pods[i]
+			}
+		}
+		return nil
+	}
+
+	tests := []struct {
+		testName      string
+		kRaftMode     bool
+		currentBroker string
+		expected      []string
+	}{
+		{
+			testName:      "not KRaft mode never gates",
+			kRaftMode:     false,
+			currentBroker: "2",
+			expected:      nil,
+		},
+		{
+			testName:      "rolling a broker-only node is not gated on controller readiness",
+			kRaftMode:     true,
+			currentBroker: "0",
+			expected:      nil,
+		},
+		{
+			testName:      "rolling a controller is blocked by another not-ready controller",
+			kRaftMode:     true,
+			currentBroker: "2",
+			expected:      []string{"1"},
+		},
+		{
+			testName:      "rolling the not-ready controller itself is not blocked by its own readiness",
+			kRaftMode:     true,
+			currentBroker: "1",
+			expected:      nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+			assert.Equal(t, test.expected, controllersBlockingRollingUpgrade(test.kRaftMode, pods, currentPodFor(test.currentBroker)))
+		})
+	}
+}

--- a/pkg/resources/kafka/pod.go
+++ b/pkg/resources/kafka/pod.go
@@ -115,10 +115,10 @@ fi`},
 					Command: []string{"/bin/bash", "-c", "export KRAFT_HEALTH_CHECK_MODE=readiness\n" + assets.KraftControllerHealthcheckSh},
 				},
 			},
-			InitialDelaySeconds: 0,
-			PeriodSeconds:       5,
-			TimeoutSeconds:      5,
-			FailureThreshold:    20,
+			InitialDelaySeconds: 15,
+			PeriodSeconds:       15,
+			TimeoutSeconds:      10,
+			FailureThreshold:    6,
 		}
 		kafkaContainer.LivenessProbe = &corev1.Probe{
 			ProbeHandler: corev1.ProbeHandler{
@@ -127,8 +127,8 @@ fi`},
 				},
 			},
 			InitialDelaySeconds: 30,
-			PeriodSeconds:       10,
-			TimeoutSeconds:      5,
+			PeriodSeconds:       15,
+			TimeoutSeconds:      10,
 			FailureThreshold:    6,
 		}
 	}

--- a/pkg/resources/kafka/pod.go
+++ b/pkg/resources/kafka/pod.go
@@ -26,7 +26,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/banzaicloud/koperator/api/assets"
 	apiutil "github.com/banzaicloud/koperator/api/util"
@@ -106,24 +105,20 @@ fi`},
 	}
 
 	if r.KafkaCluster.Spec.KRaftMode && brokerConfig.IsControllerNode() {
-		controllerlistenerPort, err := findControllerListenerPort(r.KafkaCluster)
-		if err != nil {
-			log.Error(err, "failed to find controller listener port")
-		} else {
-			kafkaContainer.ReadinessProbe = &corev1.Probe{
-				ProbeHandler: corev1.ProbeHandler{
-					TCPSocket: &corev1.TCPSocketAction{
-						Port: intstr.IntOrString{
-							Type:   intstr.Int,
-							IntVal: controllerlistenerPort,
-						},
-					},
+		// Readiness reflects quorum membership: the controller pod is Ready only once it reports a
+		// leader/follower raft state. Koperator's rolling upgrade waits on this readiness signal so it
+		// never restarts the next controller before the previously restarted one has rejoined the
+		// metadata quorum. The script runs in readiness mode (fail-closed while not yet in the quorum).
+		kafkaContainer.ReadinessProbe = &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				Exec: &corev1.ExecAction{
+					Command: []string{"/bin/bash", "-c", "export KRAFT_HEALTH_CHECK_MODE=readiness\n" + assets.KraftControllerHealthcheckSh},
 				},
-				InitialDelaySeconds: 0,
-				PeriodSeconds:       5,
-				TimeoutSeconds:      5,
-				FailureThreshold:    20,
-			}
+			},
+			InitialDelaySeconds: 0,
+			PeriodSeconds:       5,
+			TimeoutSeconds:      5,
+			FailureThreshold:    20,
 		}
 		kafkaContainer.LivenessProbe = &corev1.Probe{
 			ProbeHandler: corev1.ProbeHandler{
@@ -640,15 +635,4 @@ func generateEnvConfig(brokerConfig *v1beta1.BrokerConfig, defaultEnvVars []core
 	}
 
 	return mergedEnv
-}
-
-func findControllerListenerPort(kc *v1beta1.KafkaCluster) (int32, error) {
-	for _, listener := range kc.Spec.ListenersConfig.InternalListeners {
-		if listener.UsedForControllerCommunication {
-			return listener.ContainerPort, nil
-		}
-	}
-
-	// If no controller listener is found, return an error
-	return 0, fmt.Errorf("no controller listener found")
 }

--- a/pkg/resources/kafka/util.go
+++ b/pkg/resources/kafka/util.go
@@ -67,9 +67,12 @@ func generateQuorumVoters(kafkaCluster *v1beta1.KafkaCluster, controllerListener
 	return quorumVoters, nil
 }
 
-// generateRandomClusterID() generates a based64-encoded random UUID with 16 bytes as the cluster ID
-// it uses URL based64 encoding since that's what Kafka expects
+// generateRandomClusterID() generates a base64-encoded random UUID with 16 bytes as the cluster ID.
+// It uses URL base64 encoding without padding, matching Kafka's canonical org.apache.kafka.common.Uuid
+// string form (Base64.getUrlEncoder().withoutPadding()) which yields 22 characters. The padded form
+// (24 chars ending in "==") happens to be accepted by Kafka 3.9's Uuid.fromString (length <= 24), but it
+// is non-canonical and rejected by newer Kafka versions, so we emit the padding-free canonical form.
 func generateRandomClusterID() string {
 	randomUUID := uuid.New()
-	return base64.URLEncoding.EncodeToString(randomUUID[:])
+	return base64.RawURLEncoding.EncodeToString(randomUUID[:])
 }

--- a/pkg/resources/kafka/util_test.go
+++ b/pkg/resources/kafka/util_test.go
@@ -29,9 +29,18 @@ func TestGenerateClusterID(t *testing.T) {
 	test := make(map[string]bool, numOfIDs)
 	for i := 0; i < numOfIDs; i++ {
 		clusterID := generateRandomClusterID()
-		_, err := base64.URLEncoding.DecodeString(clusterID)
+		decoded, err := base64.RawURLEncoding.DecodeString(clusterID)
 		if err != nil {
 			t.Errorf("expected nil error, got: %v", err)
+		}
+
+		// Kafka's Uuid is a 128-bit (16-byte) value; the base64 form must decode to exactly 16 bytes
+		// and use the canonical padding-free encoding (22 characters).
+		if len(decoded) != 16 {
+			t.Errorf("expected cluster ID to decode to 16 bytes, got %d bytes for %q", len(decoded), clusterID)
+		}
+		if len(clusterID) != 22 {
+			t.Errorf("expected canonical 22-character cluster ID, got %d characters for %q", len(clusterID), clusterID)
 		}
 
 		if test[clusterID] {

--- a/pkg/webhooks/kafkacluster_validator.go
+++ b/pkg/webhooks/kafkacluster_validator.go
@@ -45,6 +45,8 @@ func (s KafkaClusterValidator) ValidateUpdate(ctx context.Context, _, kafkaClust
 		allErrs = append(allErrs, listenerErrs...)
 	}
 
+	allErrs = append(allErrs, checkKRaftConfig(&kafkaClusterNew.Spec)...)
+
 	if len(allErrs) == 0 {
 		return nil, nil
 	}
@@ -64,6 +66,8 @@ func (s KafkaClusterValidator) ValidateCreate(ctx context.Context, kafkaCluster 
 		allErrs = append(allErrs, listenerErrs...)
 	}
 
+	allErrs = append(allErrs, checkKRaftConfig(&kafkaCluster.Spec)...)
+
 	if len(allErrs) == 0 {
 		return nil, nil
 	}
@@ -76,6 +80,83 @@ func (s KafkaClusterValidator) ValidateCreate(ctx context.Context, kafkaCluster 
 
 func (s KafkaClusterValidator) ValidateDelete(_ context.Context, _ *banzaicloudv1beta1.KafkaCluster) (warnings admission.Warnings, err error) {
 	return nil, nil
+}
+
+// checkKRaftConfig validates KRaft-specific requirements on the KafkaCluster spec.
+// It is a no-op when the cluster is not in KRaft mode. These checks surface, at admission time,
+// misconfigurations that would otherwise only fail (or panic) later during reconciliation:
+//   - a KRaft cluster with no controller node cannot form a metadata quorum,
+//   - a KRaft cluster with no controller listener has no address for the quorum to communicate on,
+//   - a broker with no process role is meaningless in KRaft mode,
+//   - a node with the controller role stores the metadata log and supports only a single, immutable
+//     log directory (mirrors the reconcile-time restriction in the kafka resource reconciler).
+func checkKRaftConfig(kafkaClusterSpec *banzaicloudv1beta1.KafkaClusterSpec) field.ErrorList {
+	if !kafkaClusterSpec.KRaftMode {
+		return nil
+	}
+
+	var allErrs field.ErrorList
+
+	// Exactly one internal listener must be designated for controller communication.
+	controllerListeners := 0
+	for _, il := range kafkaClusterSpec.ListenersConfig.InternalListeners {
+		if il.UsedForControllerCommunication {
+			controllerListeners++
+		}
+	}
+	internalListenersPath := field.NewPath("spec").Child("listenersConfig").Child("internalListeners")
+	switch {
+	case controllerListeners == 0:
+		allErrs = append(allErrs, field.Required(internalListenersPath,
+			"in KRaft mode exactly one internal listener must set 'usedForControllerCommunication: true'"))
+	case controllerListeners > 1:
+		allErrs = append(allErrs, field.Invalid(internalListenersPath, controllerListeners,
+			"in KRaft mode only one internal listener may set 'usedForControllerCommunication: true'"))
+	}
+
+	// Per-broker role and storage validation.
+	controllerNodeCount := 0
+	for i, broker := range kafkaClusterSpec.Brokers {
+		brokerConfig, err := broker.GetBrokerConfig(*kafkaClusterSpec)
+		if err != nil {
+			allErrs = append(allErrs, field.Invalid(field.NewPath("spec").Child("brokers").Index(i), broker.Id,
+				fmt.Sprintf("could not resolve broker configuration: %v", err)))
+			continue
+		}
+
+		if !brokerConfig.IsBrokerNode() && !brokerConfig.IsControllerNode() {
+			allErrs = append(allErrs, field.Required(
+				field.NewPath("spec").Child("brokers").Index(i).Child("brokerConfig").Child("processRoles"),
+				fmt.Sprintf("in KRaft mode broker %d must declare at least one process role ('broker' and/or 'controller')", broker.Id)))
+		}
+
+		if brokerConfig.IsControllerNode() {
+			controllerNodeCount++
+			// A KRaft node with the controller role stores the cluster metadata log and supports only a
+			// single persistent log directory; Koperator additionally treats its mount path as immutable.
+			// This mirrors the reconcile-time restriction (reconcileKafkaPvc), which requires exactly one
+			// PVC-backed storage config for a controller (extra emptyDir volumes do not create PVCs).
+			pvcBackedStorageConfigs := 0
+			for _, sc := range brokerConfig.StorageConfigs {
+				if sc.PvcSpec != nil {
+					pvcBackedStorageConfigs++
+				}
+			}
+			if pvcBackedStorageConfigs != 1 {
+				allErrs = append(allErrs, field.Invalid(
+					field.NewPath("spec").Child("brokers").Index(i).Child("brokerConfig").Child("storageConfigs"),
+					pvcBackedStorageConfigs,
+					fmt.Sprintf("a KRaft node with the 'controller' role (broker %d) must have exactly one PVC-backed storage config", broker.Id)))
+			}
+		}
+	}
+
+	if controllerNodeCount == 0 {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("spec").Child("brokers"), controllerNodeCount,
+			"in KRaft mode at least one broker must have the 'controller' process role"))
+	}
+
+	return allErrs
 }
 
 // checkListeners validates the spec.listenersConfig object

--- a/pkg/webhooks/kafkacluster_validator_test.go
+++ b/pkg/webhooks/kafkacluster_validator_test.go
@@ -385,3 +385,127 @@ func TestCheckTargetPortsCollisionForEnvoy(t *testing.T) {
 		})
 	}
 }
+
+func TestCheckKRaftConfig(t *testing.T) {
+	interBrokerListener := v1beta1.InternalListenerConfig{
+		CommonListenerSpec: v1beta1.CommonListenerSpec{
+			Name:                            "internal",
+			ContainerPort:                   29092,
+			UsedForInnerBrokerCommunication: true,
+		},
+	}
+	controllerListener := v1beta1.InternalListenerConfig{
+		CommonListenerSpec:             v1beta1.CommonListenerSpec{Name: "controller", ContainerPort: 29093},
+		UsedForControllerCommunication: true,
+	}
+	// A controller's storage config must provision exactly one PVC (matches the reconcile-time constraint).
+	onePVCStorage := []v1beta1.StorageConfig{{MountPath: "/kafka-logs", PvcSpec: &corev1.PersistentVolumeClaimSpec{}}}
+	// One PVC plus an emptyDir is still a single PVC-backed volume, so it is valid for a controller.
+	onePVCPlusEmptyDir := []v1beta1.StorageConfig{
+		{MountPath: "/kafka-logs", PvcSpec: &corev1.PersistentVolumeClaimSpec{}},
+		{MountPath: "/ephemeral", EmptyDir: &corev1.EmptyDirVolumeSource{}},
+	}
+	twoPVCStorage := []v1beta1.StorageConfig{
+		{MountPath: "/kafka-logs", PvcSpec: &corev1.PersistentVolumeClaimSpec{}},
+		{MountPath: "/kafka-logs-2", PvcSpec: &corev1.PersistentVolumeClaimSpec{}},
+	}
+
+	validListeners := v1beta1.ListenersConfig{
+		InternalListeners: []v1beta1.InternalListenerConfig{interBrokerListener, controllerListener},
+	}
+
+	testCases := []struct {
+		testName         string
+		kafkaClusterSpec v1beta1.KafkaClusterSpec
+		expectedErrCount int
+	}{
+		{
+			testName: "not KRaft mode is a no-op even with an otherwise invalid layout",
+			kafkaClusterSpec: v1beta1.KafkaClusterSpec{
+				KRaftMode:       false,
+				ListenersConfig: v1beta1.ListenersConfig{},
+				Brokers:         []v1beta1.Broker{{Id: 0, BrokerConfig: &v1beta1.BrokerConfig{}}},
+			},
+			expectedErrCount: 0,
+		},
+		{
+			testName: "valid KRaft cluster: broker-only, controller-only and combined nodes",
+			kafkaClusterSpec: v1beta1.KafkaClusterSpec{
+				KRaftMode:       true,
+				ListenersConfig: validListeners,
+				Brokers: []v1beta1.Broker{
+					{Id: 0, BrokerConfig: &v1beta1.BrokerConfig{Roles: []string{"broker"}, StorageConfigs: twoPVCStorage}},
+					{Id: 1, BrokerConfig: &v1beta1.BrokerConfig{Roles: []string{"controller"}, StorageConfigs: onePVCStorage}},
+					{Id: 2, BrokerConfig: &v1beta1.BrokerConfig{Roles: []string{"broker", "controller"}, StorageConfigs: onePVCPlusEmptyDir}},
+				},
+			},
+			expectedErrCount: 0,
+		},
+		{
+			testName: "missing controller listener",
+			kafkaClusterSpec: v1beta1.KafkaClusterSpec{
+				KRaftMode:       true,
+				ListenersConfig: v1beta1.ListenersConfig{InternalListeners: []v1beta1.InternalListenerConfig{interBrokerListener}},
+				Brokers: []v1beta1.Broker{
+					{Id: 1, BrokerConfig: &v1beta1.BrokerConfig{Roles: []string{"controller"}, StorageConfigs: onePVCStorage}},
+				},
+			},
+			expectedErrCount: 1,
+		},
+		{
+			testName: "more than one controller listener",
+			kafkaClusterSpec: v1beta1.KafkaClusterSpec{
+				KRaftMode: true,
+				ListenersConfig: v1beta1.ListenersConfig{InternalListeners: []v1beta1.InternalListenerConfig{
+					controllerListener,
+					{CommonListenerSpec: v1beta1.CommonListenerSpec{Name: "controller2", ContainerPort: 29094}, UsedForControllerCommunication: true},
+				}},
+				Brokers: []v1beta1.Broker{
+					{Id: 1, BrokerConfig: &v1beta1.BrokerConfig{Roles: []string{"controller"}, StorageConfigs: onePVCStorage}},
+				},
+			},
+			expectedErrCount: 1,
+		},
+		{
+			testName: "no controller node",
+			kafkaClusterSpec: v1beta1.KafkaClusterSpec{
+				KRaftMode:       true,
+				ListenersConfig: validListeners,
+				Brokers: []v1beta1.Broker{
+					{Id: 0, BrokerConfig: &v1beta1.BrokerConfig{Roles: []string{"broker"}, StorageConfigs: onePVCStorage}},
+				},
+			},
+			expectedErrCount: 1,
+		},
+		{
+			testName: "broker with no process role",
+			kafkaClusterSpec: v1beta1.KafkaClusterSpec{
+				KRaftMode:       true,
+				ListenersConfig: validListeners,
+				Brokers: []v1beta1.Broker{
+					{Id: 0, BrokerConfig: &v1beta1.BrokerConfig{Roles: []string{}, StorageConfigs: onePVCStorage}},
+					{Id: 1, BrokerConfig: &v1beta1.BrokerConfig{Roles: []string{"controller"}, StorageConfigs: onePVCStorage}},
+				},
+			},
+			expectedErrCount: 1,
+		},
+		{
+			testName: "controller node with more than one storage config",
+			kafkaClusterSpec: v1beta1.KafkaClusterSpec{
+				KRaftMode:       true,
+				ListenersConfig: validListeners,
+				Brokers: []v1beta1.Broker{
+					{Id: 1, BrokerConfig: &v1beta1.BrokerConfig{Roles: []string{"controller"}, StorageConfigs: twoPVCStorage}},
+				},
+			},
+			expectedErrCount: 1,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.testName, func(t *testing.T) {
+			got := checkKRaftConfig(&testCase.kafkaClusterSpec)
+			require.Len(t, got, testCase.expectedErrCount, "unexpected errors: %v", got)
+		})
+	}
+}

--- a/pkg/webhooks/kafkacluster_validator_test.go
+++ b/pkg/webhooks/kafkacluster_validator_test.go
@@ -16,9 +16,11 @@
 package webhooks
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
+	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -506,6 +508,95 @@ func TestCheckKRaftConfig(t *testing.T) {
 		t.Run(testCase.testName, func(t *testing.T) {
 			got := checkKRaftConfig(&testCase.kafkaClusterSpec)
 			require.Len(t, got, testCase.expectedErrCount, "unexpected errors: %v", got)
+		})
+	}
+}
+
+// TestKafkaClusterValidatorValidateKRaft exercises the admission entrypoints (ValidateCreate and
+// ValidateUpdate) end-to-end for KRaft clusters, verifying that invalid layouts are actually rejected
+// (non-nil error) and valid ones are admitted - i.e. that checkKRaftConfig is wired into the webhook.
+func TestKafkaClusterValidatorValidateKRaft(t *testing.T) {
+	validator := KafkaClusterValidator{Log: logr.Discard()}
+
+	interBrokerListener := v1beta1.InternalListenerConfig{
+		CommonListenerSpec: v1beta1.CommonListenerSpec{
+			Name:                            "internal",
+			ContainerPort:                   29092,
+			UsedForInnerBrokerCommunication: true,
+		},
+	}
+	controllerListener := v1beta1.InternalListenerConfig{
+		CommonListenerSpec:             v1beta1.CommonListenerSpec{Name: "controller", ContainerPort: 29093},
+		UsedForControllerCommunication: true,
+	}
+	onePVCStorage := []v1beta1.StorageConfig{{MountPath: "/kafka-logs", PvcSpec: &corev1.PersistentVolumeClaimSpec{}}}
+	twoPVCStorage := []v1beta1.StorageConfig{
+		{MountPath: "/kafka-logs", PvcSpec: &corev1.PersistentVolumeClaimSpec{}},
+		{MountPath: "/kafka-logs-2", PvcSpec: &corev1.PersistentVolumeClaimSpec{}},
+	}
+
+	validKRaftCluster := func() *v1beta1.KafkaCluster {
+		return &v1beta1.KafkaCluster{
+			Spec: v1beta1.KafkaClusterSpec{
+				KRaftMode:       true,
+				ListenersConfig: v1beta1.ListenersConfig{InternalListeners: []v1beta1.InternalListenerConfig{interBrokerListener, controllerListener}},
+				Brokers: []v1beta1.Broker{
+					{Id: 0, BrokerConfig: &v1beta1.BrokerConfig{Roles: []string{"broker"}, StorageConfigs: onePVCStorage}},
+					{Id: 1, BrokerConfig: &v1beta1.BrokerConfig{Roles: []string{"controller"}, StorageConfigs: onePVCStorage}},
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		testName string
+		mutate   func(*v1beta1.KafkaCluster)
+		wantErr  bool
+	}{
+		{
+			testName: "valid KRaft cluster is admitted",
+			mutate:   func(*v1beta1.KafkaCluster) {},
+			wantErr:  false,
+		},
+		{
+			testName: "cluster with no controller node is rejected",
+			mutate:   func(kc *v1beta1.KafkaCluster) { kc.Spec.Brokers[1].BrokerConfig.Roles = []string{"broker"} },
+			wantErr:  true,
+		},
+		{
+			testName: "cluster with no controller listener is rejected",
+			mutate: func(kc *v1beta1.KafkaCluster) {
+				kc.Spec.ListenersConfig.InternalListeners = []v1beta1.InternalListenerConfig{interBrokerListener}
+			},
+			wantErr: true,
+		},
+		{
+			testName: "controller node with two PVC-backed storage configs is rejected",
+			mutate:   func(kc *v1beta1.KafkaCluster) { kc.Spec.Brokers[1].BrokerConfig.StorageConfigs = twoPVCStorage },
+			wantErr:  true,
+		},
+		{
+			testName: "broker with no process role is rejected",
+			mutate:   func(kc *v1beta1.KafkaCluster) { kc.Spec.Brokers[0].BrokerConfig.Roles = []string{} },
+			wantErr:  true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+			kc := validKRaftCluster()
+			test.mutate(kc)
+
+			_, errCreate := validator.ValidateCreate(context.Background(), kc)
+			_, errUpdate := validator.ValidateUpdate(context.Background(), nil, kc)
+
+			if test.wantErr {
+				require.Error(t, errCreate, "ValidateCreate should reject")
+				require.Error(t, errUpdate, "ValidateUpdate should reject")
+			} else {
+				require.NoError(t, errCreate, "ValidateCreate should admit")
+				require.NoError(t, errUpdate, "ValidateUpdate should admit")
+			}
 		})
 	}
 }


### PR DESCRIPTION
## What

A hardening pass over the KRaft implementation, addressing correctness bugs, a missing-validation gap, and an operational safety gap found during a focused audit of the KRaft code paths (cross-checked against Apache Kafka 3.9.1). ZooKeeper→KRaft migration findings are intentionally **out of scope** for this PR.

Each fix is a separate, self-contained commit.

## Commits

| Commit | Type | Change |
|---|---|---|
| `fix(kraft): generate canonical padding-free cluster ID` | bug | `generateRandomClusterID` used `base64.URLEncoding` → a 24-char padded id (`…==`). Kafka 3.9 tolerates it, but the canonical `Uuid` form is 22 chars unpadded (`Base64.getUrlEncoder().withoutPadding()`) and newer Kafka rejects longer strings. Switched to `base64.RawURLEncoding`. Existing clusters are unaffected (id is persisted in `Status.ClusterID`). |
| `fix(kraft): match controller listener by exact name, not string prefix` | bug | `configureBrokerKRaftMode` identified the controller listener with `listener[:len(name)] == name`. That can **panic** (slice out of range when the controller name is longer than a listener entry), **false-match** on prefix collisions (`CONTROLLER` vs `CONTROLLER-EXTERNAL`), and gave broker-only nodes an **empty `listeners=`** when no controller listener was set. Replaced with exact NAME-segment matching. |
| `fix(kraft): filter controller-only nodes from Cruise Control remove_broker` | bug | `add_broker` and `rebalance` already drop controller-only nodes before calling Cruise Control; `remove_broker` did not. Added the same `FilterControllerOnlyNodes` guard so all three broker-id CC operations are symmetric. |
| `docs(kraft): correct inverted comment on controller-only pod deletion` | docs | The graceful-downscale guard comment in `reconcileKafkaPodDelete` described the opposite of the code. No behavior change. |
| `feat(kraft): validate KRaft configuration in the admission webhook` | feature | The validating webhook did no KRaft checks, so invalid layouts only failed (or panicked) deep in reconciliation. Added `checkKRaftConfig` (create + update): requires ≥1 controller node, exactly one `usedForControllerCommunication` internal listener, a process role on every broker, and exactly one PVC-backed storage config on controller nodes (mirrors the existing reconcile-time restriction). |
| `feat(kraft): gate controller rolling restarts on quorum health` | feature | See below. |

## Controller rolling-restart quorum safety (the `feat` gate)

Previously the rolling upgrade deleted the next pod as soon as the prior one left `Pending`/`Terminating`, and its only health gate (`AllOfflineReplicas`/`OutOfSyncReplicas`) reflects **partition/data-plane** health — which controller-only nodes never appear in. Combined with the operator deleting pods directly (bypassing the controller PDB), a controller could be restarted before the previous one rejoined the quorum, risking loss of **metadata quorum majority**.

This PR makes controller **readiness** reflect quorum membership and gates on it:

- The controller **readiness probe** now execs the kraft healthcheck in a new fail-closed `KRAFT_HEALTH_CHECK_MODE=readiness` mode — the pod is `Ready` only once it reports a `leader`/`follower` raft state. **Liveness keeps the previous fail-open behaviour** so a slow/blipping JMX exporter never restarts a healthy controller. (Replaces the previous bare TCP-socket readiness check.)
- `handleRollingUpgrade` refuses to delete a **controller** pod while any *other* controller is not `Ready`. Broker-only restarts cannot cost the quorum its majority, so they are **not** gated here (they remain gated by the data-plane health check). The pod being reconciled is excluded, so an unhealthy controller can still be replaced. Escape hatch: `KRAFT_HEALTH_CHECK_SKIP=true`.

## Testing

- New unit tests: `TestIsControllerListenerEntry`, `TestCheckKRaftConfig`, `TestNotReadyControllerBrokerIDs`, `TestControllersBlockingRollingUpgrade`, and strengthened `TestGenerateClusterID` (asserts 16-byte / 22-char canonical id).
- `go build ./...`, `go vet`, `gofmt`, and `golangci-lint` all clean.
- Full `controllers/tests` envtest integration suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
