### PR TITLE
fix: exclude capacity.json from Cruise Control pod-template hash by default

### DIFF
--- a/controllers/tests/kafkacluster_controller_cruisecontrol_test.go
+++ b/controllers/tests/kafkacluster_controller_cruisecontrol_test.go
@@ -252,7 +252,9 @@ func expectCruiseControlDeployment(ctx context.Context, kafkaCluster *v1beta1.Ka
 	Expect(deployment.Spec.Selector.MatchLabels).To(HaveKeyWithValue(v1beta1.AppLabelKey, "cruisecontrol"))
 	Expect(deployment.Spec.Selector.MatchLabels).To(HaveKeyWithValue(v1beta1.KafkaCRLabelKey, kafkaCluster.Name))
 
-	Expect(deployment.Spec.Template.Annotations).To(HaveKey("cruiseControlCapacity.json"))
+	// cruiseControlCapacity.json is only present when the broker-capacity-config annotation opts
+	// into "static" mode (see checks further down); it is intentionally absent by default so that
+	// capacity.json changes (e.g. on broker scaling) do not roll the Cruise Control Deployment.
 	Expect(deployment.Spec.Template.Annotations).To(HaveKey("cruiseControlClusterConfig.json"))
 	Expect(deployment.Spec.Template.Annotations).To(HaveKey("cruiseControlConfig.json"))
 	Expect(deployment.Spec.Template.Annotations).To(HaveKey("cruiseControlLogConfig.json"))
@@ -388,7 +390,7 @@ func expectCruiseControlDeployment(ctx context.Context, kafkaCluster *v1beta1.Ka
 		},
 	)
 
-	if capacityConfigType, ok := userProvidedCCPodAnnotations["cruise-control.banzaicloud.com/broker-capacity-config"]; !ok || capacityConfigType == "static" {
+	if capacityConfigType, ok := userProvidedCCPodAnnotations["cruise-control.banzaicloud.com/broker-capacity-config"]; ok && capacityConfigType == "static" {
 		expectedPodAnnotations["cruiseControlCapacity.json"] = hex.EncodeToString(ccBrokerCapacityConfigHash[:])
 	}
 

--- a/controllers/tests/kafkacluster_controller_test.go
+++ b/controllers/tests/kafkacluster_controller_test.go
@@ -279,6 +279,26 @@ var _ = Describe("KafkaCluster", func() {
 			expectKafka(ctx, kafkaClusterKRaft, count)
 		})
 	})
+	When("opting into static broker-capacity-config", func() {
+		// Regression coverage for https://github.com/adobe/koperator/issues/301: the
+		// broker-capacity-config: static escape hatch must still work end-to-end through the
+		// real KafkaClusterReconciler and a real API server, not just the fake-client/unit
+		// tests in pkg/resources/cruisecontrol/.
+		BeforeEach(func() {
+			loadBalancerServiceName = fmt.Sprintf("envoy-loadbalancer-test-%s", kafkaCluster.Name)
+			externalListenerHostName = testHostName
+			loadBalancerServiceNameKRaft = fmt.Sprintf("envoy-loadbalancer-test-%s", kafkaClusterKRaft.Name)
+			externalListenerHostNameKRaft = testHostName
+			kafkaCluster.Spec.CruiseControlConfig.CruiseControlAnnotations = map[string]string{
+				"test-cc-ann": "test-cc-ann-val",
+				"cruise-control.banzaicloud.com/broker-capacity-config": "static",
+			}
+		})
+
+		It("still includes cruiseControlCapacity.json in the CruiseControl pod template", func(ctx SpecContext) {
+			expectCruiseControl(ctx, kafkaCluster)
+		})
+	})
 	When("configuring one ingress envoy controller config inside the external listener without bindings", func() {
 		BeforeEach(func() {
 			testExternalListener := kafkaCluster.Spec.ListenersConfig.ExternalListeners[0]

--- a/pkg/resources/cruisecontrol/cruisecontrol.go
+++ b/pkg/resources/cruisecontrol/cruisecontrol.go
@@ -51,6 +51,9 @@ const (
 	warnLevel                                            = -1
 )
 
+// CapacityConfigAnnotation controls whether capacity.json is hashed into the Cruise Control Deployment's
+// pod template. It defaults to excluded (any value other than "static", including unset); set it to
+// "static" to opt back into restarting the Cruise Control pod whenever capacity.json changes.
 type CapacityConfigAnnotation string
 
 // Reconciler implements the Component Reconciler

--- a/pkg/resources/cruisecontrol/cruisecontrol_reconcile_test.go
+++ b/pkg/resources/cruisecontrol/cruisecontrol_reconcile_test.go
@@ -1,0 +1,183 @@
+// Copyright 2026 Adobe. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cruisecontrol
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/go-logr/logr"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/banzaicloud/koperator/api/v1alpha1"
+	"github.com/banzaicloud/koperator/api/v1beta1"
+	"github.com/banzaicloud/koperator/pkg/kafkaclient"
+)
+
+func newIssue301TestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add corev1 to scheme: %v", err)
+	}
+	if err := appsv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add appsv1 to scheme: %v", err)
+	}
+	if err := v1beta1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add v1beta1 to scheme: %v", err)
+	}
+	if err := v1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add v1alpha1 to scheme: %v", err)
+	}
+	return scheme
+}
+
+func newIssue301TestKafkaCluster(name, namespace string, brokerIDs []int32) *v1beta1.KafkaCluster {
+	quantity := resource.MustParse("10Gi")
+	brokers := make([]v1beta1.Broker, 0, len(brokerIDs))
+	brokerStates := make(map[string]v1beta1.BrokerState, len(brokerIDs))
+	for _, id := range brokerIDs {
+		brokers = append(brokers, v1beta1.Broker{
+			Id: id,
+			BrokerConfig: &v1beta1.BrokerConfig{
+				StorageConfigs: []v1beta1.StorageConfig{
+					{
+						MountPath: "/kafka-logs",
+						PvcSpec: &corev1.PersistentVolumeClaimSpec{
+							Resources: corev1.VolumeResourceRequirements{
+								Requests: corev1.ResourceList{corev1.ResourceStorage: quantity},
+							},
+						},
+					},
+				},
+			},
+		})
+		brokerStates[strconv.Itoa(int(id))] = v1beta1.BrokerState{
+			GracefulActionState: v1beta1.GracefulActionState{
+				CruiseControlState: v1beta1.GracefulUpscaleSucceeded,
+			},
+		}
+	}
+
+	return &v1beta1.KafkaCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: v1beta1.KafkaClusterSpec{
+			Brokers: brokers,
+			ListenersConfig: v1beta1.ListenersConfig{
+				InternalListeners: []v1beta1.InternalListenerConfig{
+					{
+						CommonListenerSpec: v1beta1.CommonListenerSpec{
+							Type:                            "plaintext",
+							Name:                            "internal",
+							ContainerPort:                   29092,
+							UsedForInnerBrokerCommunication: true,
+						},
+					},
+				},
+			},
+			// auto-create short-circuits generateCCTopic before it needs a live Kafka client,
+			// so the fake KafkaClientProvider passed to New() is never invoked.
+			ReadOnlyConfig: "cruise.control.metrics.topic.auto.create=true",
+		},
+		Status: v1beta1.KafkaClusterStatus{
+			BrokersState:             brokerStates,
+			CruiseControlTopicStatus: v1beta1.CruiseControlTopicReady,
+		},
+	}
+}
+
+// TestReconcile_ScaleUpStillChangesPodTemplateWhenStaticOptInSet is an integration-level guard
+// test for https://github.com/adobe/koperator/issues/301, driving the real CruiseControl
+// Reconciler.Reconcile function (the same code path the KafkaClusterReconciler calls in
+// production) against a fake Kubernetes API. It asserts that operators who explicitly opt into
+// "static" mode still see the Deployment roll on capacity.json changes, so this fix does not
+// silently remove that capability. The default (no restart on scale) path is already covered by
+// the unit-level TestGeneratePodAnnotations_CapacityChangeDoesNotAffectPodTemplateByDefault
+// (deployment_test.go) and by the existing envtest suite in controllers/tests/, so it is not
+// duplicated here.
+func TestReconcile_ScaleUpStillChangesPodTemplateWhenStaticOptInSet(t *testing.T) {
+	scheme := newIssue301TestScheme(t)
+	log := logr.Discard()
+	namespace := "kafka-issue301-static"
+	name := "kafkacluster-issue301-static"
+
+	kafkaClusterBefore := newIssue301TestKafkaCluster(name, namespace, []int32{0, 1, 2})
+	kafkaClusterBefore.Spec.CruiseControlConfig.CruiseControlAnnotations = map[string]string{
+		capacityConfigAnnotation: string(staticCapacityConfig),
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(kafkaClusterBefore).Build()
+
+	reconciler := New(fakeClient, kafkaClusterBefore, kafkaclient.NewMockProvider())
+	if err := reconciler.Reconcile(log); err != nil {
+		t.Fatalf("Reconcile (before scale-up) failed: %v", err)
+	}
+
+	deployment := &appsv1.Deployment{}
+	deploymentKey := types.NamespacedName{Namespace: namespace, Name: name + "-cruisecontrol"}
+	if err := fakeClient.Get(t.Context(), deploymentKey, deployment); err != nil {
+		t.Fatalf("failed to get CruiseControl deployment after first reconcile: %v", err)
+	}
+	hashBefore, ok := deployment.Spec.Template.Annotations["cruiseControlCapacity.json"]
+	if !ok {
+		t.Fatalf("expected cruiseControlCapacity.json annotation to be present under static opt-in")
+	}
+
+	kafkaClusterAfter := kafkaClusterBefore.DeepCopy()
+	kafkaClusterAfter.Spec.Brokers = append(kafkaClusterAfter.Spec.Brokers, v1beta1.Broker{
+		Id: 3,
+		BrokerConfig: &v1beta1.BrokerConfig{
+			StorageConfigs: []v1beta1.StorageConfig{
+				{
+					MountPath: "/kafka-logs",
+					PvcSpec: &corev1.PersistentVolumeClaimSpec{
+						Resources: corev1.VolumeResourceRequirements{
+							Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("10Gi")},
+						},
+					},
+				},
+			},
+		},
+	})
+	kafkaClusterAfter.Status.BrokersState["3"] = v1beta1.BrokerState{
+		GracefulActionState: v1beta1.GracefulActionState{
+			CruiseControlState: v1beta1.GracefulUpscaleSucceeded,
+		},
+	}
+
+	reconciler = New(fakeClient, kafkaClusterAfter, kafkaclient.NewMockProvider())
+	if err := reconciler.Reconcile(log); err != nil {
+		t.Fatalf("Reconcile (after scale-up) failed: %v", err)
+	}
+
+	if err := fakeClient.Get(t.Context(), deploymentKey, deployment); err != nil {
+		t.Fatalf("failed to get CruiseControl deployment after second reconcile: %v", err)
+	}
+	hashAfter, ok := deployment.Spec.Template.Annotations["cruiseControlCapacity.json"]
+	if !ok {
+		t.Fatalf("expected cruiseControlCapacity.json annotation to remain present under static opt-in")
+	}
+	if hashBefore == hashAfter {
+		t.Fatalf("expected capacity hash to change across scale-up when static opt-in is set")
+	}
+}

--- a/pkg/resources/cruisecontrol/deployment.go
+++ b/pkg/resources/cruisecontrol/deployment.go
@@ -184,6 +184,11 @@ fi`},
 	}
 }
 
+// GeneratePodAnnotations computes the Cruise Control pod-template annotations, including a
+// content hash per config file so Kubernetes rolls the pod when a hashed file changes. capacity.json
+// is hashed (and so can trigger a roll) only when cruiseControlAnnotations sets
+// capacityConfigAnnotation to "static"; it is excluded by default. See CapacityConfigAnnotation
+// for why, and the inline comment below for the full rationale.
 func GeneratePodAnnotations(cruiseControlAnnotations, cruiseControlConfig map[string]string) map[string]string {
 	hashedCruiseControlConfigJson := sha256.Sum256([]byte(cruiseControlConfig["cruisecontrol.properties"]))
 	hashedCruiseControlClusterConfigJson := sha256.Sum256([]byte(cruiseControlConfig["clusterConfigs.json"]))
@@ -197,8 +202,23 @@ func GeneratePodAnnotations(cruiseControlAnnotations, cruiseControlConfig map[st
 			"cruiseControlLogConfig.json":     hex.EncodeToString(hashedCruiseControlLogConfigJson[:]),
 		},
 	}
-	if value, ok := cruiseControlAnnotations[capacityConfigAnnotation]; !ok ||
-		value == string(staticCapacityConfig) {
+	// capacity.json is deliberately excluded from the pod-template hash by default: Cruise Control only
+	// reads it at process startup, and the operator already falls back to CC's own capacity estimation for
+	// scale operations, so a capacity.json change does not need to restart a running CC pod. Restarting on
+	// every capacity.json change (e.g. every broker add/remove) risks racing an in-flight add_broker/
+	// remove_broker CruiseControlOperation: the operation is submitted based only on CC's REST API
+	// readiness, so a roll triggered here can replace the CC pod mid-operation, losing its in-memory task
+	// state. Users who need the exact (non-estimated) capacity for newly added brokers immediately, and are
+	// willing to accept the restart-race trade-off, can opt back in by setting the broker-capacity-config
+	// annotation to "static".
+	//
+	// Upgrade note: prior to this change, capacity.json was always hashed here (the annotation being unset
+	// behaved the same as "static"), so every existing cluster's live Deployment already carries the
+	// cruiseControlCapacity.json annotation. The first reconcile after upgrading to this behavior computes a
+	// pod template without that key, which k8sutil.Reconcile detects as a real diff and applies via a full
+	// Deployment update - causing exactly one CruiseControl pod restart per cluster on upgrade. This is a
+	// one-time, expected side effect of adopting the new default, not a bug; call it out in release notes.
+	if value, ok := cruiseControlAnnotations[capacityConfigAnnotation]; ok && value == string(staticCapacityConfig) {
 		hashedCruiseControlCapacityJson := sha256.Sum256([]byte(cruiseControlConfig["capacity.json"]))
 		annotations = append(annotations,
 			map[string]string{"cruiseControlCapacity.json": hex.EncodeToString(hashedCruiseControlCapacityJson[:])})

--- a/pkg/resources/cruisecontrol/deployment_test.go
+++ b/pkg/resources/cruisecontrol/deployment_test.go
@@ -1,0 +1,226 @@
+// Copyright 2026 Adobe. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cruisecontrol
+
+import (
+	"testing"
+)
+
+// TestGeneratePodAnnotations_CapacityConfigHash covers the broker-capacity-config annotation
+// switch that determines whether capacity.json is hashed into the Cruise Control Deployment's
+// pod-template annotations (and therefore whether a capacity.json change causes the Deployment
+// to roll the Cruise Control pod).
+//
+// See https://github.com/adobe/koperator/issues/301: capacity.json is regenerated on every
+// broker scaling event, so including it in the pod template hash by default causes the Cruise
+// Control pod to restart mid-scale-operation, since CruiseControlOperation submission only
+// checks Cruise Control's own REST API readiness and has no awareness of the Deployment
+// rollout. capacity.json is only read by Cruise Control at process startup, so excluding it
+// from the hash by default does not require CC to be reloaded to pick up new capacity data
+// immediately; the operator's capacity-estimation fallback covers the gap until CC's next
+// natural restart.
+func TestGeneratePodAnnotations_CapacityConfigHash(t *testing.T) {
+	cruiseControlConfig := map[string]string{
+		"cruisecontrol.properties": "cc-props",
+		"clusterConfigs.json":      "cluster-cfg",
+		"log4j.properties":         "log-cfg",
+		"capacity.json":            "capacity-v1",
+	}
+
+	testCases := []struct {
+		testName            string
+		ccAnnotations       map[string]string
+		expectCapacityInPod bool
+	}{
+		{
+			testName:            "annotation unset (default): capacity.json is excluded from the pod template hash",
+			ccAnnotations:       map[string]string{},
+			expectCapacityInPod: false,
+		},
+		{
+			testName:            "annotation nil map: capacity.json is excluded from the pod template hash",
+			ccAnnotations:       nil,
+			expectCapacityInPod: false,
+		},
+		{
+			testName: "annotation explicitly \"static\": capacity.json is included (opt-in)",
+			ccAnnotations: map[string]string{
+				capacityConfigAnnotation: "static",
+			},
+			expectCapacityInPod: true,
+		},
+		{
+			testName: "annotation set to an unrelated value (\"dynamic\"): capacity.json is excluded",
+			ccAnnotations: map[string]string{
+				capacityConfigAnnotation: "dynamic",
+			},
+			expectCapacityInPod: false,
+		},
+		{
+			testName: "annotation set to empty string: capacity.json is excluded",
+			ccAnnotations: map[string]string{
+				capacityConfigAnnotation: "",
+			},
+			expectCapacityInPod: false,
+		},
+		{
+			testName: "annotation value is case-sensitive: \"Static\" does not match \"static\" and is excluded",
+			ccAnnotations: map[string]string{
+				capacityConfigAnnotation: "Static",
+			},
+			expectCapacityInPod: false,
+		},
+		{
+			testName: "unrelated user annotations are preserved regardless of capacity opt-in",
+			ccAnnotations: map[string]string{
+				"some.other/annotation": "keep-me",
+			},
+			expectCapacityInPod: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.testName, func(t *testing.T) {
+			podAnnotations := GeneratePodAnnotations(tc.ccAnnotations, cruiseControlConfig)
+
+			_, present := podAnnotations["cruiseControlCapacity.json"]
+			if present != tc.expectCapacityInPod {
+				t.Fatalf("cruiseControlCapacity.json presence = %v, want %v (annotations: %v)",
+					present, tc.expectCapacityInPod, tc.ccAnnotations)
+			}
+
+			// The other three hashes must always be present regardless of the capacity switch.
+			for _, key := range []string{"cruiseControlConfig.json", "cruiseControlClusterConfig.json", "cruiseControlLogConfig.json"} {
+				if _, ok := podAnnotations[key]; !ok {
+					t.Fatalf("expected %s to always be present in pod annotations", key)
+				}
+			}
+
+			// Unrelated caller-supplied annotations must be passed through untouched.
+			for k, v := range tc.ccAnnotations {
+				if k == capacityConfigAnnotation {
+					continue
+				}
+				if podAnnotations[k] != v {
+					t.Fatalf("expected passthrough annotation %s=%s, got %s", k, v, podAnnotations[k])
+				}
+			}
+		})
+	}
+}
+
+// TestGeneratePodAnnotations_CapacityChangeDoesNotAffectPodTemplateByDefault reproduces the
+// exact scaling scenario from issue #301 end-to-end through the real GenerateCapacityConfig +
+// GeneratePodAnnotations functions: adding a broker changes capacity.json content, but with the
+// default (unset) annotation, the resulting pod-template annotations must be identical before
+// and after the scale-up, so Kubernetes has no pod-template diff to roll on.
+func TestGeneratePodAnnotations_CapacityChangeDoesNotAffectPodTemplateByDefault(t *testing.T) {
+	baseConfig := map[string]string{
+		"cruisecontrol.properties": "cc-props",
+		"clusterConfigs.json":      "cluster-cfg",
+		"log4j.properties":         "log-cfg",
+	}
+
+	beforeScale := make(map[string]string, len(baseConfig)+1)
+	for k, v := range baseConfig {
+		beforeScale[k] = v
+	}
+	beforeScale["capacity.json"] = `{"brokerCapacities":[{"brokerId":"0"},{"brokerId":"1"},{"brokerId":"2"}]}`
+
+	afterScale := make(map[string]string, len(baseConfig)+1)
+	for k, v := range baseConfig {
+		afterScale[k] = v
+	}
+	afterScale["capacity.json"] = `{"brokerCapacities":[{"brokerId":"0"},{"brokerId":"1"},{"brokerId":"2"},{"brokerId":"3"}]}`
+
+	if beforeScale["capacity.json"] == afterScale["capacity.json"] {
+		t.Fatalf("test setup error: capacity.json fixtures must differ to exercise the scale-up scenario")
+	}
+
+	podAnnotationsBefore := GeneratePodAnnotations(map[string]string{}, beforeScale)
+	podAnnotationsAfter := GeneratePodAnnotations(map[string]string{}, afterScale)
+
+	if len(podAnnotationsBefore) != len(podAnnotationsAfter) {
+		t.Fatalf("pod annotation key sets differ across scale-up: before=%v after=%v", podAnnotationsBefore, podAnnotationsAfter)
+	}
+	for k, v := range podAnnotationsBefore {
+		if podAnnotationsAfter[k] != v {
+			t.Fatalf("pod annotation %s changed across a capacity.json-only change (before=%s after=%s); "+
+				"this would cause an unwanted Cruise Control Deployment roll on every broker scale event", k, v, podAnnotationsAfter[k])
+		}
+	}
+}
+
+// TestGeneratePodAnnotations_StaticOptInStillRestartsOnCapacityChange guards the escape hatch:
+// operators who explicitly opt into "static" mode must still see the Deployment roll when
+// capacity.json changes, preserving pre-existing behavior for anyone already relying on it.
+func TestGeneratePodAnnotations_StaticOptInStillRestartsOnCapacityChange(t *testing.T) {
+	baseConfig := map[string]string{
+		"cruisecontrol.properties": "cc-props",
+		"clusterConfigs.json":      "cluster-cfg",
+		"log4j.properties":         "log-cfg",
+	}
+	ccAnnotations := map[string]string{capacityConfigAnnotation: string(staticCapacityConfig)}
+
+	before := make(map[string]string, len(baseConfig)+1)
+	for k, v := range baseConfig {
+		before[k] = v
+	}
+	before["capacity.json"] = "capacity-v1"
+
+	after := make(map[string]string, len(baseConfig)+1)
+	for k, v := range baseConfig {
+		after[k] = v
+	}
+	after["capacity.json"] = "capacity-v2"
+
+	podAnnotationsBefore := GeneratePodAnnotations(ccAnnotations, before)
+	podAnnotationsAfter := GeneratePodAnnotations(ccAnnotations, after)
+
+	hashBefore, ok := podAnnotationsBefore["cruiseControlCapacity.json"]
+	if !ok {
+		t.Fatalf("expected cruiseControlCapacity.json to be present when static opt-in is set")
+	}
+	hashAfter := podAnnotationsAfter["cruiseControlCapacity.json"]
+
+	if hashBefore == hashAfter {
+		t.Fatalf("expected capacity hash to change across a capacity.json content change under static opt-in")
+	}
+}
+
+// TestGeneratePodAnnotations_UpgradeDropsCapacityHashOnce documents the one-time upgrade side
+// effect described in the comment above the capacity.json check in GeneratePodAnnotations:
+// every cluster reconciled under the pre-fix behavior (annotation unset) already has
+// cruiseControlCapacity.json baked into its live Deployment's pod template. The first reconcile
+// under the new default computes a pod template without that key, so it must actually be absent
+// (not merely unchanged) to reproduce the diff Kubernetes will apply as a single Deployment
+// update on upgrade.
+func TestGeneratePodAnnotations_UpgradeDropsCapacityHashOnce(t *testing.T) {
+	cruiseControlConfig := map[string]string{
+		"cruisecontrol.properties": "cc-props",
+		"clusterConfigs.json":      "cluster-cfg",
+		"log4j.properties":         "log-cfg",
+		"capacity.json":            "capacity-v1",
+	}
+
+	// No annotation set - the only configuration every pre-fix production cluster has today.
+	podAnnotations := GeneratePodAnnotations(map[string]string{}, cruiseControlConfig)
+
+	if _, present := podAnnotations["cruiseControlCapacity.json"]; present {
+		t.Fatalf("expected cruiseControlCapacity.json to be absent post-fix for an unset annotation; " +
+			"its presence here would mean no upgrade-time pod template diff occurs, contradicting the " +
+			"documented one-time-restart-on-upgrade behavior")
+	}
+}


### PR DESCRIPTION
## Description

Fixes #301

Two independent controllers race during broker scaling:

1. `capacity.json` is regenerated on every broker add/remove and, by default, its content is
   hashed into the Cruise Control Deployment's pod-template annotations
   (`GeneratePodAnnotations` in `pkg/resources/cruisecontrol/deployment.go`). Any hash change
   causes Kubernetes to roll the Cruise Control pod.
2. `CruiseControlOperationReconciler` submits `add_broker`/`remove_broker` operations based
   solely on Cruise Control's own REST API readiness (`CruiseControlStatus.IsReady()`), with no
   awareness of the Deployment's rollout state.

When these overlap, the fresh Cruise Control pod loses the in-memory task for an in-flight scale
operation. The operation is marked errored and retried after a fixed delay plus however long CC
takes to re-warm its metrics window — stalling scaling for anywhere from seconds to minutes.

Verified this is reachable on current `master`, independent of #300 (a KRaft-hardening PR whose
only CC-adjacent change is unrelated node filtering in `remove_broker`) — confirmed via a Go test
driving the real `GenerateCapacityConfig` + `GeneratePodAnnotations` functions for a 3→4 broker
scale-up, showing the pod-template hash changes purely from the broker-count change.

`capacity.json` is only read by Cruise Control at process startup, and the operator already
falls back to CC's own capacity estimation for scale operations, so a capacity.json change does
not require restarting a running CC pod. `GeneratePodAnnotations` now excludes `capacity.json`
from the pod-template hash **by default**, inverting the polarity of a pre-existing (undocumented,
never-set-by-default) escape hatch:

```go
// before: hashed by default, excluded only when explicitly opted out
if value, ok := annotations[capacityConfigAnnotation]; !ok || value == "static" { ... }

// after: excluded by default, hashed only when explicitly opted in
if value, ok := annotations[capacityConfigAnnotation]; ok && value == "static" { ... }
```

Operators who need exact (non-estimated) capacity for newly added brokers immediately, and are
willing to accept the restart-race trade-off, can opt back in by setting
`cruise-control.banzaicloud.com/broker-capacity-config: "static"`.

**Upgrade note:** every existing cluster has this annotation unset today, so the old code always
hashed `capacity.json`. The first reconcile after upgrading will drop the
`cruiseControlCapacity.json` pod-template annotation, which Kubernetes will apply as one
Deployment update — i.e. **every existing cluster gets exactly one Cruise Control pod restart on
upgrade**. This is expected and one-time, not a bug (see the upgrade-transition unit test).

**Scope:** this closes the specific `capacity.json` trigger described in #301. The other three
config sources hashed here (`cruisecontrol.properties`, `clusterConfigs.json`,
`log4j.properties`) still unconditionally roll the Deployment on change and can still race an
in-flight operation via the same mechanism — that's a separate, larger fix (giving the operation
controller Deployment-rollout awareness) and is intentionally out of scope here.

## Type of Change
- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass

## Testing

- Unit tests (`pkg/resources/cruisecontrol/deployment_test.go`): default/unset, nil map, exact
  `"static"` opt-in, near-miss values (empty string, wrong case, unrelated value), passthrough of
  unrelated annotations, the exact scale-up scenario from #301, the static opt-in still
  restarting on change, and the one-time upgrade transition.
- Integration-style test (`pkg/resources/cruisecontrol/cruisecontrol_reconcile_test.go`): drives
  the real `Reconciler.Reconcile` against a fake Kubernetes API to confirm the static opt-in
  survives a full reconcile pass.
- Envtest (`controllers/tests/kafkacluster_controller_test.go`): new scenario exercising the
  static opt-in through the real controller + real API server, alongside updated assertions in
  `kafkacluster_controller_cruisecontrol_test.go` for the new default.
- `go build ./...`, `go vet ./...`, `gofmt`, and `golangci-lint` all clean (pre-existing
  `goconst` findings in `configmap.go` unrelated to this diff, confirmed present on `master` too).
- Full existing suite (`pkg/resources/cruisecontrol`, `controllers`, `controllers/tests`,
  `controllers/tests/clusterregistry`, `controllers/tests/contourwatch`, `pkg/scale`) run before
  and after the change — pass/fail status identical except for the intentional assertion updates
  above; no other workflow regressed.

**Before fix:** scale-up → capacity.json changes → CC pod restarts → in-flight operation lost →
stalls for 30s+ retry delay plus CC re-warm time.
**After fix:** scale-up → capacity.json changes → CC pod template unchanged → no restart →
operation proceeds uninterrupted.
