### PR TITLE
fix(kraft): generate canonical padding-free cluster ID

### DIFF
--- a/pkg/resources/kafka/util.go
+++ b/pkg/resources/kafka/util.go
@@ -67,9 +67,12 @@ func generateQuorumVoters(kafkaCluster *v1beta1.KafkaCluster, controllerListener
 	return quorumVoters, nil
 }
 
-// generateRandomClusterID() generates a based64-encoded random UUID with 16 bytes as the cluster ID
-// it uses URL based64 encoding since that's what Kafka expects
+// generateRandomClusterID() generates a base64-encoded random UUID with 16 bytes as the cluster ID.
+// It uses URL base64 encoding without padding, matching Kafka's canonical org.apache.kafka.common.Uuid
+// string form (Base64.getUrlEncoder().withoutPadding()) which yields 22 characters. The padded form
+// (24 chars ending in "==") happens to be accepted by Kafka 3.9's Uuid.fromString (length <= 24), but it
+// is non-canonical and rejected by newer Kafka versions, so we emit the padding-free canonical form.
 func generateRandomClusterID() string {
 	randomUUID := uuid.New()
-	return base64.URLEncoding.EncodeToString(randomUUID[:])
+	return base64.RawURLEncoding.EncodeToString(randomUUID[:])
 }

--- a/pkg/resources/kafka/util_test.go
+++ b/pkg/resources/kafka/util_test.go
@@ -29,9 +29,18 @@ func TestGenerateClusterID(t *testing.T) {
 	test := make(map[string]bool, numOfIDs)
 	for i := 0; i < numOfIDs; i++ {
 		clusterID := generateRandomClusterID()
-		_, err := base64.URLEncoding.DecodeString(clusterID)
+		decoded, err := base64.RawURLEncoding.DecodeString(clusterID)
 		if err != nil {
 			t.Errorf("expected nil error, got: %v", err)
+		}
+
+		// Kafka's Uuid is a 128-bit (16-byte) value; the base64 form must decode to exactly 16 bytes
+		// and use the canonical padding-free encoding (22 characters).
+		if len(decoded) != 16 {
+			t.Errorf("expected cluster ID to decode to 16 bytes, got %d bytes for %q", len(decoded), clusterID)
+		}
+		if len(clusterID) != 22 {
+			t.Errorf("expected canonical 22-character cluster ID, got %d characters for %q", len(clusterID), clusterID)
 		}
 
 		if test[clusterID] {


### PR DESCRIPTION
Split out of #300 (1/6).

`generateRandomClusterID` used `base64.URLEncoding`, producing a 24-character
padded id (e.g. "...=="). Kafka 3.9's `Uuid.fromString` happens to accept it
(length <= 24 and its URL decoder tolerates padding), but that is a
non-canonical form: Kafka itself emits the 22-character padding-free
encoding via `Base64.getUrlEncoder().withoutPadding()`, and newer Kafka
versions reject longer strings. Switch to `base64.RawURLEncoding` so freshly
generated cluster IDs match Kafka's canonical form.

Existing clusters are unaffected: their id is already persisted in
`KafkaCluster.Status.ClusterID` and reused verbatim.

Strengthens `TestGenerateClusterID` to assert the id decodes to exactly 16
bytes and is 22 characters long.