### PR TITLE
feat(kraft): validate KRaft configuration in the admission webhook

### DIFF
--- a/pkg/webhooks/kafkacluster_validator.go
+++ b/pkg/webhooks/kafkacluster_validator.go
@@ -45,6 +45,8 @@ func (s KafkaClusterValidator) ValidateUpdate(ctx context.Context, _, kafkaClust
 		allErrs = append(allErrs, listenerErrs...)
 	}
 
+	allErrs = append(allErrs, checkKRaftConfig(&kafkaClusterNew.Spec)...)
+
 	if len(allErrs) == 0 {
 		return nil, nil
 	}
@@ -64,6 +66,8 @@ func (s KafkaClusterValidator) ValidateCreate(ctx context.Context, kafkaCluster 
 		allErrs = append(allErrs, listenerErrs...)
 	}
 
+	allErrs = append(allErrs, checkKRaftConfig(&kafkaCluster.Spec)...)
+
 	if len(allErrs) == 0 {
 		return nil, nil
 	}
@@ -76,6 +80,83 @@ func (s KafkaClusterValidator) ValidateCreate(ctx context.Context, kafkaCluster 
 
 func (s KafkaClusterValidator) ValidateDelete(_ context.Context, _ *banzaicloudv1beta1.KafkaCluster) (warnings admission.Warnings, err error) {
 	return nil, nil
+}
+
+// checkKRaftConfig validates KRaft-specific requirements on the KafkaCluster spec.
+// It is a no-op when the cluster is not in KRaft mode. These checks surface, at admission time,
+// misconfigurations that would otherwise only fail (or panic) later during reconciliation:
+//   - a KRaft cluster with no controller node cannot form a metadata quorum,
+//   - a KRaft cluster with no controller listener has no address for the quorum to communicate on,
+//   - a broker with no process role is meaningless in KRaft mode,
+//   - a node with the controller role stores the metadata log and supports only a single, immutable
+//     log directory (mirrors the reconcile-time restriction in the kafka resource reconciler).
+func checkKRaftConfig(kafkaClusterSpec *banzaicloudv1beta1.KafkaClusterSpec) field.ErrorList {
+	if !kafkaClusterSpec.KRaftMode {
+		return nil
+	}
+
+	var allErrs field.ErrorList
+
+	// Exactly one internal listener must be designated for controller communication.
+	controllerListeners := 0
+	for _, il := range kafkaClusterSpec.ListenersConfig.InternalListeners {
+		if il.UsedForControllerCommunication {
+			controllerListeners++
+		}
+	}
+	internalListenersPath := field.NewPath("spec").Child("listenersConfig").Child("internalListeners")
+	switch {
+	case controllerListeners == 0:
+		allErrs = append(allErrs, field.Required(internalListenersPath,
+			"in KRaft mode exactly one internal listener must set 'usedForControllerCommunication: true'"))
+	case controllerListeners > 1:
+		allErrs = append(allErrs, field.Invalid(internalListenersPath, controllerListeners,
+			"in KRaft mode only one internal listener may set 'usedForControllerCommunication: true'"))
+	}
+
+	// Per-broker role and storage validation.
+	controllerNodeCount := 0
+	for i, broker := range kafkaClusterSpec.Brokers {
+		brokerConfig, err := broker.GetBrokerConfig(*kafkaClusterSpec)
+		if err != nil {
+			allErrs = append(allErrs, field.Invalid(field.NewPath("spec").Child("brokers").Index(i), broker.Id,
+				fmt.Sprintf("could not resolve broker configuration: %v", err)))
+			continue
+		}
+
+		if !brokerConfig.IsBrokerNode() && !brokerConfig.IsControllerNode() {
+			allErrs = append(allErrs, field.Required(
+				field.NewPath("spec").Child("brokers").Index(i).Child("brokerConfig").Child("processRoles"),
+				fmt.Sprintf("in KRaft mode broker %d must declare at least one process role ('broker' and/or 'controller')", broker.Id)))
+		}
+
+		if brokerConfig.IsControllerNode() {
+			controllerNodeCount++
+			// A KRaft node with the controller role stores the cluster metadata log and supports only a
+			// single persistent log directory; Koperator additionally treats its mount path as immutable.
+			// This mirrors the reconcile-time restriction (reconcileKafkaPvc), which requires exactly one
+			// PVC-backed storage config for a controller (extra emptyDir volumes do not create PVCs).
+			pvcBackedStorageConfigs := 0
+			for _, sc := range brokerConfig.StorageConfigs {
+				if sc.PvcSpec != nil {
+					pvcBackedStorageConfigs++
+				}
+			}
+			if pvcBackedStorageConfigs != 1 {
+				allErrs = append(allErrs, field.Invalid(
+					field.NewPath("spec").Child("brokers").Index(i).Child("brokerConfig").Child("storageConfigs"),
+					pvcBackedStorageConfigs,
+					fmt.Sprintf("a KRaft node with the 'controller' role (broker %d) must have exactly one PVC-backed storage config", broker.Id)))
+			}
+		}
+	}
+
+	if controllerNodeCount == 0 {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("spec").Child("brokers"), controllerNodeCount,
+			"in KRaft mode at least one broker must have the 'controller' process role"))
+	}
+
+	return allErrs
 }
 
 // checkListeners validates the spec.listenersConfig object

--- a/pkg/webhooks/kafkacluster_validator_test.go
+++ b/pkg/webhooks/kafkacluster_validator_test.go
@@ -16,9 +16,11 @@
 package webhooks
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
+	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -382,6 +384,219 @@ func TestCheckTargetPortsCollisionForEnvoy(t *testing.T) {
 		t.Run(testCase.testName, func(t *testing.T) {
 			got := checkTargetPortsCollisionForEnvoy(&testCase.kafkaClusterSpec)
 			require.Equal(t, testCase.expected, got)
+		})
+	}
+}
+
+func TestCheckKRaftConfig(t *testing.T) {
+	interBrokerListener := v1beta1.InternalListenerConfig{
+		CommonListenerSpec: v1beta1.CommonListenerSpec{
+			Name:                            "internal",
+			ContainerPort:                   29092,
+			UsedForInnerBrokerCommunication: true,
+		},
+	}
+	controllerListener := v1beta1.InternalListenerConfig{
+		CommonListenerSpec:             v1beta1.CommonListenerSpec{Name: "controller", ContainerPort: 29093},
+		UsedForControllerCommunication: true,
+	}
+	// A controller's storage config must provision exactly one PVC (matches the reconcile-time constraint).
+	onePVCStorage := []v1beta1.StorageConfig{{MountPath: "/kafka-logs", PvcSpec: &corev1.PersistentVolumeClaimSpec{}}}
+	// One PVC plus an emptyDir is still a single PVC-backed volume, so it is valid for a controller.
+	onePVCPlusEmptyDir := []v1beta1.StorageConfig{
+		{MountPath: "/kafka-logs", PvcSpec: &corev1.PersistentVolumeClaimSpec{}},
+		{MountPath: "/ephemeral", EmptyDir: &corev1.EmptyDirVolumeSource{}},
+	}
+	twoPVCStorage := []v1beta1.StorageConfig{
+		{MountPath: "/kafka-logs", PvcSpec: &corev1.PersistentVolumeClaimSpec{}},
+		{MountPath: "/kafka-logs-2", PvcSpec: &corev1.PersistentVolumeClaimSpec{}},
+	}
+
+	validListeners := v1beta1.ListenersConfig{
+		InternalListeners: []v1beta1.InternalListenerConfig{interBrokerListener, controllerListener},
+	}
+
+	testCases := []struct {
+		testName         string
+		kafkaClusterSpec v1beta1.KafkaClusterSpec
+		expectedErrCount int
+	}{
+		{
+			testName: "not KRaft mode is a no-op even with an otherwise invalid layout",
+			kafkaClusterSpec: v1beta1.KafkaClusterSpec{
+				KRaftMode:       false,
+				ListenersConfig: v1beta1.ListenersConfig{},
+				Brokers:         []v1beta1.Broker{{Id: 0, BrokerConfig: &v1beta1.BrokerConfig{}}},
+			},
+			expectedErrCount: 0,
+		},
+		{
+			testName: "valid KRaft cluster: broker-only, controller-only and combined nodes",
+			kafkaClusterSpec: v1beta1.KafkaClusterSpec{
+				KRaftMode:       true,
+				ListenersConfig: validListeners,
+				Brokers: []v1beta1.Broker{
+					{Id: 0, BrokerConfig: &v1beta1.BrokerConfig{Roles: []string{"broker"}, StorageConfigs: twoPVCStorage}},
+					{Id: 1, BrokerConfig: &v1beta1.BrokerConfig{Roles: []string{"controller"}, StorageConfigs: onePVCStorage}},
+					{Id: 2, BrokerConfig: &v1beta1.BrokerConfig{Roles: []string{"broker", "controller"}, StorageConfigs: onePVCPlusEmptyDir}},
+				},
+			},
+			expectedErrCount: 0,
+		},
+		{
+			testName: "missing controller listener",
+			kafkaClusterSpec: v1beta1.KafkaClusterSpec{
+				KRaftMode:       true,
+				ListenersConfig: v1beta1.ListenersConfig{InternalListeners: []v1beta1.InternalListenerConfig{interBrokerListener}},
+				Brokers: []v1beta1.Broker{
+					{Id: 1, BrokerConfig: &v1beta1.BrokerConfig{Roles: []string{"controller"}, StorageConfigs: onePVCStorage}},
+				},
+			},
+			expectedErrCount: 1,
+		},
+		{
+			testName: "more than one controller listener",
+			kafkaClusterSpec: v1beta1.KafkaClusterSpec{
+				KRaftMode: true,
+				ListenersConfig: v1beta1.ListenersConfig{InternalListeners: []v1beta1.InternalListenerConfig{
+					controllerListener,
+					{CommonListenerSpec: v1beta1.CommonListenerSpec{Name: "controller2", ContainerPort: 29094}, UsedForControllerCommunication: true},
+				}},
+				Brokers: []v1beta1.Broker{
+					{Id: 1, BrokerConfig: &v1beta1.BrokerConfig{Roles: []string{"controller"}, StorageConfigs: onePVCStorage}},
+				},
+			},
+			expectedErrCount: 1,
+		},
+		{
+			testName: "no controller node",
+			kafkaClusterSpec: v1beta1.KafkaClusterSpec{
+				KRaftMode:       true,
+				ListenersConfig: validListeners,
+				Brokers: []v1beta1.Broker{
+					{Id: 0, BrokerConfig: &v1beta1.BrokerConfig{Roles: []string{"broker"}, StorageConfigs: onePVCStorage}},
+				},
+			},
+			expectedErrCount: 1,
+		},
+		{
+			testName: "broker with no process role",
+			kafkaClusterSpec: v1beta1.KafkaClusterSpec{
+				KRaftMode:       true,
+				ListenersConfig: validListeners,
+				Brokers: []v1beta1.Broker{
+					{Id: 0, BrokerConfig: &v1beta1.BrokerConfig{Roles: []string{}, StorageConfigs: onePVCStorage}},
+					{Id: 1, BrokerConfig: &v1beta1.BrokerConfig{Roles: []string{"controller"}, StorageConfigs: onePVCStorage}},
+				},
+			},
+			expectedErrCount: 1,
+		},
+		{
+			testName: "controller node with more than one storage config",
+			kafkaClusterSpec: v1beta1.KafkaClusterSpec{
+				KRaftMode:       true,
+				ListenersConfig: validListeners,
+				Brokers: []v1beta1.Broker{
+					{Id: 1, BrokerConfig: &v1beta1.BrokerConfig{Roles: []string{"controller"}, StorageConfigs: twoPVCStorage}},
+				},
+			},
+			expectedErrCount: 1,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.testName, func(t *testing.T) {
+			got := checkKRaftConfig(&testCase.kafkaClusterSpec)
+			require.Len(t, got, testCase.expectedErrCount, "unexpected errors: %v", got)
+		})
+	}
+}
+
+// TestKafkaClusterValidatorValidateKRaft exercises the admission entrypoints (ValidateCreate and
+// ValidateUpdate) end-to-end for KRaft clusters, verifying that invalid layouts are actually rejected
+// (non-nil error) and valid ones are admitted - i.e. that checkKRaftConfig is wired into the webhook.
+func TestKafkaClusterValidatorValidateKRaft(t *testing.T) {
+	validator := KafkaClusterValidator{Log: logr.Discard()}
+
+	interBrokerListener := v1beta1.InternalListenerConfig{
+		CommonListenerSpec: v1beta1.CommonListenerSpec{
+			Name:                            "internal",
+			ContainerPort:                   29092,
+			UsedForInnerBrokerCommunication: true,
+		},
+	}
+	controllerListener := v1beta1.InternalListenerConfig{
+		CommonListenerSpec:             v1beta1.CommonListenerSpec{Name: "controller", ContainerPort: 29093},
+		UsedForControllerCommunication: true,
+	}
+	onePVCStorage := []v1beta1.StorageConfig{{MountPath: "/kafka-logs", PvcSpec: &corev1.PersistentVolumeClaimSpec{}}}
+	twoPVCStorage := []v1beta1.StorageConfig{
+		{MountPath: "/kafka-logs", PvcSpec: &corev1.PersistentVolumeClaimSpec{}},
+		{MountPath: "/kafka-logs-2", PvcSpec: &corev1.PersistentVolumeClaimSpec{}},
+	}
+
+	validKRaftCluster := func() *v1beta1.KafkaCluster {
+		return &v1beta1.KafkaCluster{
+			Spec: v1beta1.KafkaClusterSpec{
+				KRaftMode:       true,
+				ListenersConfig: v1beta1.ListenersConfig{InternalListeners: []v1beta1.InternalListenerConfig{interBrokerListener, controllerListener}},
+				Brokers: []v1beta1.Broker{
+					{Id: 0, BrokerConfig: &v1beta1.BrokerConfig{Roles: []string{"broker"}, StorageConfigs: onePVCStorage}},
+					{Id: 1, BrokerConfig: &v1beta1.BrokerConfig{Roles: []string{"controller"}, StorageConfigs: onePVCStorage}},
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		testName string
+		mutate   func(*v1beta1.KafkaCluster)
+		wantErr  bool
+	}{
+		{
+			testName: "valid KRaft cluster is admitted",
+			mutate:   func(*v1beta1.KafkaCluster) {},
+			wantErr:  false,
+		},
+		{
+			testName: "cluster with no controller node is rejected",
+			mutate:   func(kc *v1beta1.KafkaCluster) { kc.Spec.Brokers[1].BrokerConfig.Roles = []string{"broker"} },
+			wantErr:  true,
+		},
+		{
+			testName: "cluster with no controller listener is rejected",
+			mutate: func(kc *v1beta1.KafkaCluster) {
+				kc.Spec.ListenersConfig.InternalListeners = []v1beta1.InternalListenerConfig{interBrokerListener}
+			},
+			wantErr: true,
+		},
+		{
+			testName: "controller node with two PVC-backed storage configs is rejected",
+			mutate:   func(kc *v1beta1.KafkaCluster) { kc.Spec.Brokers[1].BrokerConfig.StorageConfigs = twoPVCStorage },
+			wantErr:  true,
+		},
+		{
+			testName: "broker with no process role is rejected",
+			mutate:   func(kc *v1beta1.KafkaCluster) { kc.Spec.Brokers[0].BrokerConfig.Roles = []string{} },
+			wantErr:  true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+			kc := validKRaftCluster()
+			test.mutate(kc)
+
+			_, errCreate := validator.ValidateCreate(context.Background(), kc)
+			_, errUpdate := validator.ValidateUpdate(context.Background(), nil, kc)
+
+			if test.wantErr {
+				require.Error(t, errCreate, "ValidateCreate should reject")
+				require.Error(t, errUpdate, "ValidateUpdate should reject")
+			} else {
+				require.NoError(t, errCreate, "ValidateCreate should admit")
+				require.NoError(t, errUpdate, "ValidateUpdate should admit")
+			}
 		})
 	}
 }


### PR DESCRIPTION
Split out of #300 (5/6).

The KafkaCluster validating webhook performed no KRaft-specific checks, so
invalid KRaft layouts were only caught (or would panic) deep in
reconciliation. Adds `checkKRaftConfig`, run on create and update, which
rejects, when `spec.kRaft` is true:

- no internal listener (or more than one) marked `usedForControllerCommunication`,
- any broker that resolves to no process role (neither broker nor controller),
- a cluster with no controller node,
- a controller node that does not have exactly one PVC-backed storage config.

The storage rule mirrors the existing reconcile-time restriction in
`reconcileKafkaPvc` (which requires exactly one PVC for a controller and
treats its mount path as immutable); it deliberately counts PVC-backed
configs, not total storage configs, so an extra emptyDir volume does not
trip it.

Adds `TestCheckKRaftConfig` covering the valid layout plus each rejection.