### PR TITLE
feat(kraft): gate controller rolling restarts on quorum health

### DIFF
--- a/api/assets/kafka/kraft-controller-healthcheck.sh
+++ b/api/assets/kafka/kraft-controller-healthcheck.sh
@@ -15,38 +15,65 @@
 # limitations under the License.
 
 
-# This script returns a successful exit code (0) if the controller is a follower or leader.  For any other state, it returns a failure exit code (1).
-# In addition, if the environment variable KRAFT_HEALTH_CHECK_SKIP is set to "true" (case insensitive), the script will exit successfully without performing any checks.
+# Health check for a KRaft controller, driven by the Prometheus JMX exporter's raft current-state gauge.
+# The jmx-exporter maps the "raft-metrics current-state=<state>" MBean attribute to a single gauge named
+# kafka_server_raft_metrics_current_state_<state> with value 1, so exactly one such gauge exists at a time
+# and its name is the controller's current raft state (leader, follower, candidate, unattached, ...).
+#
+# Behaviour is selected by KRAFT_HEALTH_CHECK_MODE:
+#   readiness        -> fail-closed: succeeds only when the controller is a leader or follower (a
+#                       functioning quorum member). Koperator's rolling upgrade waits on this readiness
+#                       signal so it never restarts the next controller before the previously restarted
+#                       one has rejoined the metadata quorum.
+#   liveness (default) -> fails only when the controller is reachable and reporting a state that is not
+#                       leader/follower; a not-yet-emitted state (startup/catch-up) or an unreachable
+#                       metrics endpoint is treated as healthy (fail-open) so a slow-starting or briefly
+#                       unavailable JMX exporter does not restart an otherwise healthy controller.
+# If KRAFT_HEALTH_CHECK_SKIP is set to "true" (case insensitive) all checks are skipped.
 
 skip_check=$(echo "$KRAFT_HEALTH_CHECK_SKIP" | tr '[:upper:]' '[:lower:]')
+mode=$(echo "${KRAFT_HEALTH_CHECK_MODE:-liveness}" | tr '[:upper:]' '[:lower:]')
 
 if [ "$skip_check" = "true" ]; then
-    echo "KRAFT_HEALTH_CHECK_SKIP is set to TRUE. Exiting health check."
+    echo "KRAFT_HEALTH_CHECK_SKIP is set to TRUE. Skipping health check."
     exit 0
 fi
 
-JMX_ENDPOINT="http://localhost:9020/metrics"
 METRIC_PREFIX="kafka_server_raft_metrics_current_state_"
 
-# Fetch the matching current-state metric with value of 1.0 from the JMX endpoint
-MATCHING_METRIC=$(curl -s "$JMX_ENDPOINT" | grep "^${METRIC_PREFIX}" | awk '$2 == 1.0 {print $1}')
+# Request only the raft current-state gauges via the Prometheus name[] query filter, so the exporter
+# returns a few lines instead of the whole /metrics exposition (which on a combined broker+controller
+# node is large). Only the node's current state is ever present, but we list all known raft states so we
+# can still tell "reporting a non-leader/follower state" apart from "no state emitted yet". If the
+# exporter version ignores name[] it returns the full exposition and the same greps below still work.
+STATES="unattached voted prospective candidate leader follower observer resigned"
+FILTER=""
+for state in ${STATES}; do
+    FILTER="${FILTER}&name[]=${METRIC_PREFIX}${state}"
+done
+URL="http://localhost:9020/metrics?${FILTER#&}"
 
-# If it's not empty, it means we found a metric with a value of 1.0.
-if [ -n "$MATCHING_METRIC" ]; then
-    # Determine the state of the controller using the last field name of the metric 
-    # Possible values are leader, candidate, voted, follower, unattached, observer
-    STATE=$(echo "$MATCHING_METRIC" | rev | cut -d'_' -f1 | rev)
-
-    # Check if the extracted state is 'leader' or 'follower'
-    if [ "$STATE" == "leader" ] || [ "$STATE" == "follower" ]; then
-        echo "The controller is in a healthy quorum state."
-        exit 0
-    else
-        # Any other state (e.g., 'candidate', 'unattached', 'observer') is not considered healthy
-        echo "Failure: The controller is in an unexpected state: $STATE. Expecting 'leader' or 'follower'."
-        exit 1
-    fi
-else
-    echo "JMX Exporter endpoint is not avaiable or kafka_server_raft_metrics_current_state_ was not found."
+if ! METRICS=$(curl -s --max-time 4 "${URL}"); then
+    echo "JMX exporter metrics endpoint is not reachable."
+    # Unreachable: not a confirmed quorum member (not ready), but do not restart on a transient blip.
+    [ "${mode}" = "readiness" ] && exit 1
     exit 0
 fi
+
+# Healthy quorum member: the leader or follower current-state gauge is present.
+if echo "${METRICS}" | grep -Eq "^${METRIC_PREFIX}(leader|follower) 1(\.[0-9]+)?$"; then
+    echo "The controller is in a healthy quorum state (leader or follower)."
+    exit 0
+fi
+
+# Reachable and reporting some other raft state (e.g. candidate, unattached, observer).
+if echo "${METRICS}" | grep -q "^${METRIC_PREFIX}"; then
+    STATE=$(echo "${METRICS}" | grep "^${METRIC_PREFIX}" | head -n 1 | sed -E "s/^${METRIC_PREFIX}([a-z]+).*/\1/")
+    echo "Failure: the controller is in an unexpected state: ${STATE}. Expecting 'leader' or 'follower'."
+    exit 1
+fi
+
+# Reachable but no raft current-state gauge yet (startup / not caught up).
+echo "kafka_server_raft_metrics_current_state_ was not found (controller not caught up yet)."
+[ "${mode}" = "readiness" ] && exit 1
+exit 0

--- a/pkg/resources/kafka/kafka.go
+++ b/pkg/resources/kafka/kafka.go
@@ -1050,6 +1050,20 @@ func (r *Reconciler) handleRollingUpgrade(log logr.Logger, desiredPod, currentPo
 				return errorfactory.New(errorfactory.ReconcileRollingUpgrade{}, errors.New("pod count differs from brokers spec"), "rolling upgrade in progress")
 			}
 
+			// In KRaft mode, do not delete a controller pod while any other controller is still catching up
+			// in the metadata quorum. A controller pod's readiness reflects quorum membership (see its
+			// readiness probe), so waiting for all other controllers to be Ready keeps the operator from
+			// restarting the next controller before the previously restarted one has rejoined the quorum -
+			// which could otherwise cost the quorum its majority. The pod being reconciled is excluded so an
+			// unhealthy controller can still be replaced. Broker-only restarts cannot affect quorum majority
+			// and are gated by the data-plane health check below, so they are not blocked here.
+			if notReadyControllers := controllersBlockingRollingUpgrade(r.KafkaCluster.Spec.KRaftMode, podList.Items, currentPod); len(notReadyControllers) > 0 {
+				return errorfactory.New(errorfactory.ReconcileRollingUpgrade{},
+					errors.New("KRaft controller quorum is not stable yet"),
+					"waiting for KRaft controllers to rejoin the quorum before continuing rolling upgrade",
+					"notReadyControllerBrokerIDs", strings.Join(notReadyControllers, ","))
+			}
+
 			// Check if we support multiple broker restarts and restart only in same AZ, otherwise restart only 1 broker at once
 			terminatingOrPendingPods := getPodsInTerminatingOrPendingState(podList.Items)
 			if len(terminatingOrPendingPods) >= r.KafkaCluster.Spec.RollingUpgradeConfig.ConcurrentBrokerRestartCountPerRack {
@@ -1658,6 +1672,50 @@ func getPodsInTerminatingOrPendingState(items []corev1.Pod) []corev1.Pod {
 		}
 	}
 	return pods
+}
+
+// controllersBlockingRollingUpgrade returns the not-Ready controller broker IDs that must block the
+// rolling upgrade before currentPod is deleted, or nil when the upgrade may proceed. The quorum-readiness
+// gate applies only when the cluster is in KRaft mode AND currentPod is itself a controller node:
+// restarting a broker-only node cannot cost the metadata quorum its majority (brokers are not voters),
+// so broker restarts are gated by the data-plane health check instead, not by controller readiness.
+func controllersBlockingRollingUpgrade(kRaftMode bool, pods []corev1.Pod, currentPod *corev1.Pod) []string {
+	if !kRaftMode || currentPod.Labels[banzaiv1beta1.IsControllerNodeKey] != configValueTrue {
+		return nil
+	}
+	return notReadyControllerBrokerIDs(pods, currentPod)
+}
+
+// notReadyControllerBrokerIDs returns the broker IDs of KRaft controller pods (broker id label of pods
+// labeled isControllerNode=true) that are not Ready, excluding the pod currently being reconciled.
+// A controller pod's readiness reflects its metadata-quorum membership, so a non-empty result means the
+// quorum is still stabilizing and the rolling upgrade should pause before deleting another pod.
+func notReadyControllerBrokerIDs(pods []corev1.Pod, currentPod *corev1.Pod) []string {
+	var notReady []string
+	currentBrokerID := currentPod.Labels[banzaiv1beta1.BrokerIdLabelKey]
+	for i := range pods {
+		pod := &pods[i]
+		if pod.Labels[banzaiv1beta1.BrokerIdLabelKey] == currentBrokerID {
+			continue
+		}
+		if pod.Labels[banzaiv1beta1.IsControllerNodeKey] != configValueTrue {
+			continue
+		}
+		if !isPodReady(pod) {
+			notReady = append(notReady, pod.Labels[banzaiv1beta1.BrokerIdLabelKey])
+		}
+	}
+	return notReady
+}
+
+// isPodReady reports whether the pod's Ready condition is true.
+func isPodReady(pod *corev1.Pod) bool {
+	for _, cond := range pod.Status.Conditions {
+		if cond.Type == corev1.PodReady {
+			return cond.Status == corev1.ConditionTrue
+		}
+	}
+	return false
 }
 
 func (r *Reconciler) getBrokerAz(pod *corev1.Pod, kafkaBrokerAvailabilityZoneMap map[int32]string) (string, error) {

--- a/pkg/resources/kafka/kafka_test.go
+++ b/pkg/resources/kafka/kafka_test.go
@@ -2136,3 +2136,149 @@ func TestBrokerNeedsVersionUpdate(t *testing.T) {
 		})
 	}
 }
+
+func TestNotReadyControllerBrokerIDs(t *testing.T) {
+	makePod := func(brokerID, isController string, ready bool) corev1.Pod {
+		readyStatus := corev1.ConditionFalse
+		if ready {
+			readyStatus = corev1.ConditionTrue
+		}
+		return corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					v1beta1.BrokerIdLabelKey:    brokerID,
+					v1beta1.IsControllerNodeKey: isController,
+				},
+			},
+			Status: corev1.PodStatus{
+				Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: readyStatus}},
+			},
+		}
+	}
+
+	tests := []struct {
+		testName      string
+		pods          []corev1.Pod
+		currentBroker string
+		expected      []string
+	}{
+		{
+			testName: "all controllers ready",
+			pods: []corev1.Pod{
+				makePod("0", "false", true),
+				makePod("1", "true", true),
+				makePod("2", "true", true),
+			},
+			currentBroker: "0",
+			expected:      nil,
+		},
+		{
+			testName: "one other controller not ready is reported",
+			pods: []corev1.Pod{
+				makePod("0", "false", true),
+				makePod("1", "true", false),
+				makePod("2", "true", true),
+			},
+			currentBroker: "0",
+			expected:      []string{"1"},
+		},
+		{
+			testName: "the controller being reconciled is excluded even when not ready",
+			pods: []corev1.Pod{
+				makePod("1", "true", false),
+				makePod("2", "true", true),
+			},
+			currentBroker: "1",
+			expected:      nil,
+		},
+		{
+			testName: "not-ready broker-only node is ignored",
+			pods: []corev1.Pod{
+				makePod("0", "false", false),
+				makePod("1", "true", true),
+			},
+			currentBroker: "1",
+			expected:      nil,
+		},
+		{
+			testName: "combined node counts as a controller",
+			pods: []corev1.Pod{
+				makePod("0", "true", false),
+				makePod("1", "true", true),
+			},
+			currentBroker: "1",
+			expected:      []string{"0"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+			currentPod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{v1beta1.BrokerIdLabelKey: test.currentBroker}}}
+			assert.Equal(t, test.expected, notReadyControllerBrokerIDs(test.pods, currentPod))
+		})
+	}
+}
+
+func TestControllersBlockingRollingUpgrade(t *testing.T) {
+	pod := func(brokerID, isController string, ready bool) corev1.Pod {
+		readyStatus := corev1.ConditionFalse
+		if ready {
+			readyStatus = corev1.ConditionTrue
+		}
+		return corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{
+				v1beta1.BrokerIdLabelKey:    brokerID,
+				v1beta1.IsControllerNodeKey: isController,
+			}},
+			Status: corev1.PodStatus{Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: readyStatus}}},
+		}
+	}
+	// broker 0: broker-only, broker 1: controller (not ready), broker 2: controller (ready)
+	pods := []corev1.Pod{pod("0", "false", true), pod("1", "true", false), pod("2", "true", true)}
+	currentPodFor := func(brokerID string) *corev1.Pod {
+		for i := range pods {
+			if pods[i].Labels[v1beta1.BrokerIdLabelKey] == brokerID {
+				return &pods[i]
+			}
+		}
+		return nil
+	}
+
+	tests := []struct {
+		testName      string
+		kRaftMode     bool
+		currentBroker string
+		expected      []string
+	}{
+		{
+			testName:      "not KRaft mode never gates",
+			kRaftMode:     false,
+			currentBroker: "2",
+			expected:      nil,
+		},
+		{
+			testName:      "rolling a broker-only node is not gated on controller readiness",
+			kRaftMode:     true,
+			currentBroker: "0",
+			expected:      nil,
+		},
+		{
+			testName:      "rolling a controller is blocked by another not-ready controller",
+			kRaftMode:     true,
+			currentBroker: "2",
+			expected:      []string{"1"},
+		},
+		{
+			testName:      "rolling the not-ready controller itself is not blocked by its own readiness",
+			kRaftMode:     true,
+			currentBroker: "1",
+			expected:      nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+			assert.Equal(t, test.expected, controllersBlockingRollingUpgrade(test.kRaftMode, pods, currentPodFor(test.currentBroker)))
+		})
+	}
+}

--- a/pkg/resources/kafka/pod.go
+++ b/pkg/resources/kafka/pod.go
@@ -26,7 +26,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/banzaicloud/koperator/api/assets"
 	apiutil "github.com/banzaicloud/koperator/api/util"
@@ -106,24 +105,20 @@ fi`},
 	}
 
 	if r.KafkaCluster.Spec.KRaftMode && brokerConfig.IsControllerNode() {
-		controllerlistenerPort, err := findControllerListenerPort(r.KafkaCluster)
-		if err != nil {
-			log.Error(err, "failed to find controller listener port")
-		} else {
-			kafkaContainer.ReadinessProbe = &corev1.Probe{
-				ProbeHandler: corev1.ProbeHandler{
-					TCPSocket: &corev1.TCPSocketAction{
-						Port: intstr.IntOrString{
-							Type:   intstr.Int,
-							IntVal: controllerlistenerPort,
-						},
-					},
+		// Readiness reflects quorum membership: the controller pod is Ready only once it reports a
+		// leader/follower raft state. Koperator's rolling upgrade waits on this readiness signal so it
+		// never restarts the next controller before the previously restarted one has rejoined the
+		// metadata quorum. The script runs in readiness mode (fail-closed while not yet in the quorum).
+		kafkaContainer.ReadinessProbe = &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				Exec: &corev1.ExecAction{
+					Command: []string{"/bin/bash", "-c", "export KRAFT_HEALTH_CHECK_MODE=readiness\n" + assets.KraftControllerHealthcheckSh},
 				},
-				InitialDelaySeconds: 0,
-				PeriodSeconds:       5,
-				TimeoutSeconds:      5,
-				FailureThreshold:    20,
-			}
+			},
+			InitialDelaySeconds: 15,
+			PeriodSeconds:       15,
+			TimeoutSeconds:      10,
+			FailureThreshold:    6,
 		}
 		kafkaContainer.LivenessProbe = &corev1.Probe{
 			ProbeHandler: corev1.ProbeHandler{
@@ -132,8 +127,8 @@ fi`},
 				},
 			},
 			InitialDelaySeconds: 30,
-			PeriodSeconds:       10,
-			TimeoutSeconds:      5,
+			PeriodSeconds:       15,
+			TimeoutSeconds:      10,
 			FailureThreshold:    6,
 		}
 	}
@@ -640,15 +635,4 @@ func generateEnvConfig(brokerConfig *v1beta1.BrokerConfig, defaultEnvVars []core
 	}
 
 	return mergedEnv
-}
-
-func findControllerListenerPort(kc *v1beta1.KafkaCluster) (int32, error) {
-	for _, listener := range kc.Spec.ListenersConfig.InternalListeners {
-		if listener.UsedForControllerCommunication {
-			return listener.ContainerPort, nil
-		}
-	}
-
-	// If no controller listener is found, return an error
-	return 0, fmt.Errorf("no controller listener found")
 }


### PR DESCRIPTION
Split out of #300 (6/6).

During a rolling upgrade the operator deleted the next pod as soon as the
previous one left the Pending/Terminating phase
(`getPodsInTerminatingOrPendingState`), and its only health gate
(AllOfflineReplicas/OutOfSyncReplicas) reflects partition/data-plane health,
which controller-only nodes never appear in. The KafkaClient exposes no
metadata-quorum API, so a controller could be restarted before the
previously restarted one had rejoined the quorum, risking loss of quorum
majority. The controller PodDisruptionBudget does not help here because the
operator deletes pods directly, bypassing the PDB.

Makes controller readiness reflect quorum membership and gates the rolling
upgrade on it:

- The controller readiness probe now execs the kraft healthcheck in a new
  "readiness" mode (`KRAFT_HEALTH_CHECK_MODE=readiness`), which is
  fail-closed: the pod is Ready only once the controller reports a
  leader/follower raft state. Liveness keeps the previous fail-open
  behaviour so a slow or briefly unavailable JMX exporter never restarts a
  healthy controller. This replaces the previous bare TCP-socket readiness
  check (and the now-unused `findControllerListenerPort` helper).
- `handleRollingUpgrade` now refuses (requeues) to delete a controller pod
  while any other KRaft controller is not Ready
  (`controllersBlockingRollingUpgrade` -> `notReadyControllerBrokerIDs`).
  The gate fires only when the pod being rolled is itself a controller:
  broker-only restarts cannot cost the quorum its majority and stay gated
  by the data-plane health check. The pod being reconciled is excluded so
  an unhealthy controller can still be replaced. Operators can bypass via
  `KRAFT_HEALTH_CHECK_SKIP` if the metric is unavailable clusterwide.

Adds unit tests for `notReadyControllerBrokerIDs` and
`controllersBlockingRollingUpgrade`.