### PR TITLE
test(e2e): print a running [k/N] specs-done progress counter

### DIFF
--- a/tests/e2e/koperator_suite_test.go
+++ b/tests/e2e/koperator_suite_test.go
@@ -18,6 +18,7 @@
 package e2e
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/k8s"
@@ -30,6 +31,21 @@ func TestKoperator(t *testing.T) {
 	gomega.RegisterFailHandler(ginkgo.Fail) // Note: Ginkgo - Gomega connector.
 	ginkgo.RunSpecs(t, "Koperator end to end test suite")
 }
+
+// totalSpecsToRun and completedSpecCount back the "[k/N]" progress line printed after each spec below.
+// The suite runs in series (no -p/--procs), so plain package vars are safe without synchronization.
+var totalSpecsToRun int
+var completedSpecCount int
+
+var _ = ginkgo.ReportBeforeSuite(func(report ginkgo.Report) {
+	totalSpecsToRun = report.PreRunStats.SpecsThatWillRun
+})
+
+var _ = ginkgo.ReportAfterEach(func(report ginkgo.SpecReport) {
+	completedSpecCount++
+	fmt.Printf("--- [%d/%d specs done] %s: %s (took %s)\n",
+		completedSpecCount, totalSpecsToRun, report.FullText(), report.State, report.RunTime)
+})
 
 var _ = ginkgo.BeforeSuite(func() {
 	ginkgo.By("Acquiring K8s cluster")


### PR DESCRIPTION
The e2e suite runs `--ginkgo.v` (`make test-e2e`), but Ginkgo only prints
the total spec count once up front ("Will run N of N specs") and a final
summary at the very end. During the ~45m CI run there's no way to tell how
far along a run is from the log — e.g. https://github.com/adobe/koperator/actions/runs/31584238727/job/94074210240?pr=304.

Adds a `ReportBeforeSuite` hook to capture the total spec count and a
`ReportAfterEach` hook that prints:

```
--- [k/N specs done] <spec full text>: <passed|failed|...> (took <duration>)
```

after every spec, so both progress and per-spec timing are visible straight
off the CI log as the run streams. The suite runs in series (no `-p`), so
plain package-level counters are safe without extra synchronization.

Verified with `--ginkgo.dry-run` (99/99 specs, correct counter) plus
`go build`/`go vet`/`golangci-lint` on `tests/e2e`.