### PR TITLE
fix(renovate): close docker image version coverage gaps in samples, patches, and workflow tooling

### DIFF
--- a/.github/actions/kind-create/action.yaml
+++ b/.github/actions/kind-create/action.yaml
@@ -81,7 +81,7 @@ runs:
     id: cloud-provider-kind
     run: |
       echo "Install cloud-provider-kind"
-      go install sigs.k8s.io/cloud-provider-kind@latest
+      go install sigs.k8s.io/cloud-provider-kind@v0.11.1 # renovate: datasource=go depName=sigs.k8s.io/cloud-provider-kind
       kubectl label node e2e-kind-control-plane node.kubernetes.io/exclude-from-external-load-balancers- 
       ~/go/bin/cloud-provider-kind &
     shell: bash

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Helm
         uses: azure/setup-helm@v5
         with:
-          version: '4.2.3'
+          version: '4.2.3' # renovate: datasource=github-releases depName=helm/helm
 
       - name: Clean Go module cache
         run: |

--- a/config/base/manager/manager.yaml
+++ b/config/base/manager/manager.yaml
@@ -20,7 +20,7 @@ spec:
         - /manager
         args:
         - --enable-leader-election
-        image: ghcr.io/adobe/koperator:latest
+        image: ghcr.io/adobe/koperator:latest # renovate: datasource=docker depName=ghcr.io/adobe/koperator
         name: manager
         livenessProbe:
           initialDelaySeconds: 15

--- a/config/overlays/auth-proxy-enabled/manager_auth_proxy_patch.yaml
+++ b/config/overlays/auth-proxy-enabled/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: quay.io/brancz/kube-rbac-proxy:v0.20.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.20.0 # renovate: datasource=docker depName=quay.io/brancz/kube-rbac-proxy
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/config/overlays/certmanager-with-auth-proxy/auth-proxy/manager_auth_proxy_patch.yaml
+++ b/config/overlays/certmanager-with-auth-proxy/auth-proxy/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: quay.io/brancz/kube-rbac-proxy:v0.20.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.20.0 # renovate: datasource=docker depName=quay.io/brancz/kube-rbac-proxy
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/config/samples/banzaicloud_v1beta1_kafkacluster.yaml
+++ b/config/samples/banzaicloud_v1beta1_kafkacluster.yaml
@@ -252,7 +252,7 @@ spec:
         #volumeMounts:
         #  - mountPath: "/opt/kafka/libs/extra-jars"
         #    name: "jars"
-    - image: "ghcr.io/adobe/koperator/kafka:2.13-3.9.1"
+    - image: "ghcr.io/adobe/koperator/kafka:2.13-3.9.1" # renovate: datasource=docker depName=ghcr.io/adobe/koperator/kafka
       id: 1
       config: |
         auto.create.topics.enable=false
@@ -274,7 +274,7 @@ spec:
       readOnlyConfig: |
         auto.create.topics.enable=false
       brokerConfig:
-        image: "ghcr.io/adobe/koperator/kafka:2.13-3.9.1"
+        image: "ghcr.io/adobe/koperator/kafka:2.13-3.9.1" # renovate: datasource=docker depName=ghcr.io/adobe/koperator/kafka
         storageConfigs:
           - mountPath: "/kafka-logs"
             pvcSpec:

--- a/config/samples/kafkacluster-prometheus.yaml
+++ b/config/samples/kafkacluster-prometheus.yaml
@@ -85,7 +85,7 @@ spec:
         storageClass: 'gp2'
         mountPath: '/kafkalog'
         diskSize: '10G'
-        image: 'ghcr.io/adobe/koperator/kafka:2.13-3.9.1'
+        image: 'ghcr.io/adobe/koperator/kafka:2.13-3.9.1' # renovate: datasource=docker depName=ghcr.io/adobe/koperator/kafka
         # annotations to be applied onto the broker pod
         # brokerAnnotations: '{ "sidecar.istio.io/logLevel": "trace", "sidecar.istio.io/proxyCPULimit": "50m" }'
         command: 'upScale'
@@ -101,7 +101,7 @@ spec:
         storageClass: 'gp2'
         mountPath: '/kafkalog'
         diskSize: '10G'
-        image: 'ghcr.io/adobe/koperator/kafka:2.13-3.9.1'
+        image: 'ghcr.io/adobe/koperator/kafka:2.13-3.9.1' # renovate: datasource=docker depName=ghcr.io/adobe/koperator/kafka
         # annotations to be applied onto the broker pod
         # brokerAnnotations: '{ "sidecar.istio.io/logLevel": "trace", "sidecar.istio.io/proxyCPULimit": "50m" }'
         command: 'upScale'
@@ -117,7 +117,7 @@ spec:
         storageClass: 'gp2'
         mountPath: '/kafkalog'
         diskSize: '10G'
-        image: 'ghcr.io/adobe/koperator/kafka:2.13-3.9.1'
+        image: 'ghcr.io/adobe/koperator/kafka:2.13-3.9.1' # renovate: datasource=docker depName=ghcr.io/adobe/koperator/kafka
         # annotations to be applied onto the broker pod
         # brokerAnnotations: '{ "sidecar.istio.io/logLevel": "trace", "sidecar.istio.io/proxyCPULimit": "50m" }'
         command: 'upScale'

--- a/config/samples/kafkacluster_with_external_ssl.yaml
+++ b/config/samples/kafkacluster_with_external_ssl.yaml
@@ -10,7 +10,7 @@ spec:
   zkAddresses:
     - "zookeeper-server-client.zookeeper:2181"
   oneBrokerPerNode: false
-  clusterImage: "ghcr.io/adobe/koperator/kafka:2.13-3.9.1"
+  clusterImage: "ghcr.io/adobe/koperator/kafka:2.13-3.9.1" # renovate: datasource=docker depName=ghcr.io/adobe/koperator/kafka
   readOnlyConfig: |
     auto.create.topics.enable=false
     cruise.control.metrics.topic.auto.create=true

--- a/config/samples/kafkacluster_with_external_ssl_customcert.yaml
+++ b/config/samples/kafkacluster_with_external_ssl_customcert.yaml
@@ -10,7 +10,7 @@ spec:
   zkAddresses:
     - "zookeeper-server-client.zookeeper:2181"
   oneBrokerPerNode: false
-  clusterImage: "ghcr.io/adobe/koperator/kafka:2.13-3.9.1"
+  clusterImage: "ghcr.io/adobe/koperator/kafka:2.13-3.9.1" # renovate: datasource=docker depName=ghcr.io/adobe/koperator/kafka
   readOnlyConfig: |
     auto.create.topics.enable=false
     cruise.control.metrics.topic.auto.create=true

--- a/config/samples/kafkacluster_with_ssl_groups.yaml
+++ b/config/samples/kafkacluster_with_ssl_groups.yaml
@@ -15,7 +15,7 @@ spec:
       - "failure-domain.beta.kubernetes.io/region"
       - "failure-domain.beta.kubernetes.io/zone"
   oneBrokerPerNode: false
-  clusterImage: "ghcr.io/adobe/koperator/kafka:2.13-3.9.1"
+  clusterImage: "ghcr.io/adobe/koperator/kafka:2.13-3.9.1" # renovate: datasource=docker depName=ghcr.io/adobe/koperator/kafka
   readOnlyConfig: |
     auto.create.topics.enable=false
     cruise.control.metrics.topic.auto.create=true

--- a/config/samples/kafkacluster_with_ssl_groups_customcert.yaml
+++ b/config/samples/kafkacluster_with_ssl_groups_customcert.yaml
@@ -15,7 +15,7 @@ spec:
       - "failure-domain.beta.kubernetes.io/region"
       - "failure-domain.beta.kubernetes.io/zone"
   oneBrokerPerNode: false
-  clusterImage: "ghcr.io/adobe/koperator/kafka:2.13-3.9.1"
+  clusterImage: "ghcr.io/adobe/koperator/kafka:2.13-3.9.1" # renovate: datasource=docker depName=ghcr.io/adobe/koperator/kafka
   readOnlyConfig: |
     auto.create.topics.enable=false
     cruise.control.metrics.topic.auto.create=true

--- a/config/samples/kafkacluster_with_ssl_hybrid_customcert.yaml
+++ b/config/samples/kafkacluster_with_ssl_hybrid_customcert.yaml
@@ -15,7 +15,7 @@ spec:
       - "failure-domain.beta.kubernetes.io/region"
       - "failure-domain.beta.kubernetes.io/zone"
   oneBrokerPerNode: false
-  clusterImage: "ghcr.io/adobe/koperator/kafka:2.13-3.9.1"
+  clusterImage: "ghcr.io/adobe/koperator/kafka:2.13-3.9.1" # renovate: datasource=docker depName=ghcr.io/adobe/koperator/kafka
   readOnlyConfig: |
     auto.create.topics.enable=false
     cruise.control.metrics.topic.auto.create=true

--- a/config/samples/kafkacluster_without_ssl.yaml
+++ b/config/samples/kafkacluster_without_ssl.yaml
@@ -10,7 +10,7 @@ spec:
   zkAddresses:
     - "zookeeper-server-client.zookeeper:2181"
   oneBrokerPerNode: false
-  clusterImage: "ghcr.io/adobe/koperator/kafka:2.13-3.9.1"
+  clusterImage: "ghcr.io/adobe/koperator/kafka:2.13-3.9.1" # renovate: datasource=docker depName=ghcr.io/adobe/koperator/kafka
   readOnlyConfig: |
     auto.create.topics.enable=false
     cruise.control.metrics.topic.auto.create=true

--- a/config/samples/kafkacluster_without_ssl_groups.yaml
+++ b/config/samples/kafkacluster_without_ssl_groups.yaml
@@ -10,7 +10,7 @@ spec:
   zkAddresses:
     - "zookeeper-server-client.zookeeper:2181"
   oneBrokerPerNode: false
-  clusterImage: "ghcr.io/adobe/koperator/kafka:2.13-3.9.1"
+  clusterImage: "ghcr.io/adobe/koperator/kafka:2.13-3.9.1" # renovate: datasource=docker depName=ghcr.io/adobe/koperator/kafka
   readOnlyConfig: |
     auto.create.topics.enable=false
     cruise.control.metrics.topic.auto.create=true

--- a/config/samples/kraft/simplekafkacluster_kraft.yaml
+++ b/config/samples/kraft/simplekafkacluster_kraft.yaml
@@ -7,11 +7,11 @@ metadata:
 spec:
   kRaft: true
   monitoringConfig:
-    jmxImage: "ghcr.io/adobe/koperator/jmx-javaagent:1.5.0"
+    jmxImage: "ghcr.io/adobe/koperator/jmx-javaagent:1.5.0" # renovate: datasource=docker depName=ghcr.io/adobe/koperator/jmx-javaagent
   headlessServiceEnabled: true
   propagateLabels: false
   oneBrokerPerNode: false
-  clusterImage: "ghcr.io/adobe/koperator/kafka:2.13-3.9.2-jdk21.0.11"
+  clusterImage: "ghcr.io/adobe/koperator/kafka:2.13-3.9.2-jdk21.0.11" # renovate: datasource=docker depName=ghcr.io/adobe/koperator/kafka
   taintedBrokersSelector:
     matchLabels:
       restart: me

--- a/config/samples/simplekafkacluster-with-brokerbindings.yaml
+++ b/config/samples/simplekafkacluster-with-brokerbindings.yaml
@@ -11,7 +11,7 @@ spec:
     - "zookeeper-server-client.zookeeper:2181"
   propagateLabels: false
   oneBrokerPerNode: false
-  clusterImage: "ghcr.io/adobe/koperator/kafka:2.13-3.9.1"
+  clusterImage: "ghcr.io/adobe/koperator/kafka:2.13-3.9.1" # renovate: datasource=docker depName=ghcr.io/adobe/koperator/kafka
   readOnlyConfig: |
     auto.create.topics.enable=false
     cruise.control.metrics.topic.auto.create=true

--- a/config/samples/simplekafkacluster-with-nodeport-external.yaml
+++ b/config/samples/simplekafkacluster-with-nodeport-external.yaml
@@ -11,7 +11,7 @@ spec:
     - "zookeeper-server-client.zookeeper:2181"
   propagateLabels: false
   oneBrokerPerNode: false
-  clusterImage: "ghcr.io/adobe/koperator/kafka:2.13-3.9.1"
+  clusterImage: "ghcr.io/adobe/koperator/kafka:2.13-3.9.1" # renovate: datasource=docker depName=ghcr.io/adobe/koperator/kafka
   readOnlyConfig: |
     auto.create.topics.enable=false
     cruise.control.metrics.topic.auto.create=true

--- a/config/samples/simplekafkacluster.yaml
+++ b/config/samples/simplekafkacluster.yaml
@@ -8,13 +8,13 @@ spec:
   localDebugEnabled: true
   kRaft: false
   monitoringConfig:
-    jmxImage: "ghcr.io/adobe/koperator/jmx-javaagent:1.4.0"
+    jmxImage: "ghcr.io/adobe/koperator/jmx-javaagent:1.4.0" # renovate: datasource=docker depName=ghcr.io/adobe/koperator/jmx-javaagent
   headlessServiceEnabled: false
   zkAddresses:
     - "zookeeper-server-client.zookeeper:2181"
   propagateLabels: false
   oneBrokerPerNode: false
-  clusterImage: "ghcr.io/adobe/koperator/kafka:2.13-3.9.1"
+  clusterImage: "ghcr.io/adobe/koperator/kafka:2.13-3.9.1" # renovate: datasource=docker depName=ghcr.io/adobe/koperator/kafka
   readOnlyConfig: |
     auto.create.topics.enable=false
     cruise.control.metrics.topic.auto.create=true
@@ -85,7 +85,7 @@ spec:
 #      limits:
 #        cpu: 500m
 #        memory: 1Gi
-    image: "adobe/cruise-control:3.0.3-adbe-20250804"
+    image: "adobe/cruise-control:3.0.3-adbe-20250804" # renovate: datasource=docker depName=adobe/cruise-control
     config: |
       # Copyright 2017 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
       #

--- a/config/samples/simplekafkacluster_2disk.yaml
+++ b/config/samples/simplekafkacluster_2disk.yaml
@@ -7,13 +7,13 @@ metadata:
 spec:
   kRaft: false
   monitoringConfig:
-    jmxImage: "ghcr.io/adobe/koperator/jmx-javaagent:1.4.0"
+    jmxImage: "ghcr.io/adobe/koperator/jmx-javaagent:1.4.0" # renovate: datasource=docker depName=ghcr.io/adobe/koperator/jmx-javaagent
   headlessServiceEnabled: true
   zkAddresses:
     - "zookeeper-server-client.zookeeper:2181"
   propagateLabels: false
   oneBrokerPerNode: false
-  clusterImage: "ghcr.io/adobe/koperator/kafka:2.13-3.9.1"
+  clusterImage: "ghcr.io/adobe/koperator/kafka:2.13-3.9.1" # renovate: datasource=docker depName=ghcr.io/adobe/koperator/kafka
   readOnlyConfig: |
     auto.create.topics.enable=false
     cruise.control.metrics.topic.auto.create=true
@@ -91,7 +91,7 @@ spec:
 #      limits:
 #        cpu: 500m
 #        memory: 1Gi
-    image: "adobe/cruise-control:3.0.3-adbe-20250804"
+    image: "adobe/cruise-control:3.0.3-adbe-20250804" # renovate: datasource=docker depName=adobe/cruise-control
     config: |
       # Copyright 2017 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
       #

--- a/config/samples/simplekafkacluster_4disk.yaml
+++ b/config/samples/simplekafkacluster_4disk.yaml
@@ -7,13 +7,13 @@ metadata:
 spec:
   kRaft: false
   monitoringConfig:
-    jmxImage: "ghcr.io/adobe/koperator/jmx-javaagent:1.4.0"
+    jmxImage: "ghcr.io/adobe/koperator/jmx-javaagent:1.4.0" # renovate: datasource=docker depName=ghcr.io/adobe/koperator/jmx-javaagent
   headlessServiceEnabled: true
   zkAddresses:
     - "zookeeper-server-client.zookeeper:2181"
   propagateLabels: false
   oneBrokerPerNode: false
-  clusterImage: "ghcr.io/adobe/koperator/kafka:2.13-3.9.1"
+  clusterImage: "ghcr.io/adobe/koperator/kafka:2.13-3.9.1" # renovate: datasource=docker depName=ghcr.io/adobe/koperator/kafka
   readOnlyConfig: |
     auto.create.topics.enable=false
     cruise.control.metrics.topic.auto.create=true
@@ -105,7 +105,7 @@ spec:
 #      limits:
 #        cpu: 500m
 #        memory: 1Gi
-    image: "adobe/cruise-control:3.0.3-adbe-20250804"
+    image: "adobe/cruise-control:3.0.3-adbe-20250804" # renovate: datasource=docker depName=adobe/cruise-control
     config: |
       # Copyright 2017 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
       #

--- a/config/samples/simplekafkacluster_5broker.yaml
+++ b/config/samples/simplekafkacluster_5broker.yaml
@@ -7,13 +7,13 @@ metadata:
 spec:
   kRaft: false
   monitoringConfig:
-    jmxImage: "ghcr.io/adobe/koperator/jmx-javaagent:1.4.0"
+    jmxImage: "ghcr.io/adobe/koperator/jmx-javaagent:1.4.0" # renovate: datasource=docker depName=ghcr.io/adobe/koperator/jmx-javaagent
   headlessServiceEnabled: true
   zkAddresses:
     - "zookeeper-server-client.zookeeper:2181"
   propagateLabels: false
   oneBrokerPerNode: false
-  clusterImage: "ghcr.io/adobe/koperator/kafka:2.13-3.9.1"
+  clusterImage: "ghcr.io/adobe/koperator/kafka:2.13-3.9.1" # renovate: datasource=docker depName=ghcr.io/adobe/koperator/kafka
   readOnlyConfig: |
     auto.create.topics.enable=false
     cruise.control.metrics.topic.auto.create=true
@@ -88,7 +88,7 @@ spec:
 #      limits:
 #        cpu: 500m
 #        memory: 1Gi
-    image: "adobe/cruise-control:3.0.3-adbe-20250804"
+    image: "adobe/cruise-control:3.0.3-adbe-20250804" # renovate: datasource=docker depName=adobe/cruise-control
     config: |
       # Copyright 2017 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
       #

--- a/config/samples/simplekafkacluster_affinity.yaml
+++ b/config/samples/simplekafkacluster_affinity.yaml
@@ -13,7 +13,7 @@ spec:
   # If true OneBrokerPerNode ensures that each kafka broker will be placed on a different node unless a custom
   # Affinity definition overrides this behavior either set in brokerConfigGroups or in one specific brokerConfig
   oneBrokerPerNode: false
-  clusterImage: "ghcr.io/adobe/koperator/kafka:2.13-3.9.1"
+  clusterImage: "ghcr.io/adobe/koperator/kafka:2.13-3.9.1" # renovate: datasource=docker depName=ghcr.io/adobe/koperator/kafka
   readOnlyConfig: |
     auto.create.topics.enable=false
     cruise.control.metrics.topic.auto.create=true

--- a/config/samples/simplekafkacluster_ebs_csi.yaml
+++ b/config/samples/simplekafkacluster_ebs_csi.yaml
@@ -16,7 +16,7 @@ spec:
   zkPath: "/kafka"
   propagateLabels: true
   oneBrokerPerNode: false
-  clusterImage: "ghcr.io/adobe/koperator/kafka:2.13-3.9.1"
+  clusterImage: "ghcr.io/adobe/koperator/kafka:2.13-3.9.1" # renovate: datasource=docker depName=ghcr.io/adobe/koperator/kafka
   readOnlyConfig: |
     auto.create.topics.enable=false
     cruise.control.metrics.topic.auto.create=true

--- a/config/samples/simplekafkacluster_ssl.yaml
+++ b/config/samples/simplekafkacluster_ssl.yaml
@@ -11,7 +11,7 @@ spec:
     - "zookeeper-server-client.zookeeper:2181"
   propagateLabels: false
   oneBrokerPerNode: false
-  clusterImage: "ghcr.io/adobe/koperator/kafka:2.13-3.9.1"
+  clusterImage: "ghcr.io/adobe/koperator/kafka:2.13-3.9.1" # renovate: datasource=docker depName=ghcr.io/adobe/koperator/kafka
   readOnlyConfig: |
     auto.create.topics.enable=false
     cruise.control.metrics.topic.auto.create=true

--- a/config/samples/simplekafkacluster_with_contour.yaml
+++ b/config/samples/simplekafkacluster_with_contour.yaml
@@ -6,13 +6,13 @@ metadata:
   name: kafka
 spec:
   monitoringConfig:
-    jmxImage: "ghcr.io/adobe/koperator/jmx-javaagent:1.4.0"
+    jmxImage: "ghcr.io/adobe/koperator/jmx-javaagent:1.4.0" # renovate: datasource=docker depName=ghcr.io/adobe/koperator/jmx-javaagent
   headlessServiceEnabled: true
   zkAddresses:
     - "zookeeper-server-client.zookeeper:2181"
   propagateLabels: false
   oneBrokerPerNode: false
-  clusterImage: "ghcr.io/adobe/koperator/kafka:2.13-3.9.1"
+  clusterImage: "ghcr.io/adobe/koperator/kafka:2.13-3.9.1" # renovate: datasource=docker depName=ghcr.io/adobe/koperator/kafka
   ingressController: "contour"
   readOnlyConfig: |
     auto.create.topics.enable=false

--- a/config/samples/simplekafkacluster_with_k8s_provided_nodeport.yaml
+++ b/config/samples/simplekafkacluster_with_k8s_provided_nodeport.yaml
@@ -11,7 +11,7 @@ spec:
     - "zookeeper-server-client.zookeeper:2181"
   propagateLabels: false
   oneBrokerPerNode: false
-  clusterImage: "ghcr.io/adobe/koperator/kafka:2.13-3.9.1"
+  clusterImage: "ghcr.io/adobe/koperator/kafka:2.13-3.9.1" # renovate: datasource=docker depName=ghcr.io/adobe/koperator/kafka
   readOnlyConfig: |
     auto.create.topics.enable=false
     cruise.control.metrics.topic.auto.create=true

--- a/config/samples/simplekafkacluster_with_sasl.yaml
+++ b/config/samples/simplekafkacluster_with_sasl.yaml
@@ -11,7 +11,7 @@ spec:
     - "zookeeper-server-client.zookeeper:2181"
   propagateLabels: false
   oneBrokerPerNode: false
-  clusterImage: "ghcr.io/adobe/koperator/kafka:2.13-3.9.1"
+  clusterImage: "ghcr.io/adobe/koperator/kafka:2.13-3.9.1" # renovate: datasource=docker depName=ghcr.io/adobe/koperator/kafka
   readOnlyConfig: |
     auto.create.topics.enable=false
     cruise.control.metrics.topic.auto.create=true

--- a/docs/benchmarks/infrastructure/kafka.yaml
+++ b/docs/benchmarks/infrastructure/kafka.yaml
@@ -10,7 +10,7 @@ spec:
   zkAddresses:
     - "zookeeper-server-client.zookeeper:2181"
   oneBrokerPerNode: true
-  clusterImage: "ghcr.io/adobe/koperator/kafka:2.13-3.9.1"
+  clusterImage: "ghcr.io/adobe/koperator/kafka:2.13-3.9.1" # renovate: datasource=docker depName=ghcr.io/adobe/koperator/kafka
   readOnlyConfig: |
     auto.create.topics.enable=false
   rackAwareness:

--- a/docs/benchmarks/infrastructure/kafka_202001_3brokers.yaml
+++ b/docs/benchmarks/infrastructure/kafka_202001_3brokers.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   kRaft: false
   monitoringConfig:
-    jmxImage: "ghcr.io/adobe/koperator/jmx-javaagent:1.5.0"
+    jmxImage: "ghcr.io/adobe/koperator/jmx-javaagent:1.5.0" # renovate: datasource=docker depName=ghcr.io/adobe/koperator/jmx-javaagent
     pathToJar: "/jmx_prometheus_javaagent.jar"
     kafkaJMXExporterConfig: |2
       lowercaseOutputName: true
@@ -66,7 +66,7 @@ spec:
   zkAddresses:
     - "zookeeper-server-client.zookeeper:2181"
   oneBrokerPerNode: true
-  clusterImage: "ghcr.io/adobe/koperator/kafka:2.13-3.9.1"
+  clusterImage: "ghcr.io/adobe/koperator/kafka:2.13-3.9.1" # renovate: datasource=docker depName=ghcr.io/adobe/koperator/kafka
   readOnlyConfig: |
     auto.create.topics.enable=false
     min.insync.replicas=3

--- a/hack/kafka-test-pod/manifest_certmanager.yaml
+++ b/hack/kafka-test-pod/manifest_certmanager.yaml
@@ -66,7 +66,7 @@ spec:
 
     # Container reading from topic with the consumer credentials
     - name: consumer
-      image: banzaicloud/kafka-test:latest
+      image: banzaicloud/kafka-test:latest # renovate: datasource=docker depName=banzaicloud/kafka-test
       imagePullPolicy: IfNotPresent
       env:
         - name: KAFKA_MODE
@@ -78,7 +78,7 @@ spec:
 
     # Container writing to topic with the producer credentials
     - name: producer
-      image: banzaicloud/kafka-test:latest
+      image: banzaicloud/kafka-test:latest # renovate: datasource=docker depName=banzaicloud/kafka-test
       imagePullPolicy: IfNotPresent
       env:
         - name: KAFKA_MODE

--- a/renovate.json
+++ b/renovate.json
@@ -21,7 +21,8 @@
       "managerFilePatterns": [
         "/(^|/)Makefile$/",
         "/(^|/)Dockerfile$/",
-        "/(^|/)\\.github/workflows/regenerate-crd-docs\\.yaml$/"
+        "/(^|/)\\.github/workflows/regenerate-crd-docs\\.yaml$/",
+        "/(^|/)scripts/install_kustomize\\.sh$/"
       ],
       "matchStrings": [
         "(?<depName>[A-Z][A-Z0-9_]*)_VERSION\\s*=\\s*(?<currentValue>[^\\s]+)\\s*#\\s*renovate:\\s*datasource=(?<datasource>[^\\s]+)\\s*depName=(?<packageName>[^\\s]+)(?:\\s*extractVersion=(?<extractVersion>[^\\s]+))?"
@@ -68,10 +69,52 @@
     {
       "customType": "regex",
       "managerFilePatterns": [
-        "/(^|/)\\.github/actions/kind-create/action\\.yaml$/"
+        "/(^|/)\\.github/actions/kind-create/action\\.yaml$/",
+        "/(^|/)\\.github/workflows/e2e-test\\.yaml$/"
       ],
       "matchStrings": [
         "(?:default|version):\\s*'?(?<currentValue>[^\\s'#]+)'?\\s*#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<packageName>\\S+)"
+      ],
+      "datasourceTemplate": "{{datasource}}",
+      "depNameTemplate": "{{packageName}}"
+    },
+    {
+      "customType": "regex",
+      "description": "go install <module>@<version> pins inside composite action shell steps (e.g. .github/actions/kind-create/action.yaml). Not covered by any built-in manager.",
+      "managerFilePatterns": [
+        "/(^|/)\\.github/actions/kind-create/action\\.yaml$/"
+      ],
+      "matchStrings": [
+        "go install \\S+@(?<currentValue>\\S+)\\s*#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<packageName>\\S+)"
+      ],
+      "datasourceTemplate": "{{datasource}}",
+      "depNameTemplate": "{{packageName}}"
+    },
+    {
+      "customType": "regex",
+      "description": "Docker images embedded as flat 'repo:tag' strings in KafkaCluster sample manifests, benchmark infra YAML, and kustomize strategic-merge patches. The built-in helm-values manager only matches files literally named values.yaml/values.yml with a nested {repository,tag} shape, kustomize only reads the kustomization.yaml 'images:' transformer (unused in this repo), and the kubernetes manager has no default managerFilePatterns and is not configured here - so none of these were previously watched.",
+      "managerFilePatterns": [
+        "/(^|/)config/samples/.*\\.yaml$/",
+        "/(^|/)docs/benchmarks/infrastructure/.*\\.yaml$/",
+        "/(^|/)tests/e2e/templates/.*\\.tmpl$/",
+        "/(^|/)config/base/manager/manager\\.yaml$/",
+        "/(^|/)config/overlays/.*/manager_auth_proxy_patch\\.yaml$/",
+        "/(^|/)hack/kafka-test-pod/manifest_certmanager\\.yaml$/"
+      ],
+      "matchStrings": [
+        "[\"']?[a-zA-Z0-9-]+(?:\\.[a-zA-Z0-9-]+)*(?:/[a-zA-Z0-9._-]+)+:(?<currentValue>[a-zA-Z0-9._-]+)[\"']?\\s*#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<packageName>\\S+)"
+      ],
+      "datasourceTemplate": "{{datasource}}",
+      "depNameTemplate": "{{packageName}}"
+    },
+    {
+      "customType": "regex",
+      "description": "Docker images embedded as nested helm-style {repository, tag} blocks in tests/e2e/templates/*.tmpl fixtures. The .tmpl extension is never matched by the built-in helm-values manager (values.yaml/.yml only), even though the shape matches.",
+      "managerFilePatterns": [
+        "/(^|/)tests/e2e/templates/.*\\.tmpl$/"
+      ],
+      "matchStrings": [
+        "tag:\\s*(?<currentValue>\\S+)\\s*#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<packageName>\\S+)"
       ],
       "datasourceTemplate": "{{datasource}}",
       "depNameTemplate": "{{packageName}}"
@@ -95,13 +138,17 @@
     {
       "groupName": "config samples docker images",
       "groupSlug": "config-samples-docker",
+      "description": "Was scoped to matchManagers: [helm-values], but that manager only reads files literally named values.yaml/values.yml with a nested {repository,tag} shape - it never matched anything under these paths, so this rule was a no-op. The images here are now tracked via explicit '# renovate:' comment annotations (custom.regex manager); see the customManagers entries covering config/samples, docs/benchmarks/infrastructure, tests/e2e/templates, config/base/manager, config/overlays, and hack/kafka-test-pod.",
       "matchFileNames": [
         "config/samples/**",
         "docs/benchmarks/infrastructure/**",
-        "tests/e2e/templates/**"
+        "tests/e2e/templates/**",
+        "config/base/manager/**",
+        "config/overlays/**",
+        "hack/kafka-test-pod/**"
       ],
       "matchManagers": [
-        "helm-values"
+        "custom.regex"
       ],
       "matchUpdateTypes": [
         "major",
@@ -121,6 +168,14 @@
       "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(?:-ado?be-(?<build>\\d+))?$",
       "description": "Self-scoping: applies to ANY docker dep whose current pin is <semver>-adbe|adobe-<yyyymmdd> (cruise-control uses 'adbe', zookeeper-operator 'adobe'; new adobe-fork images inherit this with no config change). Default docker versioning treats that suffix as an immutable compatibility string, so newer daily builds are never offered; capturing the date as a purely-numeric 'build' (handled like patch) makes e.g. 3.0.3-adbe-20250804 -> 3.0.3-adbe-20260722 and 0.2.15-adobe-20250923 track their newest build. matchCurrentValue requires the suffix, so only these deps are touched; the versioning's suffix is optional so the same image can still publish a plain-semver tag. Trailing '$' excludes '-rc'."
        },
+    {
+      "matchPackageNames": [
+        "ghcr.io/adobe/koperator/kafka"
+      ],
+      "matchCurrentValue": "/^\\d+\\.\\d+-\\d+\\.\\d+\\.\\d+$/",
+      "versioning": "regex:^(?<compatibility>\\d+\\.\\d+)-(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
+      "description": "Tag format is <scala_version>-<kafka_version>, e.g. 2.13-3.9.1. Verified live against ghcr.io: default docker versioning parses currentVersion as just '2.13' and silently drops everything after the first hyphen, so Renovate can never see a real 3.9.1->3.9.2 bump (only digest-pin updates fire, via the docker pinDigests rule below) - this affects every '# renovate:' annotated occurrence of this image, including the pre-existing api/v1beta1/kafkacluster_types.go constants. Pinning the scala prefix as 'compatibility' (never auto-changed) and parsing the kafka release as major.minor.patch fixes real version comparison. matchCurrentValue excludes the '-jdk<version>' suffixed variant (config/samples/kraft/simplekafkacluster_kraft.yaml) - that one needs a second compatibility slot this single regex can't express, so it deliberately keeps today's (limited but not broken) default-versioning behavior rather than risk a wrong match."
+    },
     {
       "groupName": "kafka docker images (major)",
       "groupSlug": "kafka-docker-major",

--- a/scripts/install_kustomize.sh
+++ b/scripts/install_kustomize.sh
@@ -14,11 +14,11 @@
 # limitations under the License.
 
 
-version=3.1.0
+KUSTOMIZE_VERSION=3.1.0 # renovate: datasource=github-releases depName=kubernetes-sigs/kustomize extractVersion=^kustomize/v(?<version>.+)$
 opsys=$(echo "$(uname -s)" | awk '{print tolower($0)}')
 
 # download the release
-curl -O -L https://github.com/kubernetes-sigs/kustomize/releases/download/v${version}/kustomize_${version}_${opsys}_amd64
+curl -O -L https://github.com/kubernetes-sigs/kustomize/releases/download/v${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_${opsys}_amd64
 # move to bin
 mkdir -p bin
 mv kustomize_*_${opsys}_amd64 bin/kustomize

--- a/tests/e2e/templates/kcat.yaml.tmpl
+++ b/tests/e2e/templates/kcat.yaml.tmpl
@@ -7,7 +7,7 @@ spec:
   serviceAccount: {{or .ServiceAccount "default"}}
   containers:
   - name: kafka-client
-    image: edenhill/kcat:1.7.0
+    image: edenhill/kcat:1.7.0 # renovate: datasource=docker depName=edenhill/kcat
     # Just spin & wait forever
     command: [ "/bin/sh", "-c", "--" ]
     args: [ "while true; do sleep 3000; done;" ]

--- a/tests/e2e/templates/zookeeper_cluster.yaml.tmpl
+++ b/tests/e2e/templates/zookeeper_cluster.yaml.tmpl
@@ -7,6 +7,6 @@ spec:
     replicas: {{ or .Replicas 1 }}
     image:
         repository: ghcr.io/adobe/zookeeper-operator/zookeeper
-        tag: 3.8.4-0.2.15-adobe-20250923
+        tag: 3.8.4-0.2.15-adobe-20250923 # renovate: datasource=docker depName=ghcr.io/adobe/zookeeper-operator/zookeeper
     persistence:
         reclaimPolicy: Delete


### PR DESCRIPTION
## Summary

Audit of every place a docker image/software version is referenced in this repo turned up several locations Renovate silently never watched, plus one dependency where the versioning scheme itself was broken.

**Coverage gaps (extraction never happened):**
- `config/samples/**`, `docs/benchmarks/infrastructure/**`, `tests/e2e/templates/*.tmpl`, `config/base/manager/manager.yaml`, `config/overlays/**/manager_auth_proxy_patch.yaml`, `hack/kafka-test-pod/manifest_certmanager.yaml` — the existing `"config samples docker images"` packageRule scoped `matchManagers: ["helm-values"]`, but that manager only reads files literally named `values.yaml`/`values.yml` with a nested `{repository, tag}` shape. None of these files match either condition, so the rule was a no-op despite looking like coverage.
- `.github/actions/kind-create/action.yaml`: `go install sigs.k8s.io/cloud-provider-kind@latest` — unpinned and untracked by any manager.
- `.github/workflows/e2e-test.yaml`: Helm CLI `version: '4.2.3'` inside a `with:` block — not covered by the github-actions manager (which only tracks `uses:@ref`).
- `scripts/install_kustomize.sh`: lowercase `version=3.1.0` — the existing `_VERSION` regex manager requires an uppercase `PREFIX_VERSION` name.

Fixed by adding explicit `# renovate:` comment annotations (the convention already used for Makefile/Dockerfile `_VERSION` vars and `api/v1beta1/kafkacluster_types.go`) plus matching `customManagers`, and repointing the dead packageRule at `custom.regex`.

**Evidence this already caused drift:** several newly-annotated samples were still pinned to `jmx-javaagent:1.4.0` and `cruise-control:3.0.3-adbe-20250804`, both stale against the annotated (and actually-watched) defaults in `api/v1beta1/kafkacluster_types.go` (`1.5.0` / `3.0.3-adbe-20260722`).

**Versioning bug (extraction worked, but comparison didn't):** verified with a live local Renovate run (`RENOVATE_PLATFORM=local`, dry-run) against `ghcr.io` that the default `docker` versioning scheme parses `ghcr.io/adobe/koperator/kafka`'s `<scala>-<kafka>` tag format (e.g. `2.13-3.9.1`) as just `"2.13"` — it silently drops everything after the first hyphen. This already affected the pre-existing, correctly-annotated `DefaultKafkaImage` constant, so no real Kafka version-bump PR has ever been possible for this image, only digest pins. Added a `compatibility`-anchored regex versioning packageRule (same technique already used for cruise-control/zookeeper-operator's `-adbe`/`-adobe` suffix) so the Kafka release itself now compares correctly.

I checked the live tag list on `ghcr.io/adobe/koperator/kafka` and there's currently no plain `2.13-3.9.2` tag published (only `2.13-3.9.1`, `latest`, `2.13-3.9.2-jdk21.0.11`, and a malformed `2.13-3.9.2-jdk` with no JDK version suffix — possibly a CI tagging bug worth a separate look). So the fix won't visibly change anything today, but will surface a real update the moment a plain-format successor tag is published. The `-jdk<version>` suffixed variant (only `config/samples/kraft/simplekafkacluster_kraft.yaml`) is deliberately excluded from the new versioning rule — pinning two separate compatibility anchors (scala prefix *and* JDK suffix) around a middle version isn't expressible in a single `compatibility` capture group, so it keeps today's non-broken-but-limited default versioning rather than risk a wrong match.

## Test plan
- [x] `renovate-config-validator` (actual current Renovate, v44.32.6) passes clean
- [x] Full local Renovate dry-run (`RENOVATE_PLATFORM=local --dry-run=full`) against live registries confirms all 34 edited files are now extracted (regex manager: 41 files / 70 deps, up from ~0 for these paths)
- [x] Confirmed via the same dry-run that `ghcr.io/adobe/koperator/kafka` now parses `currentVersion` as the full `2.13-3.9.1` instead of truncating to `2.13`
- [x] Confirmed the kraft sample's jdk-suffixed tag is unaffected (still `currentVersion: "2.13"`, no regression)
- [ ] Maintainer review of the two new customManager regexes (flat `repo:tag` + nested `tag:` block) against any file patterns not covered by this audit

🤖 Generated with [Claude Code](https://claude.com/claude-code)