### PR TITLE
fix(kafka): preserve broker Service during pending removal

### DIFF
--- a/config/samples/kraft/simplekafkacluster_kraft.yaml
+++ b/config/samples/kraft/simplekafkacluster_kraft.yaml
@@ -305,18 +305,8 @@ spec:
       {
         "min.insync.replicas": 3
       }
-    capacityConfig: |-
-      {
-        "brokerCapacities":[
-          {
-            "brokerId": "-1",
-            "capacity": {
-              "DISK": {"/kafka-logs-broker/kafka": "10240"},
-              "CPU": {"num.cores": "1"},
-              "NW_IN": "900000",
-              "NW_OUT": "900000"
-            },
-            "doc": "This is the default capacity. Capacity unit used for disk is in MB, cpu is in cores, network throughput is in KB."
-          }
-        ]
-      }
+    # NOTE: intentionally NO capacityConfig here. A "brokerId": "-1" universal-default entry makes
+    # GenerateCapacityConfig return early, so Cruise Control's capacity.json stays constant across scaling
+    # and the #301 capacity-roll path (and its fix) is never exercised. Omitting it forces per-broker
+    # capacity generation, which is exactly what the KRaft broker-scaling e2e regression-tests. Do not add
+    # a universal default back or the regression coverage silently disappears.

--- a/pkg/resources/kafka/kafka.go
+++ b/pkg/resources/kafka/kafka.go
@@ -489,7 +489,23 @@ func (r *Reconciler) Reconcile(log logr.Logger) error {
 	// reconcile flow. The services must be deleted at the end of the reconcile flow after the new services
 	// were created and broker configurations reflecting the new services otherwise the Kafka brokers
 	// won't be reachable by koperator.
-	if r.KafkaCluster.Spec.HeadlessServiceEnabled {
+	//
+	// A broker pod can still be running outside spec.Brokers while its removal is pending. Deletion is gated
+	// on Cruise Control finishing the data migration off it.
+	// That pod is not touched by the per-broker loop above, so it never gets a replacement address on the
+	// other addressing scheme; its only reachable address is whichever Service this reconcile is about to
+	// delete. Deleting it out from under a broker that is still alive and still needed would orphan that
+	// broker from the network entirely, stalling the very Cruise Control operation the removal is waiting on.
+	// Rather than reasoning about whether this particular deletion happens to be safe this time,
+	// skip both service-topology transitions while any such pod exists, log it clearly, and let a later
+	// reconcile retry once the pod is gone.
+	if pendingBrokerID, stillPending := firstRunningBrokerOutsideSpec(runningBrokers, r.KafkaCluster.Spec.Brokers); stillPending {
+		log.Info("deferring headless/non-headless service reconciliation: a broker outside spec.Brokers still has a running pod",
+			"component", componentName,
+			"clusterName", r.KafkaCluster.Name,
+			"clusterNamespace", r.KafkaCluster.Namespace,
+			"pendingBrokerId", pendingBrokerID)
+	} else if r.KafkaCluster.Spec.HeadlessServiceEnabled {
 		log.V(1).Info("deleting non-headless services for all of the brokers")
 
 		if err := r.deleteNonHeadlessServices(ctx); err != nil {
@@ -1680,6 +1696,25 @@ func getServiceFromExternalListener(client client.Client, cluster *banzaiv1beta1
 		return nil, errors.WrapIfWithDetails(err, "could not get LoadBalancer service", "serviceName", iControllerServiceName)
 	}
 	return foundLBService, nil
+}
+
+// firstRunningBrokerOutsideSpec reports whether any broker with a running pod (runningBrokers, keyed by
+// BrokerIdLabelKey value) is absent from desiredBrokers, returning its ID for logging. Such a broker is
+// outside the per-broker reconcile loop entirely (see reorderBrokers) - e.g. one dropped from spec.Brokers
+// while its removal is still pending Cruise Control's data migration - so it never receives a replacement
+// address on the other Service-addressing scheme. Iteration order over the map is nondeterministic, but
+// finding any single one is enough for callers that only need to know whether it is safe to proceed.
+func firstRunningBrokerOutsideSpec(runningBrokers map[string]struct{}, desiredBrokers []banzaiv1beta1.Broker) (string, bool) {
+	inSpec := make(map[string]struct{}, len(desiredBrokers))
+	for _, b := range desiredBrokers {
+		inSpec[strconv.Itoa(int(b.Id))] = struct{}{}
+	}
+	for id := range runningBrokers {
+		if _, ok := inSpec[id]; !ok {
+			return id, true
+		}
+	}
+	return "", false
 }
 
 // reorderBrokers returns the KafkaCluster brokers list reordered for reconciliation such that:

--- a/pkg/resources/kafka/kafka_test.go
+++ b/pkg/resources/kafka/kafka_test.go
@@ -591,6 +591,52 @@ func TestReorderBrokers(t *testing.T) {
 	}
 }
 
+func TestFirstRunningBrokerOutsideSpec(t *testing.T) {
+	testCases := []struct {
+		testName       string
+		runningBrokers map[string]struct{}
+		desiredBrokers []v1beta1.Broker
+		wantFound      bool
+		wantID         string
+	}{
+		{
+			testName:       "no running brokers at all",
+			runningBrokers: map[string]struct{}{},
+			desiredBrokers: []v1beta1.Broker{{Id: 0}, {Id: 1}},
+			wantFound:      false,
+		},
+		{
+			testName:       "every running broker is still in spec",
+			runningBrokers: map[string]struct{}{"0": {}, "1": {}, "2": {}},
+			desiredBrokers: []v1beta1.Broker{{Id: 0}, {Id: 1}, {Id: 2}},
+			wantFound:      false,
+		},
+		{
+			testName: "a broker dropped from spec still has a running pod",
+			// Mirrors the service-transition failure mode: broker 3 was removed from spec.Brokers while its
+			// pod, pending Cruise Control's data migration, is still Running.
+			runningBrokers: map[string]struct{}{"0": {}, "1": {}, "2": {}, "3": {}},
+			desiredBrokers: []v1beta1.Broker{{Id: 0}, {Id: 1}, {Id: 2}},
+			wantFound:      true,
+			wantID:         "3",
+		},
+		{
+			testName:       "a desired broker has no running pod yet (scale-up in progress)",
+			runningBrokers: map[string]struct{}{"0": {}},
+			desiredBrokers: []v1beta1.Broker{{Id: 0}, {Id: 1}},
+			wantFound:      false,
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.testName, func(t *testing.T) {
+			id, found := firstRunningBrokerOutsideSpec(tt.runningBrokers, tt.desiredBrokers)
+			assert.Equal(t, tt.wantFound, found)
+			assert.Equal(t, tt.wantID, id)
+		})
+	}
+}
+
 func TestGetServerPasswordKeysAndUsers(t *testing.T) { //nolint funlen
 	t.Parallel()
 	testCases := []struct {

--- a/tests/e2e/const.go
+++ b/tests/e2e/const.go
@@ -87,7 +87,8 @@ const (
 	contourName     = "contour"
 
 	// Kubernetes resource kinds.
-	podsResource = "pods"
+	podsResource       = "pods"
+	configMapsResource = "configmaps"
 
 	// Common string values and CLI flags/keys.
 	falseString   = "false"

--- a/tests/e2e/k8s.go
+++ b/tests/e2e/k8s.go
@@ -483,6 +483,12 @@ func deleteK8sResourceNoErrNotFound(kubectlOptions k8s.KubectlOptions, timeout t
 	return err
 }
 
+func deleteK8sCRDNoErrNotFound(kubectlOptions k8s.KubectlOptions, crdName string) error {
+	clusterScopedOptions := kubectlOptions
+	clusterScopedOptions.Namespace = ""
+	return deleteK8sResourceNoErrNotFound(clusterScopedOptions, defaultDeletionTimeout, crdKind, crdName)
+}
+
 // applyK8sResourceManifestFromString applies the specified manifest in string format to the provided
 // kubectl context and namespace.
 func applyK8sResourceManifestFromString(kubectlOptions k8s.KubectlOptions, manifest string) error {

--- a/tests/e2e/kafkacluster_brokers.go
+++ b/tests/e2e/kafkacluster_brokers.go
@@ -1,0 +1,83 @@
+// Copyright 2026 Adobe. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build e2e
+
+package e2e
+
+import (
+	"encoding/json"
+
+	"github.com/gruntwork-io/terratest/modules/k8s"
+
+	"github.com/banzaicloud/koperator/api/v1beta1"
+)
+
+// patchKafkaClusterBrokers fetches the running KafkaCluster CR, applies mutate to its current spec.brokers,
+// and patches only that field back - leaving every other field untouched. The broker-removal test previously
+// applied a second manifest to change broker count; besides the removal itself, that manifest can silently
+// carry unrelated drift (e.g. simplekafkacluster.yaml's headlessServiceEnabled: false, which raced the
+// operator's headless Service teardown against an in-flight broker removal).
+// Patching only spec.brokers cannot introduce that kind of unrelated drift.
+func patchKafkaClusterBrokers(kubectlOptions k8s.KubectlOptions, clusterName string, mutate func([]v1beta1.Broker) []v1beta1.Broker) error {
+	raw, err := runKubectlSilent(kubectlOptions, "get", "kafkacluster", clusterName, "-o", "json")
+	if err != nil {
+		return err
+	}
+
+	var current struct {
+		Spec struct {
+			Brokers []v1beta1.Broker `json:"brokers"`
+		} `json:"spec"`
+	}
+	if err := json.Unmarshal([]byte(raw), &current); err != nil {
+		return err
+	}
+
+	mergePatch, err := json.Marshal(map[string]any{
+		"spec": map[string]any{
+			"brokers": mutate(current.Spec.Brokers),
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	_, err = runKubectlSilent(kubectlOptions, "patch", "kafkacluster", clusterName, "--type=merge", "-p", string(mergePatch))
+	return err
+}
+
+// removeKafkaClusterBrokers patches spec.brokers to exclude the given IDs. See patchKafkaClusterBrokers.
+func removeKafkaClusterBrokers(kubectlOptions k8s.KubectlOptions, clusterName string, brokerIDsToRemove ...int32) error {
+	remove := make(map[int32]bool, len(brokerIDsToRemove))
+	for _, id := range brokerIDsToRemove {
+		remove[id] = true
+	}
+	return patchKafkaClusterBrokers(kubectlOptions, clusterName, func(brokers []v1beta1.Broker) []v1beta1.Broker {
+		remaining := make([]v1beta1.Broker, 0, len(brokers))
+		for _, broker := range brokers {
+			if !remove[broker.Id] {
+				remaining = append(remaining, broker)
+			}
+		}
+		return remaining
+	})
+}
+
+// addKafkaClusterBroker patches spec.brokers to append newBroker. See patchKafkaClusterBrokers.
+func addKafkaClusterBroker(kubectlOptions k8s.KubectlOptions, clusterName string, newBroker v1beta1.Broker) error {
+	return patchKafkaClusterBrokers(kubectlOptions, clusterName, func(brokers []v1beta1.Broker) []v1beta1.Broker {
+		return append(brokers, newBroker)
+	})
+}

--- a/tests/e2e/koperator_suite_test.go
+++ b/tests/e2e/koperator_suite_test.go
@@ -93,6 +93,7 @@ var _ = ginkgo.When("Testing e2e test altogether", ginkgo.Ordered, func() {
 	testInstallKafkaCluster("../../config/samples/kraft/simplekafkacluster_kraft.yaml")
 	testProduceConsumeInternal()
 	testJmxExporter()
+	testKRaftBrokerScaling()
 	testUninstallKafkaCluster()
 	testUninstall()
 	snapshotClusterAndCompare(snapshottedInfo)

--- a/tests/e2e/test_broker_removal.go
+++ b/tests/e2e/test_broker_removal.go
@@ -74,9 +74,10 @@ func testBatchedBrokerRemoval() bool {
 			}, batchedBrokerRemovalTimeout, batchedBrokerRemovalPollInterval).Should(gomega.BeTrue())
 		})
 
-		ginkgo.It("Applying 3-broker manifest to trigger removal of brokers 3 and 4", func() {
-			ginkgo.By("Patching KafkaCluster to remove brokers 3 and 4")
-			applyK8sResourceManifest(kubectlOptions, "../../config/samples/simplekafkacluster.yaml")
+		ginkgo.It("Removing brokers 3 and 4 from the running KafkaCluster", func() {
+			ginkgo.By("Fetching the running KafkaCluster and patching out brokers 3 and 4")
+			err := removeKafkaClusterBrokers(kubectlOptions, kafkaClusterName, 3, 4)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		})
 
 		ginkgo.It("Waiting for exactly one remove_broker CruiseControlOperation to be created", func() {

--- a/tests/e2e/test_kraft_broker_scaling.go
+++ b/tests/e2e/test_kraft_broker_scaling.go
@@ -1,0 +1,302 @@
+// Copyright 2026 Adobe. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"sort"
+	"strings"
+
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	ginkgo "github.com/onsi/ginkgo/v2"
+	gomega "github.com/onsi/gomega"
+
+	"github.com/banzaicloud/koperator/api/v1alpha1"
+	"github.com/banzaicloud/koperator/api/v1beta1"
+)
+
+// testKRaftBrokerScaling upscales a KRaft cluster from 3 broker-only nodes to 4 (add broker 103) and then
+// downscales it back to 3, asserting Cruise Control drives each direction with exactly one
+// add_broker / remove_broker operation, the broker-only node set tracks the spec by exact id, and the 3
+// controller-only nodes (ids 0,1,2) are never touched (controller-only nodes are not CC brokers). The
+// assertions check exact broker/controller ids - not just pod counts - so a manifest that silently swaps
+// ids (rather than adding a single broker) would fail instead of passing green.
+//
+// This is the regression test for #301, and it deliberately exercises BOTH directions:
+//   - UPSCALE is the case a "stop hashing capacity.json" fix would have silently broken: the capacity roll
+//     is what loads the new broker's exact capacity into CC, so the fix must keep rolling on add and
+//     sequence the add_broker op after the roll settles.
+//   - DOWNSCALE is the case that stalled on master: the pre-downscale capacity roll kept CC un-ready so the
+//     remove_broker op was never created.
+func testKRaftBrokerScaling() bool {
+	return ginkgo.When("KRaft broker scaling: upscale then downscale, controllers untouched", func() {
+		var kubectlOptions k8s.KubectlOptions
+		var err error
+
+		ginkgo.It("Acquiring K8s config and context", func() {
+			kubectlOptions, err = kubectlOptionsForCurrentContext()
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			kubectlOptions.Namespace = koperatorLocalHelmDescriptor.Namespace
+		})
+
+		ginkgo.It("Waiting for Cruise Control to be ready and settled before upscale", func() {
+			ginkgo.By("Ensuring the KafkaCluster is running")
+			gomega.Expect(waitForKafkaClusterWithPodStatusCheck(kubectlOptions, kafkaClusterName, kafkaClusterResourceReadinessTimeout)).NotTo(gomega.HaveOccurred())
+			ginkgo.By("Waiting until no Cruise Control operation is in flight (initial rebalance finished)")
+			gomega.Eventually(context.Background(), func() (bool, error) {
+				return hasNoInFlightCruiseControlOperation(kubectlOptions)
+			}, batchedBrokerRemovalTimeout, batchedBrokerRemovalPollInterval).Should(gomega.BeTrue())
+			ginkgo.By("Waiting until the Cruise Control Deployment is fully rolled out (single Ready replica)")
+			gomega.Eventually(context.Background(), func() (bool, error) {
+				return isCruiseControlDeploymentRolledOut(kubectlOptions)
+			}, batchedBrokerRemovalTimeout, batchedBrokerRemovalPollInterval).Should(gomega.BeTrue())
+		})
+
+		ginkgo.It("Asserting the cluster starts with broker-only nodes 100,101,102 and controllers 0,1,2", func() {
+			ids, err := brokerPodIDs(kubectlOptions)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(ids).To(gomega.ConsistOf("100", "101", "102"), "unexpected broker-only ids before scaling")
+			ids, err = controllerPodIDs(kubectlOptions)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(ids).To(gomega.ConsistOf("0", "1", "2"), "unexpected controller-only ids before scaling")
+		})
+
+		// --- Upscale: add broker 103 ---
+
+		ginkgo.It("Adding broker 103 to the running KafkaCluster", func() {
+			ginkgo.By("Fetching the running KafkaCluster and adding broker 103")
+			// Matches the "broker" config group simplekafkacluster_kraft.yaml assigns brokers 100-102.
+			err := addKafkaClusterBroker(kubectlOptions, kafkaClusterName, v1beta1.Broker{Id: 103, BrokerConfigGroup: "broker"})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("Waiting for exactly one add_broker CruiseControlOperation", func() {
+			gomega.Eventually(context.Background(), func() (bool, error) {
+				return hasExactlyNBrokerOperations(kubectlOptions, v1alpha1.OperationAddBroker, 1)
+			}, batchedBrokerRemovalTimeout, batchedBrokerRemovalPollInterval).Should(gomega.BeTrue())
+		})
+
+		ginkgo.It("Waiting for broker 103 to join (broker-only nodes 100,101,102,103) and the cluster to be healthy", func() {
+			gomega.Eventually(context.Background(), func() ([]string, error) {
+				return brokerPodIDs(kubectlOptions)
+			}, batchedBrokerRemovalTimeout, batchedBrokerRemovalPollInterval).Should(gomega.ConsistOf("100", "101", "102", "103"))
+			gomega.Expect(waitForKafkaClusterWithPodStatusCheck(kubectlOptions, kafkaClusterName, kafkaClusterResourceReadinessTimeout)).NotTo(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("Asserting controllers are untouched after upscale (still exactly controllers 0,1,2)", func() {
+			ids, err := controllerPodIDs(kubectlOptions)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(ids).To(gomega.ConsistOf("0", "1", "2"), "controller-only nodes must not be affected by an upscale")
+		})
+
+		ginkgo.It("Asserting Cruise Control's capacity.json gained a real entry for the added broker 103", func() {
+			// add_broker runs with AllowCapacityEstimation=true, so a healthy add alone does not prove the
+			// operator wrote broker 103's capacity - CC could have estimated it. Assert the per-broker entry
+			// is actually present so a regression that stops generating/rolling capacity.json is caught.
+			gomega.Eventually(context.Background(), func() ([]string, error) {
+				return cruiseControlCapacityBrokerIDs(kubectlOptions)
+			}, batchedBrokerRemovalTimeout, batchedBrokerRemovalPollInterval).Should(gomega.ContainElement("103"),
+				"broker 103's capacity must be written to capacity.json, not left to CC estimation")
+		})
+
+		ginkgo.It("Asserting the running CC pod's template carries the current capacity.json hash", func() {
+			// The per-broker entry existing in the ConfigMap is not enough: the capacity must also have been
+			// hashed into the pod template and rolled out. Assert the hash on the *running* CC pod (not just
+			// the Deployment template) matches the current capacity.json - so a Ready CC pod started from that
+			// capacity. It does not by itself prove the CC process re-read the file, but combined with a Ready
+			// pod it is strong evidence the roll landed rather than add_broker relying on capacity estimation.
+			gomega.Eventually(context.Background(), func() (bool, error) {
+				return runningCruiseControlPodHasCurrentCapacityHash(kubectlOptions)
+			}, batchedBrokerRemovalTimeout, batchedBrokerRemovalPollInterval).Should(gomega.BeTrue(),
+				"the running CC pod's template must carry the hash of the current capacity.json")
+		})
+
+		// --- Downscale: remove broker 103 ---
+
+		ginkgo.It("Waiting for Cruise Control to be settled again before downscale", func() {
+			gomega.Eventually(context.Background(), func() (bool, error) {
+				return hasNoInFlightCruiseControlOperation(kubectlOptions)
+			}, batchedBrokerRemovalTimeout, batchedBrokerRemovalPollInterval).Should(gomega.BeTrue())
+			gomega.Eventually(context.Background(), func() (bool, error) {
+				return isCruiseControlDeploymentRolledOut(kubectlOptions)
+			}, batchedBrokerRemovalTimeout, batchedBrokerRemovalPollInterval).Should(gomega.BeTrue())
+		})
+
+		ginkgo.It("Removing broker 103 from the running KafkaCluster", func() {
+			ginkgo.By("Fetching the running KafkaCluster and patching out broker 103")
+			err := removeKafkaClusterBrokers(kubectlOptions, kafkaClusterName, 103)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("Waiting for exactly one remove_broker CruiseControlOperation", func() {
+			gomega.Eventually(context.Background(), func() (bool, error) {
+				return hasExactlyNBrokerOperations(kubectlOptions, v1alpha1.OperationRemoveBroker, 1)
+			}, batchedBrokerRemovalTimeout, batchedBrokerRemovalPollInterval).Should(gomega.BeTrue())
+		})
+
+		ginkgo.It("Waiting for broker 103 to be removed (broker-only nodes back to 100,101,102) and the cluster to be healthy", func() {
+			gomega.Eventually(context.Background(), func() ([]string, error) {
+				return brokerPodIDs(kubectlOptions)
+			}, batchedBrokerRemovalTimeout, batchedBrokerRemovalPollInterval).Should(gomega.ConsistOf("100", "101", "102"))
+			gomega.Expect(waitForKafkaClusterWithPodStatusCheck(kubectlOptions, kafkaClusterName, kafkaClusterResourceReadinessTimeout)).NotTo(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("Asserting controllers are untouched after downscale (still exactly controllers 0,1,2)", func() {
+			ids, err := controllerPodIDs(kubectlOptions)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(ids).To(gomega.ConsistOf("0", "1", "2"), "controller-only nodes must not be affected by a downscale")
+		})
+
+		ginkgo.It("Asserting Cruise Control's capacity.json dropped the removed broker 103", func() {
+			// Once broker 103's pod is gone and it leaves the status, the merge stops preserving its entry
+			// and capacity.json shrinks back - the departing broker's capacity must not linger indefinitely.
+			gomega.Eventually(context.Background(), func() ([]string, error) {
+				return cruiseControlCapacityBrokerIDs(kubectlOptions)
+			}, batchedBrokerRemovalTimeout, batchedBrokerRemovalPollInterval).ShouldNot(gomega.ContainElement("103"),
+				"broker 103's capacity must be removed from capacity.json once it is fully downscaled")
+		})
+	})
+}
+
+// hasExactlyNBrokerOperations returns true when exactly n CruiseControlOperations whose current task is the
+// given operation type exist in the namespace.
+func hasExactlyNBrokerOperations(kubectlOptions k8s.KubectlOptions, operation v1alpha1.CruiseControlTaskOperation, n int) (bool, error) {
+	ops, err := getK8sResources(kubectlOptions,
+		[]string{"cruisecontroloperation"},
+		"",
+		"",
+		"-o", "jsonpath={range .items[*]}{.status.currentTask.operation}{'\\n'}{end}",
+	)
+	if err != nil {
+		return false, err
+	}
+	count := 0
+	for _, op := range ops {
+		if op == string(operation) {
+			count++
+		}
+	}
+	return count == n, nil
+}
+
+// brokerPodIDs returns the sorted broker ids (brokerId label) of the Running broker-only pods
+// (isControllerNode=false) in the namespace.
+func brokerPodIDs(kubectlOptions k8s.KubectlOptions) ([]string, error) {
+	return podBrokerIDs(kubectlOptions, kafkaLabelSelectorBrokers)
+}
+
+// controllerPodIDs returns the sorted broker ids (brokerId label) of the Running controller-only pods
+// (isControllerNode=true) in the namespace.
+func controllerPodIDs(kubectlOptions k8s.KubectlOptions) ([]string, error) {
+	return podBrokerIDs(kubectlOptions, kafkaLabelSelectorControllers)
+}
+
+// podBrokerIDs returns the sorted brokerId label values of the Running pods matching roleSelector. Asserting
+// on the exact id set (rather than just a pod count) is what lets the scaling test catch a manifest that
+// swaps ids instead of adding/removing a single node.
+func podBrokerIDs(kubectlOptions k8s.KubectlOptions, roleSelector string) ([]string, error) {
+	ids, err := getK8sResources(kubectlOptions,
+		[]string{podsResource},
+		v1beta1.KafkaCRLabelKey+"="+kafkaClusterName+","+roleSelector,
+		"",
+		"--field-selector=status.phase=Running",
+		"-o", "jsonpath={range .items[*]}{.metadata.labels.brokerId}{'\\n'}{end}",
+	)
+	if err != nil {
+		return nil, err
+	}
+	sort.Strings(ids)
+	return ids, nil
+}
+
+// cruiseControlCapacityBrokerIDs returns the sorted broker ids present in Cruise Control's capacity.json
+// (read from the CC ConfigMap). Asserting a scaled broker appears/disappears here proves the operator
+// actually generated and rolled its per-broker capacity, independently of add_broker succeeding via Cruise
+// Control's capacity estimation (AllowCapacityEstimation) - so a regression that stops writing per-broker
+// capacity is caught rather than masked by estimation.
+func cruiseControlCapacityBrokerIDs(kubectlOptions k8s.KubectlOptions) ([]string, error) {
+	lines, err := getK8sResources(kubectlOptions,
+		[]string{configMapsResource},
+		v1beta1.KafkaCRLabelKey+"="+kafkaClusterName+",app=cruisecontrol",
+		"",
+		"-o", "jsonpath={range .items[*]}{.data.capacity\\.json}{end}",
+	)
+	if err != nil {
+		return nil, err
+	}
+	raw := strings.TrimSpace(strings.Join(lines, "\n"))
+	if raw == "" {
+		return nil, nil
+	}
+	var parsed struct {
+		BrokerCapacities []struct {
+			BrokerID string `json:"brokerId"`
+		} `json:"brokerCapacities"`
+	}
+	if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
+		return nil, err
+	}
+	ids := make([]string, 0, len(parsed.BrokerCapacities))
+	for _, bc := range parsed.BrokerCapacities {
+		ids = append(ids, bc.BrokerID)
+	}
+	sort.Strings(ids)
+	return ids, nil
+}
+
+// runningCruiseControlPodHasCurrentCapacityHash reports whether the Running CC pod's template carries the hash
+// of the CC ConfigMap's current capacity.json (the annotation koperator stamps in GeneratePodAnnotations).
+// Reading the pod (not the Deployment template) shows what the currently-running CC actually started from, so
+// with a Ready pod it is evidence the capacity roll landed rather than add_broker relying on capacity
+// estimation. The hash is computed the same way the operator does (hex(sha256(capacity.json))). During a
+// rollout there may briefly be two CC pods with different hashes; requiring an exact single-value match makes
+// this true only once the roll has settled to the current-capacity pod.
+func runningCruiseControlPodHasCurrentCapacityHash(kubectlOptions k8s.KubectlOptions) (bool, error) {
+	ccSelector := v1beta1.KafkaCRLabelKey + "=" + kafkaClusterName + ",app=cruisecontrol"
+
+	cmLines, err := getK8sResources(kubectlOptions,
+		[]string{configMapsResource},
+		ccSelector,
+		"",
+		"-o", "jsonpath={range .items[*]}{.data.capacity\\.json}{end}",
+	)
+	if err != nil {
+		return false, err
+	}
+	// Do not trim the capacity.json - it is hashed byte-for-byte by the operator.
+	capacityJSON := strings.Join(cmLines, "\n")
+	if capacityJSON == "" {
+		return false, nil
+	}
+
+	podLines, err := getK8sResources(kubectlOptions,
+		[]string{podsResource},
+		ccSelector,
+		"",
+		"--field-selector=status.phase=Running",
+		"-o", "jsonpath={range .items[*]}{.metadata.annotations.cruiseControlCapacity\\.json}{'\\n'}{end}",
+	)
+	if err != nil {
+		return false, err
+	}
+	runningHash := strings.TrimSpace(strings.Join(podLines, "\n"))
+	sum := sha256.Sum256([]byte(capacityJSON))
+	return runningHash != "" && runningHash == hex.EncodeToString(sum[:]), nil
+}

--- a/tests/e2e/uninstall.go
+++ b/tests/e2e/uninstall.go
@@ -63,7 +63,7 @@ func requireUninstallingKoperatorHelmChart(kubectlOptions k8s.KubectlOptions) {
 func requireRemoveKoperatorCRDs(kubectlOptions k8s.KubectlOptions) {
 	ginkgo.It("Removing koperator CRDs", func() {
 		for _, crd := range koperatorCRDs() {
-			err := deleteK8sResourceNoErrNotFound(kubectlOptions, defaultDeletionTimeout, crdKind, crd)
+			err := deleteK8sCRDNoErrNotFound(kubectlOptions, crd)
 			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 		}
 	})
@@ -109,7 +109,7 @@ func requireUninstallingZookeeperOperatorHelmChart(kubectlOptions k8s.KubectlOpt
 func requireRemoveZookeeperOperatorCRDs(kubectlOptions k8s.KubectlOptions) {
 	ginkgo.It("Removing zookeeper-operator CRDs", func() {
 		for _, crd := range dependencyCRDs.Zookeeper() {
-			err := deleteK8sResourceNoErrNotFound(kubectlOptions, defaultDeletionTimeout, crdKind, crd)
+			err := deleteK8sCRDNoErrNotFound(kubectlOptions, crd)
 			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 		}
 	})
@@ -156,7 +156,7 @@ func requireUninstallingPrometheusOperatorHelmChart(kubectlOptions k8s.KubectlOp
 func requireRemovePrometheusOperatorCRDs(kubectlOptions k8s.KubectlOptions) {
 	ginkgo.It("Removing prometheus-operator CRDs", func() {
 		for _, crd := range dependencyCRDs.Prometheus() {
-			err := deleteK8sResourceNoErrNotFound(kubectlOptions, defaultDeletionTimeout, crdKind, crd)
+			err := deleteK8sCRDNoErrNotFound(kubectlOptions, crd)
 			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 		}
 	})
@@ -204,7 +204,7 @@ func requireRemoveCertManagerCRDs(kubectlOptions k8s.KubectlOptions) {
 	ginkgo.It("Removing cert-manager CRDs", func() {
 		// First, try to remove CRDs detected by the dependencyCRDs system
 		for _, crd := range dependencyCRDs.CertManager() {
-			err := deleteK8sResourceNoErrNotFound(kubectlOptions, defaultDeletionTimeout, crdKind, crd)
+			err := deleteK8sCRDNoErrNotFound(kubectlOptions, crd)
 			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 		}
 
@@ -219,7 +219,7 @@ func requireRemoveCertManagerCRDs(kubectlOptions k8s.KubectlOptions) {
 		}
 
 		for _, crd := range knownCertManagerCRDs {
-			err := deleteK8sResourceNoErrNotFound(kubectlOptions, defaultDeletionTimeout, crdKind, crd)
+			err := deleteK8sCRDNoErrNotFound(kubectlOptions, crd)
 			if err != nil && !isKubectlNotFoundError(err) {
 				ginkgo.By(fmt.Sprintf("Warning: Failed to delete CRD %s: %v", crd, err))
 			}
@@ -276,7 +276,7 @@ func requireUninstallingContourHelmChart(kubectlOptions k8s.KubectlOptions) {
 func requireRemoveContourCRDs(kubectlOptions k8s.KubectlOptions) {
 	ginkgo.It("Removing Contour Ingress Controller CRDs", func() {
 		for _, crd := range dependencyCRDs.Contour() {
-			err := deleteK8sResourceNoErrNotFound(kubectlOptions, defaultDeletionTimeout, crdKind, crd)
+			err := deleteK8sCRDNoErrNotFound(kubectlOptions, crd)
 			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 		}
 	})


### PR DESCRIPTION
## Summary
- defer headless/non-headless Service cleanup while a running broker pod is outside spec.brokers
- add focused unit coverage for the outside-spec running broker guard
- update broker-scaling e2e paths to patch spec.brokers directly instead of applying independent manifests with unrelated drift
- add the KRaft broker upscale/downscale e2e path using addKafkaClusterBroker/removeKafkaClusterBrokers
- remove the universal capacity default from the KRaft sample so capacity.json actually changes during scaling
- avoid passing namespaces to cluster-scoped CRD deletes in e2e uninstall cleanup, removing noisy kubectl warnings without changing generic delete behavior


## Testing
- go test ./pkg/resources/kafka
- (cd tests/e2e && go test -tags=e2e . -run '^$')