### PR TITLE
fix(renovate): update zookeeper image tag versioning

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -167,7 +167,17 @@
       "matchCurrentValue": "/^\\d+\\.\\d+\\.\\d+-ado?be-\\d+$/",
       "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(?:-ado?be-(?<build>\\d+))?$",
       "description": "Self-scoping: applies to ANY docker dep whose current pin is <semver>-adbe|adobe-<yyyymmdd> (cruise-control uses 'adbe', zookeeper-operator 'adobe'; new adobe-fork images inherit this with no config change). Default docker versioning treats that suffix as an immutable compatibility string, so newer daily builds are never offered; capturing the date as a purely-numeric 'build' (handled like patch) makes e.g. 3.0.3-adbe-20250804 -> 3.0.3-adbe-20260722 and 0.2.15-adobe-20250923 track their newest build. matchCurrentValue requires the suffix, so only these deps are touched; the versioning's suffix is optional so the same image can still publish a plain-semver tag. Trailing '$' excludes '-rc'."
-       },
+    },
+    {
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchPackageNames": [
+        "ghcr.io/adobe/zookeeper-operator/zookeeper"
+      ],
+      "allowedVersions": "/^\\d+\\.\\d+\\.\\d+-\\d+\\.\\d+\\.\\d+-adobe-\\d{8}$/",
+      "versioning": "loose"
+    },
     {
       "matchPackageNames": [
         "ghcr.io/adobe/koperator/kafka"


### PR DESCRIPTION
## Summary
- Add a package-specific Renovate rule for ghcr.io/adobe/zookeeper-operator/zookeeper tags.
- Use `loose` versioning with an `allowedVersions` guard for the stable Adobe tag shape.
- Keep experimental tag variants such as logging-test or alternate adobe separators excluded.

## Verification
- jq empty renovate.json
- env LOG_LEVEL=debug npx --yes -p node@24.11.0 -p renovate@44.33.2 renovate --platform=local --dry-run=full --include-paths=tests/e2e/templates/zookeeper_cluster.yaml.tmpl --enabled-managers=custom.regex

Dry-run result: Renovate proposed 3.8.4-0.2.15-adobe-20250923 -> 3.8.4-0.2.15-adobe-20260818 for tests/e2e/templates/zookeeper_cluster.yaml.tmpl.