### PR TITLE
fix(cruisecontrol): re-validate remove_disks log dirs before retrying

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -136,4 +136,14 @@ jobs:
           kubectl -n kafka get deploy,rs -l app=cruisecontrol -o wide
           kubectl -n kafka describe deploy -l app=cruisecontrol
           echo "::endgroup::"
+          # Disk-removal stalls can also leave orphaned PVCs behind: a broker's old volume
+          # gets deleted once Cruise Control confirms removal, but the delete only completes
+          # once the pvc-protection finalizer clears (i.e. nothing still mounts it). `get -o wide`
+          # surfaces a stuck `Terminating` STATUS at a glance; `describe` shows the finalizers/
+          # deletionTimestamp and any FailedAttachVolume/VolumeFailedDelete events explaining why.
+          echo "::group::persistentvolumeclaims (kafka)"
+          kubectl -n kafka get pvc -o wide
+          echo "----- describe pvc (kafka) -----"
+          kubectl -n kafka describe pvc
+          echo "::endgroup::"
           exit 0

--- a/controllers/cruisecontroloperation_controller.go
+++ b/controllers/cruisecontroloperation_controller.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -224,6 +225,12 @@ func (r *CruiseControlOperationReconciler) Reconcile(ctx context.Context, reques
 		return requeueAfter(defaultRequeueIntervalInSeconds)
 	}
 
+	// A retried OperationRemoveDisks replays a stale parameter snapshot unchanged; skip resubmission
+	// this cycle if Cruise Control's current state no longer agrees with it. See staleRemoveDisksRetry.
+	if r.staleRemoveDisksRetry(ctx, log, ccOperationExecution) {
+		return requeueAfter(defaultRequeueIntervalInSeconds)
+	}
+
 	log.Info("executing Cruise Control task", "operation", ccOperationExecution.CurrentTaskOperation(), "parameters", ccOperationExecution.CurrentTaskParameters())
 	// Executing operation
 	cruseControlTaskResult, err := r.executeOperation(ctx, ccOperationExecution)
@@ -290,6 +297,49 @@ func (r *CruiseControlOperationReconciler) executeOperation(ctx context.Context,
 		err = errors.NewWithDetails("Cruise Control operation not supported", "name", ccOperationExecution.GetName(), "namespace", ccOperationExecution.GetNamespace(), "operation", ccOperationExecution.CurrentTaskOperation(), "parameters", ccOperationExecution.CurrentTaskParameters())
 	}
 	return cruseControlTaskResult, err
+}
+
+// staleRemoveDisksRetry reports whether a retried OperationRemoveDisks should be skipped this cycle
+// because Cruise Control's current view of broker log dirs no longer matches the request's frozen
+// brokerid_and_logdirs snapshot (e.g. a Cruise Control restart reset its state while the request was in
+// flight). We don't trim the request down to just the still-valid pairs and resubmit it: Cruise Control
+// reports success/failure for the whole operation, so submitting a partial request could make the
+// dropped broker/log-dir's disk-removal status be falsely marked succeeded once the trimmed request
+// completes. Skipping costs one retry backoff interval; a later cycle resubmits once Cruise Control's
+// view catches back up.
+func (r *CruiseControlOperationReconciler) staleRemoveDisksRetry(ctx context.Context, log logr.Logger, ccOperationExecution *banzaiv1alpha1.CruiseControlOperation) bool {
+	if ccOperationExecution.CurrentTaskOperation() != banzaiv1alpha1.OperationRemoveDisks ||
+		ccOperationExecution.CurrentTaskState() != banzaiv1beta1.CruiseControlTaskCompletedWithError {
+		return false
+	}
+
+	logDirsByBroker, err := r.scaler.LogDirsByBroker(ctx)
+	if err != nil {
+		log.Error(err, "failed to refresh broker log dirs before retrying remove_disks", "name", ccOperationExecution.GetName(), "namespace", ccOperationExecution.GetNamespace())
+		return true
+	}
+	if removeDisksParamsCurrentlyOnline(ccOperationExecution.CurrentTaskParameters(), logDirsByBroker) {
+		return false
+	}
+
+	log.Info("skipping remove_disks retry: Cruise Control no longer reports all requested log dirs online for their broker",
+		"name", ccOperationExecution.GetName(), "namespace", ccOperationExecution.GetNamespace(), "parameters", ccOperationExecution.CurrentTaskParameters())
+	return true
+}
+
+// removeDisksParamsCurrentlyOnline returns true if every (brokerID, logDir) pair encoded in the
+// brokerid_and_logdirs parameter is still reported online for that broker in logDirsByBroker.
+func removeDisksParamsCurrentlyOnline(params map[string]string, logDirsByBroker map[string]map[scale.LogDirState][]string) bool {
+	for _, pair := range strings.Split(params[scale.ParamBrokerIDAndLogDirs], ",") {
+		brokerID, logDir, ok := strings.Cut(pair, "-")
+		if !ok {
+			continue
+		}
+		if !slices.Contains(logDirsByBroker[brokerID][scale.LogDirStateOnline], logDir) {
+			return false
+		}
+	}
+	return true
 }
 
 func sortOperations(ccOperations []*banzaiv1alpha1.CruiseControlOperation) map[string][]*banzaiv1alpha1.CruiseControlOperation {

--- a/controllers/cruisecontroloperation_controller_test.go
+++ b/controllers/cruisecontroloperation_controller_test.go
@@ -116,6 +116,71 @@ func TestSortOperations(t *testing.T) {
 	}
 }
 
+// TestRemoveDisksParamsCurrentlyOnline exercises the re-validation predicate used before retrying a
+// stalled OperationRemoveDisks task. The task's brokerid_and_logdirs parameter is a snapshot frozen at
+// operation-creation time and replayed unchanged on every retry; if Cruise Control's own view of a
+// broker's online log dirs has since diverged from that snapshot (e.g. because Cruise Control restarted
+// and rebuilt its state while the request was created), blindly resubmitting the frozen snapshot repeats
+// the same permanent rejection forever. This predicate re-checks the snapshot against a freshly fetched
+// LogDirsByBroker result so a retry can tell whether Cruise Control's current state still agrees with it.
+func TestRemoveDisksParamsCurrentlyOnline(t *testing.T) {
+	testCases := []struct {
+		testName        string
+		params          map[string]string
+		logDirsByBroker map[string]map[scale.LogDirState][]string
+		expectedValid   bool
+	}{
+		{
+			testName: "all requested log dirs are still online for their broker",
+			params: map[string]string{
+				scale.ParamBrokerIDAndLogDirs: "0-/kafka-logs2/kafka,1-/kafka-logs2/kafka",
+			},
+			logDirsByBroker: map[string]map[scale.LogDirState][]string{
+				"0": {scale.LogDirStateOnline: {"/kafka-logs1/kafka", "/kafka-logs2/kafka"}},
+				"1": {scale.LogDirStateOnline: {"/kafka-logs2/kafka"}},
+			},
+			expectedValid: true,
+		},
+		{
+			testName: "a requested log dir is no longer online for its broker",
+			params: map[string]string{
+				scale.ParamBrokerIDAndLogDirs: "0-/kafka-logs2/kafka,1-/kafka-logs2/kafka",
+			},
+			logDirsByBroker: map[string]map[scale.LogDirState][]string{
+				// Broker 0 no longer reports this log dir online (e.g. after a Cruise Control restart
+				// reset its view) even though it was online when this snapshot was originally taken.
+				"0": {scale.LogDirStateOnline: {"/kafka-logs1/kafka"}},
+				"1": {scale.LogDirStateOnline: {"/kafka-logs2/kafka"}},
+			},
+			expectedValid: false,
+		},
+		{
+			testName: "the broker is entirely absent from Cruise Control's current view",
+			params: map[string]string{
+				scale.ParamBrokerIDAndLogDirs: "0-/kafka-logs2/kafka",
+			},
+			logDirsByBroker: map[string]map[scale.LogDirState][]string{},
+			expectedValid:   false,
+		},
+		{
+			testName: "a requested log dir is reported offline rather than online",
+			params: map[string]string{
+				scale.ParamBrokerIDAndLogDirs: "0-/kafka-logs2/kafka",
+			},
+			logDirsByBroker: map[string]map[scale.LogDirState][]string{
+				"0": {scale.LogDirStateOffline: {"/kafka-logs2/kafka"}},
+			},
+			expectedValid: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.testName, func(t *testing.T) {
+			assert.Equal(t, tc.expectedValid, removeDisksParamsCurrentlyOnline(tc.params, tc.logDirsByBroker))
+		})
+	}
+}
+
 // TestGetStatusDoesNotPanicWhenStatusNil exercises the res.Status==nil branch of
 // getStatus. On that path statusOperation is always nil (it is only assigned in the
 // early-returning statusOperation!=nil branch), so the error-wraps must reference the

--- a/tests/e2e/test_config_change_with_disk_removal.go
+++ b/tests/e2e/test_config_change_with_disk_removal.go
@@ -95,7 +95,10 @@ func testConfigChangeWithDiskRemoval() bool {
 			// The core regression assertion: a config change while a disk removal is pending must not
 			// wedge the reconcile. If the deadlock regressed, the cluster would stay in
 			// ClusterRollingUpgrading and this wait would time out.
-			err := waitForKafkaClusterWithPodStatusCheck(kubectlOptions, kafkaClusterName, kafkaClusterResourceReadinessTimeout)
+			// Use the scenario's own (longer) timeout budget, not the generic readiness one: the
+			// preceding steps already use configChangeDiskRemovalTimeout because this scenario can
+			// take long, and the final rolling restart this gates on is no faster.
+			err := waitForKafkaClusterWithPodStatusCheck(kubectlOptions, kafkaClusterName, configChangeDiskRemovalTimeout)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		})
 

--- a/tests/e2e/test_multidisk_removal.go
+++ b/tests/e2e/test_multidisk_removal.go
@@ -123,7 +123,10 @@ func testMultiDiskRemoval() bool {
 			// Disk removal rolls the broker pods, so their names change underneath us. Gate on
 			// the operator's own ClusterRunning state and re-resolve the live pod set each poll
 			// instead of `kubectl wait`-ing on a snapshot of pod names that get deleted mid-roll.
-			err := waitForKafkaClusterWithPodStatusCheck(kubectlOptions, kafkaClusterName, kafkaClusterResourceReadinessTimeout)
+			// Use the scenario's own (longer) timeout budget, not the generic readiness one: a
+			// rolling restart across all brokers with fresh PVC provisioning per broker can
+			// legitimately take longer than kafkaClusterResourceReadinessTimeout under CI load.
+			err := waitForKafkaClusterWithPodStatusCheck(kubectlOptions, kafkaClusterName, multidiskRemovalTimeout)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		})
 	})


### PR DESCRIPTION
OperationRemoveDisks retries replay a `brokerid_and_logdirs` snapshot frozen at operation-creation time; if Cruise Control's view diverges (e.g. a CC restart mid-race, see #301), the identical invalid request retries forever. Skip stale retries until CC's current state agrees with the snapshot again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)