### PR TITLE
fix(pvc-reconciler): scope PVC update diff check to patchable fields

### DIFF
--- a/controllers/kafkacluster_controller.go
+++ b/controllers/kafkacluster_controller.go
@@ -17,7 +17,6 @@ package controllers
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"reflect"
 	"time"
@@ -358,41 +357,6 @@ func (r *KafkaClusterReconciler) updateAndFetchLatest(ctx context.Context, clust
 	return cluster, nil
 }
 
-// ignoreMetadataFields returns a patch.CalculateOption that drops only the given fields
-// under metadata (e.g. "managedFields", "resourceVersion") instead of the whole metadata
-// object like patch.IgnoreField("metadata") does, so other metadata changes (labels,
-// annotations, etc.) still count toward the diff.
-func ignoreMetadataFields(fields ...string) patch.CalculateOption {
-	return func(current, modified []byte) ([]byte, []byte, error) {
-		current, err := deleteMetadataFields(current, fields...)
-		if err != nil {
-			return nil, nil, errors.WrapIf(err, "could not delete metadata fields from current byte sequence")
-		}
-
-		modified, err = deleteMetadataFields(modified, fields...)
-		if err != nil {
-			return nil, nil, errors.WrapIf(err, "could not delete metadata fields from modified byte sequence")
-		}
-
-		return current, modified, nil
-	}
-}
-
-func deleteMetadataFields(obj []byte, fields ...string) ([]byte, error) {
-	var objectMap map[string]interface{}
-	if err := json.Unmarshal(obj, &objectMap); err != nil {
-		return nil, errors.WrapIf(err, "could not unmarshal byte sequence")
-	}
-
-	if metadata, ok := objectMap["metadata"].(map[string]interface{}); ok {
-		for _, field := range fields {
-			delete(metadata, field)
-		}
-	}
-
-	return json.Marshal(objectMap)
-}
-
 // SetupKafkaClusterWithManager registers kafka cluster controller to the manager
 func SetupKafkaClusterWithManager(mgr ctrl.Manager, contourEnabled bool) *ctrl.Builder {
 	log := mgr.GetLogger()
@@ -424,7 +388,7 @@ func SetupKafkaClusterWithManager(mgr ctrl.Manager, contourEnabled bool) *ctrl.B
 			UpdateFunc: func(e event.UpdateEvent) bool {
 				switch newObj := e.ObjectNew.(type) {
 				case *corev1.Pod, *corev1.ConfigMap, *corev1.PersistentVolumeClaim:
-					patchResult, err := patch.DefaultPatchMaker.Calculate(e.ObjectOld, e.ObjectNew, patch.IgnoreStatusFields(), ignoreMetadataFields("managedFields", "resourceVersion"))
+					patchResult, err := patch.DefaultPatchMaker.Calculate(e.ObjectOld, e.ObjectNew, patch.IgnoreStatusFields(), patch.IgnoreMetadataFields("managedFields", "resourceVersion"))
 					if err != nil {
 						log.Error(err, "could not match objects", "kind", e.ObjectOld.GetObjectKind())
 					} else if patchResult.IsEmpty() {

--- a/pkg/resources/kafka/kafka.go
+++ b/pkg/resources/kafka/kafka.go
@@ -1229,9 +1229,10 @@ func (r *Reconciler) reconcileKafkaPvc(ctx context.Context, log logr.Logger, bro
 	brokersVolumesState := make(map[string]map[string]banzaiv1beta1.VolumeState)
 	var brokerIds []string
 	waitForDiskRemovalToFinish := false
+	desiredType := reflect.TypeOf(&corev1.PersistentVolumeClaim{})
+	log = log.WithValues("kind", desiredType)
 
 	for brokerId, desiredPvcs := range brokersDesiredPvcs {
-		desiredType := reflect.TypeOf(&corev1.PersistentVolumeClaim{})
 		brokerVolumesState := make(map[string]banzaiv1beta1.VolumeState)
 
 		pvcList := &corev1.PersistentVolumeClaimList{}
@@ -1242,8 +1243,6 @@ func (r *Reconciler) reconcileKafkaPvc(ctx context.Context, log logr.Logger, bro
 				map[string]string{banzaiv1beta1.BrokerIdLabelKey: brokerId},
 			),
 		)
-
-		log = log.WithValues("kind", desiredType)
 
 		err := r.List(ctx, pvcList,
 			client.InNamespace(r.KafkaCluster.GetNamespace()), matchingLabels)
@@ -1326,6 +1325,13 @@ func (r *Reconciler) reconcileKafkaPvc(ctx context.Context, log logr.Logger, bro
 				continue
 			}
 			if err == nil {
+				// Compute desire state (only patchable fields) before checking if the object needs to be updated.
+				resReq := desiredPvc.Spec.Resources.Requests
+				labels := desiredPvc.Labels
+				desiredPvc = currentPvc.DeepCopy()
+				desiredPvc.Spec.Resources.Requests = resReq
+				desiredPvc.Labels = labels
+
 				if k8sutil.CheckIfObjectUpdated(log, desiredType, currentPvc, desiredPvc) {
 					if err := patch.DefaultAnnotator.SetLastAppliedAnnotation(desiredPvc); err != nil {
 						return errors.WrapIf(err, "could not apply last state to annotation")
@@ -1336,16 +1342,10 @@ func (r *Reconciler) reconcileKafkaPvc(ctx context.Context, log logr.Logger, bro
 							"one can not reduce the size of a PVC", "kind", desiredType)
 					}
 
-					resReq := desiredPvc.Spec.Resources.Requests
-					labels := desiredPvc.Labels
-					desiredPvc = currentPvc.DeepCopy()
-					desiredPvc.Spec.Resources.Requests = resReq
-					desiredPvc.Labels = labels
-
 					if err := r.Update(ctx, desiredPvc); err != nil {
 						return errorfactory.New(errorfactory.APIFailure{}, err, "updating resource failed", "kind", desiredType)
 					}
-					log.Info("resource updated")
+					log.Info("resource updated", "name", desiredPvc.Name)
 				}
 			}
 		}

--- a/third_party/github.com/banzaicloud/k8s-objectmatcher/patch/deletenull.go
+++ b/third_party/github.com/banzaicloud/k8s-objectmatcher/patch/deletenull.go
@@ -57,6 +57,37 @@ func IgnoreField(field string) CalculateOption {
 	}
 }
 
+func IgnoreMetadataFields(fields ...string) CalculateOption {
+	return func(current, modified []byte) ([]byte, []byte, error) {
+		current, err := deleteMetadataFields(current, fields...)
+		if err != nil {
+			return nil, nil, errors.WrapIf(err, "could not delete metadata fields from current byte sequence")
+		}
+
+		modified, err = deleteMetadataFields(modified, fields...)
+		if err != nil {
+			return nil, nil, errors.WrapIf(err, "could not delete metadata fields from modified byte sequence")
+		}
+
+		return current, modified, nil
+	}
+}
+
+func deleteMetadataFields(obj []byte, fields ...string) ([]byte, error) {
+	var objectMap map[string]interface{}
+	if err := json.Unmarshal(obj, &objectMap); err != nil {
+		return nil, errors.WrapIf(err, "could not unmarshal byte sequence")
+	}
+
+	if metadata, ok := objectMap["metadata"].(map[string]interface{}); ok {
+		for _, field := range fields {
+			delete(metadata, field)
+		}
+	}
+
+	return json.Marshal(objectMap)
+}
+
 func IgnoreVolumeClaimTemplateTypeMetaAndStatus() CalculateOption {
 	return func(current, modified []byte) ([]byte, []byte, error) {
 		current, err := deleteVolumeClaimTemplateFields(current)


### PR DESCRIPTION


## Description

Previously reconcileKafkaPvc computed the effective desired PVC (current PVC with only resource requests and labels overlaid) after already calling CheckIfObjectUpdated against the full, unscoped desired object. This meant the update decision could be driven by fields that are never actually sent in the update, causing spurious diffs/updates unrelated to the real patchable state. Compute the scoped desired object first so the diff check and the subsequent update operate on the same object.

"kind" values was added to the log context for each PVC in the iteration, resulting in dupliacat entries for an event.

Moved IgnoreMetadataFields into the vendored k8s-objectmatcher patch package

## Type of Change
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
