### PR TITLE
fix(renovate): keep go.mod's go directive in sync with the golang docker image

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -130,6 +130,17 @@
       "description": "Disable Go module updates on master - handled by automated workflow: .github/workflows/update-go-deps.yml. gh-pages' go.mod is Hugo Modules (theme deps like docsy), not app code, so it stays enabled there."
     },
     {
+      "matchManagers": [
+        "gomod"
+      ],
+      "matchDepNames": ["go"],
+      "matchBaseBranches": ["master"],
+      "enabled": true,
+      "rangeStrategy": "bump",
+      "postUpdateOptions": ["gomodTidy"],
+      "description": "Re-enable just the 'go' directive (depName 'go', covers a future 'toolchain' directive too) so go.mod's Go version tracks upstream instead of drifting from the Dockerfile's golang image, which bumps independently (see PR #302). rangeStrategy=bump: default 'replace' treats 'go X.Y.Z' as a caret range, so newer releases always 'satisfy' it and no update is ever proposed. postUpdateOptions=gomodTidy: without it Renovate only runs 'go get', not 'go mod tidy', and CI's tidy-check job would reject the PR."
+    },
+    {
       "matchCategories": [
         "docker"
       ],
@@ -227,7 +238,8 @@
         "dockerfile",
         "docker-compose",
         "custom.regex",
-        "helm-values"
+        "helm-values",
+        "gomod"
       ],
       "commitMessagePrefix": "chore(deps):",
       "commitMessageAction": "update",
@@ -249,7 +261,8 @@
         "docker-compose",
         "custom.regex",
         "helm-values",
-        "docker"
+        "docker",
+        "gomod"
       ],
       "commitMessagePrefix": "chore(deps):",
       "commitMessageAction": "update",


### PR DESCRIPTION
## Summary
- `go.mod`'s `go` directive was drifting from the Dockerfile's `golang` builder image (e.g. `golang:1.26->1.27` in #302 never touched `go.mod`) because the blanket `gomod` manager disable on `master` (module deps are handled by `update-go-deps.yml`) also silently disabled tracking of the `go` directive itself.
- Re-enables just the `go` depName within the disabled `gomod` manager and groups it into the same major/non-major dependency PRs the Dockerfile bump already lands in.
- Adds `rangeStrategy: bump` - without it, `go-mod-directive` versioning treats `go X.Y.Z` as an npm caret range, so any newer Go release always "satisfies" the current directive and Renovate never proposes an update.
- Adds `postUpdateOptions: [gomodTidy]` - without it, Renovate's gomod artifact updater only runs `go get`, not `go mod tidy`, and this repo's CI "Check Go modules dependency file integrity" job would reject the resulting PR.

Both requirements were verified locally against this repo (and a minimal `go.mod` fixture) via `npx renovate --platform=local --dry-run=full`, and by reading the installed `renovate` package's `gomod`/`go-mod-directive` source directly.

## Test plan
- [ ] `npx renovate-config-validator renovate.json` passes (already run locally)
- [ ] Next Renovate run on `master` proposes a `go` module directive update alongside the grouped non-major/major dependency PR
- [ ] That PR's CI "Check Go modules dependency file integrity" job passes (confirms `gomodTidy` actually ran)