### PR TITLE
fix(makefile): move CONTROLLER_GEN_VERSION bump into make update-go-deps

### DIFF
--- a/.github/workflows/update-go-deps.yml
+++ b/.github/workflows/update-go-deps.yml
@@ -62,6 +62,7 @@ jobs:
 
             ### Changes made:
             - Updated Go module dependencies via `make update-go-deps`
+            - Bumped `CONTROLLER_GEN_VERSION` in the Makefile to the latest release
             - Regenerated manifests via `make generate manifests`
             - Applied formatting and linting fixes via `make fmt lint-fix`
 

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ REL_TAG = $(shell ./scripts/increment_version.sh -${RELEASE_TYPE} ${TAG})
 # Version constants
 GOLANGCI_VERSION = 2.13.2 # renovate: datasource=github-releases depName=golangci/golangci-lint
 LICENSEI_VERSION = 0.9.0 # renovate: datasource=github-releases depName=goph/licensei
-CONTROLLER_GEN_VERSION = v0.21.0 # renovate: datasource=github-releases depName=kubernetes-sigs/controller-tools
+CONTROLLER_GEN_VERSION = v0.21.0 # kept in sync with kubernetes-sigs/controller-tools by `make update-go-deps`
 ENVTEST_K8S_VERSION = 1.37.0 # renovate: datasource=github-releases depName=kubernetes-sigs/controller-tools extractVersion=^envtest-v(?<version>.+)$
 SETUP_ENVTEST_VERSION := latest
 ADDLICENSE_VERSION = 1.2.0 # renovate: datasource=github-releases depName=google/addlicense
@@ -346,6 +346,13 @@ update-go-deps: ## Update Go modules dependencies.
 	@if [ -f ./tests/e2e/go.mod ]; then \
 		($(call update-module-deps,./tests/e2e)); \
 	fi
+	@echo "Updating CONTROLLER_GEN_VERSION..."
+	@latest="$$(go list -m -versions sigs.k8s.io/controller-tools | tr ' ' '\n' | tail -1)"; \
+	if [ -z "$$latest" ]; then \
+		echo "Could not determine latest controller-gen version" >&2; \
+		exit 1; \
+	fi; \
+	sed -E "s/^CONTROLLER_GEN_VERSION = v[0-9.]+ /CONTROLLER_GEN_VERSION = $$latest /" Makefile > Makefile.tmp && mv Makefile.tmp Makefile
 
 tidy: ## Run go mod tidy in all Go modules.
 	@echo "Finding all directories with go.mod files..."


### PR DESCRIPTION
## Summary
- Renovate's regex manager bumps `CONTROLLER_GEN_VERSION` in the Makefile as a standalone PR (e.g. #328), but only text-replaces the version pin - it never runs `make generate manifests`. The generated CRDs carry a `controller-gen.kubebuilder.io/version` annotation, so this leaves it stale and fails the "Check integrity" CI job (manifests were last regenerated separately in #313).
- `update-go-deps.yml` already runs `make generate manifests` after updating Go deps, so this moves the controller-gen bump into `make update-go-deps` itself, keeping the version bump and the regenerated manifests atomic in the same automated commit.
- Drops the `# renovate: ...` annotation from `CONTROLLER_GEN_VERSION` so Renovate's regex manager stops tracking it separately. `ENVTEST_K8S_VERSION` keeps its annotation and stays Renovate-managed - it needs no generated-file regen.

## Test plan
- [x] `go list -m -versions sigs.k8s.io/controller-tools | tr ' ' '\n' | tail -1` resolves the latest release (verified locally, currently `v0.22.0`)
- [x] The Makefile substitution correctly rewrites `CONTROLLER_GEN_VERSION` in place (verified locally against a copy of this repo's Makefile)
- [ ] Next scheduled/manual run of `update-go-deps.yml` bumps `CONTROLLER_GEN_VERSION` and includes the regenerated manifests in the same PR
- [ ] That PR's "Check integrity" CI job passes