### PR TITLE
fix(operator-tools): remove unused CONTROLLER_GEN_VERSION pin and controller-gen targets

### DIFF
--- a/third_party/github.com/banzaicloud/operator-tools/Makefile
+++ b/third_party/github.com/banzaicloud/operator-tools/Makefile
@@ -6,23 +6,6 @@
 SHELL = /bin/bash
 .SHELLFLAGS := -eu -o pipefail -c
 
-PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
-BIN_DIR := $(PROJECT_DIR)/bin
-
-# Version constants
-CONTROLLER_GEN_VERSION = v0.21.0 # renovate: datasource=github-releases depName=kubernetes-sigs/controller-tools
-
-# Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
-ifeq (,$(shell go env GOBIN))
-GOBIN=$(shell go env GOPATH)/bin
-else
-GOBIN=$(shell go env GOBIN)
-endif
-
-export PATH := $(BIN_DIR):$(PATH)
-
-CONTROLLER_GEN = $(BIN_DIR)/controller-gen
-
 help: ## Display this help.
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^([a-zA-Z_0-9-]|\/)+:.*?##/ { printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
@@ -32,13 +15,3 @@ help: ## Display this help.
 check-diff: ## Check for uncommitted changes (run from repository root)
 	@echo "Note: This target should be run from the repository root directory"
 	@echo "Run: make -C ../../.. check-diff-operator-tools"
-
-# Local tool installation (for standalone use of this module)
-
-bin/controller-gen: bin/controller-gen-$(CONTROLLER_GEN_VERSION) ## Symlink controller-gen-<version> into versionless controller-gen.
-	@ln -sf controller-gen-$(CONTROLLER_GEN_VERSION) bin/controller-gen
-
-bin/controller-gen-$(CONTROLLER_GEN_VERSION): ## Download versioned controller-gen.
-	@mkdir -p bin
-	GOBIN=$(BIN_DIR) go install sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_GEN_VERSION)
-	@mv bin/controller-gen bin/controller-gen-$(CONTROLLER_GEN_VERSION)


### PR DESCRIPTION
## Summary
Follow-up to #332. `third_party/github.com/banzaicloud/operator-tools/Makefile` had its own `CONTROLLER_GEN_VERSION` (with the same `# renovate: datasource=github-releases depName=kubernetes-sigs/controller-tools` annotation) plus `bin/controller-gen` download/symlink targets - but they're dead code:

- Nothing invokes this Makefile: no `make -C third_party/...` anywhere in the root Makefile or `.github/workflows/*.yml`, and its `check-diff` target explicitly says to run the equivalent from the repository root instead.
- Its own `$(CONTROLLER_GEN)` variable is never actually invoked here - only downloaded/symlinked.
- The root Makefile's `generate` target already regenerates this module's `zz_generated.deepcopy.go` files itself, by `cd`-ing into `third_party/.../operator-tools` and running the **root** Makefile's `$(CONTROLLER_GEN)`/`CONTROLLER_GEN_VERSION` (the one fixed in #332) - a `cd && command` doesn't pull in that directory's own Makefile.

Left alone, Renovate would keep proposing standalone bumps of this pin - same failure mode as #332, but for a version that does nothing. Removed the dead variable and targets; also dropped `PROJECT_DIR`/`BIN_DIR`/`GOBIN` detection/`export PATH`, which were only there to support them and are now unused too.

## Test plan
- [x] `make help` and `make check-diff` still work from `third_party/github.com/banzaicloud/operator-tools/` (verified locally)
- [x] Confirmed via `grep` that no workflow or Makefile references this file's `bin/controller-gen` targets