### PR TITLE
fix(deps): pin k8s.io/kube-openapi to apimachinery's tested version in update-go-deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -327,6 +327,11 @@ define update-module-deps
 		api_ver="$$(go list -m -f '{{.Version}}' k8s.io/api)"; \
 		go get k8s.io/kubectl@"$$api_ver" k8s.io/cli-runtime@"$$api_ver"; \
 	fi; \
+	if go list -m k8s.io/apimachinery >/dev/null 2>&1 && go list -m k8s.io/kube-openapi >/dev/null 2>&1; then \
+		apimachinery_ver="$$(go list -m -f '{{.Version}}' k8s.io/apimachinery)"; \
+		openapi_ver="$$(go mod graph | grep "^k8s.io/apimachinery@$$apimachinery_ver k8s.io/kube-openapi@" | head -1 | sed 's/.*kube-openapi@//')"; \
+		if [ -n "$$openapi_ver" ]; then go get k8s.io/kube-openapi@"$$openapi_ver"; fi; \
+	fi; \
 	go mod tidy
 endef
 


### PR DESCRIPTION
## Summary
- Fixes the failing scheduled [Update Go Dependencies](https://github.com/adobe/koperator/actions/runs/34103905260/job/101684412945) workflow.
- Root cause: `make update-go-deps`'s per-module `go get -u` loop bumps every direct dependency, and `-u`'s effect propagates across the whole build graph. This pushed the untagged/pseudo-versioned `k8s.io/kube-openapi` past the exact commit that the pinned `k8s.io/apimachinery@v0.37.0` release was built and tested against. The newer kube-openapi commit switched its internal use of `sigs.k8s.io/structured-merge-diff` from v6 to v7 (a distinct Go module, so MVS happily required both), breaking apimachinery's frozen source, which still expects v6 types — surfacing as a `typecheck` failure in `golangci-lint` (`pkg/resources/reconciler.go` → ... → `k8s.io/apimachinery@v0.37.0/pkg/util/managedfields/internal/typeconverter.go:51`).
- Fix: extend `update-module-deps` in the `Makefile` with a guard that mirrors the existing `k8s.io/kubectl`/`k8s.io/cli-runtime` re-pinning pattern — after the update loop, re-pin `k8s.io/kube-openapi` to whatever version the resolved `k8s.io/apimachinery` actually declares as its dependency, instead of trusting `go get -u`'s graph-wide bump.
- Scoped to just the `Makefile` guard — no dependency bump/manifest regen bundled here; the scheduled `Update Go Dependencies` workflow will produce those on its next (re-triggered) run using this fix.

## Test plan
- [x] Reproduced the CI failure locally on a clean `master` worktree (`make update-go-deps && make tidy && make generate manifests && make fmt lint-fix`).
- [x] Applied the `Makefile` fix and re-ran the same sequence end-to-end — exits 0, `0 issues.` in every lint dir, no `sigs.k8s.io/structured-merge-diff/v7` left in any `go.mod`/`go.sum`.
- [ ] Re-trigger `Update Go Dependencies` workflow and confirm it succeeds with this fix in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)