### PR TITLE
chore(docker): bump Kafka image base from debian:bullseye to trixie

### DIFF
--- a/docker/jmx_exporter/Dockerfile
+++ b/docker/jmx_exporter/Dockerfile
@@ -1,4 +1,4 @@
-ARG JMX_EXPORTER_VERSION=v1.6.0 # renovate: datasource=github-releases depName=prometheus/jmx_exporter
+ARG JMX_EXPORTER_VERSION=1.6.0 # renovate: datasource=github-releases depName=prometheus/jmx_exporter
 
 FROM maven:3-amazoncorretto-21@sha256:81de222c1f34ac467bf968e1800b73fb41e714427c0212ba004296ea972e808a AS build
 ARG JMX_EXPORTER_VERSION

--- a/docker/kafka/Dockerfile
+++ b/docker/kafka/Dockerfile
@@ -34,7 +34,7 @@ RUN apk add --no-cache gnupg wget && \
 
 
 # backported from https://github.com/docker-library/openjdk/blob/master/18/jdk/slim-bullseye/Dockerfile
-FROM debian:bullseye-slim@sha256:e5b6442dd2e9684cf5e87d8338b5968f3b348636fc0be6d7850a381e3731a2bd
+FROM debian:trixie-slim@sha256:d7e12182ce18b85b93007c1dedf31f2d29e01ccf3182cc4017c709b6259bc132
 
 ARG scala_version
 ARG KAFKA_VERSION


### PR DESCRIPTION
debian:bullseye-slim's officially reached its end-of-life and concluded its Long Term Support (LTS) on August 31, 2026. Move to trixie (Debian 13), the current stable release.


## Type of Change
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass
